### PR TITLE
fix(upload-ctx-provider): run parent init callback before accessing event emitter

### DIFF
--- a/blocks/UploadCtxProvider/UploadCtxProvider.js
+++ b/blocks/UploadCtxProvider/UploadCtxProvider.js
@@ -5,6 +5,8 @@ class UploadCtxProviderClass extends UploaderBlock {
   requireCtxName = true;
 
   initCallback() {
+    super.initCallback();
+
     this.$['*eventEmitter'].bindTarget(this);
   }
 }


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
