### PR TITLE
fix(shadow-wrapper): do not call success callback on the second `css-src` attribute change

### DIFF
--- a/utils/waitForAttribute.js
+++ b/utils/waitForAttribute.js
@@ -10,10 +10,27 @@
  * }} options
  */
 export const waitForAttribute = ({ element, attribute, onSuccess, onTimeout, timeout = 300 }) => {
+  const currentAttrValue = element.getAttribute(attribute);
+  if (currentAttrValue !== null) {
+    onSuccess(currentAttrValue);
+    return;
+  }
+
+  const observer = new MutationObserver((mutations) => {
+    const mutation = mutations[mutations.length - 1];
+    handleMutation(mutation);
+  });
+
+  observer.observe(element, {
+    attributes: true,
+    attributeFilter: [attribute],
+  });
+
   const timeoutId = setTimeout(() => {
     observer.disconnect();
     onTimeout();
   }, timeout);
+
   /** @param {MutationRecord} mutation */
   const handleMutation = (mutation) => {
     const attrValue = element.getAttribute(attribute);
@@ -23,17 +40,4 @@ export const waitForAttribute = ({ element, attribute, onSuccess, onTimeout, tim
       onSuccess(attrValue);
     }
   };
-  const currentAttrValue = element.getAttribute(attribute);
-  if (currentAttrValue !== null) {
-    clearTimeout(timeoutId);
-    onSuccess(currentAttrValue);
-  }
-  const observer = new MutationObserver((mutations) => {
-    const mutation = mutations[mutations.length - 1];
-    handleMutation(mutation);
-  });
-  observer.observe(element, {
-    attributes: true,
-    attributeFilter: [attribute],
-  });
 };

--- a/utils/waitForAttribute.test.js
+++ b/utils/waitForAttribute.test.js
@@ -55,4 +55,24 @@ describe('waitForAttribute', () => {
     expect(onSuccess.getCall(0).args[0]).to.equal('test');
     expect(onTimeout.called).to.be.false;
   });
+
+  it('should not call onSuccess on the second attribute change', async () => {
+    const element = document.createElement('div');
+    element.setAttribute(TEST_ATTRIBUTE, 'test');
+    const onSuccess = spy();
+    const onTimeout = spy();
+    waitForAttribute({
+      element,
+      attribute: TEST_ATTRIBUTE,
+      onSuccess,
+      onTimeout,
+      timeout: 10,
+    });
+    await delay(100);
+    element.setAttribute(TEST_ATTRIBUTE, 'tes2');
+    await delay(100);
+    expect(onSuccess.calledOnce).to.be.true;
+    expect(onSuccess.getCall(0).args[0]).to.equal('test');
+    expect(onTimeout.called).to.be.false;
+  });
 });


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
