### PR TITLE
fix: set `cdnUrlModifers` default to empty string after file upload

### DIFF
--- a/blocks/FileItem/FileItem.js
+++ b/blocks/FileItem/FileItem.js
@@ -390,6 +390,7 @@ export class FileItem extends UploaderBlock {
         return uploadFile(fileInput, uploadClientOptions);
       };
 
+      /** @type {import('@uploadcare/upload-client').UploadcareFile} */
       let fileInfo = await this.$['*uploadQueue'].add(uploadTask);
       entry.setMultipleValues({
         fileInfo,
@@ -400,6 +401,7 @@ export class FileItem extends UploaderBlock {
         mimeType: fileInfo.contentInfo?.mime?.mime ?? fileInfo.mimeType,
         uuid: fileInfo.uuid,
         cdnUrl: fileInfo.cdnUrl,
+        cdnUrlModifiers: '',
         uploadProgress: 100,
       });
 


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))
