### PR TITLE
fix(upload-list): set fixed modal container width to avoid bouncy width (could lead to some l10n ui width glitches but we're ok with them)

### DIFF
--- a/blocks/UploadList/upload-list.css
+++ b/blocks/UploadList/upload-list.css
@@ -9,7 +9,7 @@ lr-upload-list {
 }
 
 lr-modal lr-upload-list {
-  min-width: min(calc(var(--modal-normal-w) - var(--gap-mid) * 2), calc(100vw - var(--gap-mid) * 2));
+  width: min(calc(var(--modal-normal-w) - var(--gap-mid) * 2), calc(100vw - var(--gap-mid) * 2));
   height: max-content;
   max-height: var(--modal-max-content-height);
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the width setting of the upload list modal to improve layout consistency across devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->