### PR TITLE
feat(lr-file-uploader-regular): added prop headless

### DIFF
--- a/solutions/file-uploader/regular/FileUploaderRegular.js
+++ b/solutions/file-uploader/regular/FileUploaderRegular.js
@@ -1,10 +1,27 @@
 // @ts-check
 import { SolutionBlock } from '../../../abstract/SolutionBlock.js';
 import { EventType } from '../../../blocks/UploadCtxProvider/EventEmitter.js';
+import { asBoolean } from '../../../blocks/Config/normalizeConfigValue.js';
 
 export class FileUploaderRegular extends SolutionBlock {
+  constructor() {
+    super();
+
+    this.init$ = {
+      ...this.init$,
+      isHidden: false,
+    };
+  }
+
   initCallback() {
     super.initCallback();
+
+    this.defineAccessor(
+      'headless',
+      /** @param {unknown} value */ (value) => {
+        this.set$({ isHidden: asBoolean(value) });
+      },
+    );
 
     this.sub(
       '*modalActive',
@@ -22,7 +39,7 @@ export class FileUploaderRegular extends SolutionBlock {
 }
 
 FileUploaderRegular.template = /* HTML */ `
-  <lr-simple-btn></lr-simple-btn>
+  <lr-simple-btn set="@hidden: isHidden"></lr-simple-btn>
 
   <lr-modal strokes block-body-scrolling>
     <lr-start-from>
@@ -40,3 +57,8 @@ FileUploaderRegular.template = /* HTML */ `
 
   <lr-progress-bar-common></lr-progress-bar-common>
 `;
+
+FileUploaderRegular.bindAttributes({
+  // @ts-expect-error TODO: fix types inside symbiote
+  headless: null,
+});


### PR DESCRIPTION
Added the ability to use the headless attribute to hide/visible a button

## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a `headless` mode in the File Uploader, allowing users to control the visibility of the uploader interface via a simple boolean property.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->