### PR TITLE
fix(styles): added prefix uc- to className in the js

### DIFF
--- a/blocks/CloudImageEditor/src/elements/slider/SliderUi.js
+++ b/blocks/CloudImageEditor/src/elements/slider/SliderUi.js
@@ -140,8 +140,8 @@ export class SliderUi extends Block {
     let fr = document.createDocumentFragment();
     let minorStepEl = document.createElement('div');
     let borderStepEl = document.createElement('div');
-    minorStepEl.className = 'minor-step';
-    borderStepEl.className = 'border-step';
+    minorStepEl.className = 'uc-minor-step';
+    borderStepEl.className = 'uc-border-step';
     fr.appendChild(borderStepEl);
     for (let i = 0; i < count; i++) {
       fr.appendChild(minorStepEl.cloneNode());
@@ -153,7 +153,7 @@ export class SliderUi extends Block {
     fr.appendChild(borderStepEl.cloneNode());
 
     let zeroDotEl = document.createElement('div');
-    zeroDotEl.className = 'zero-dot';
+    zeroDotEl.className = 'uc-zero-dot';
     fr.appendChild(zeroDotEl);
     this._zeroDotEl = zeroDotEl;
 

--- a/blocks/Modal/Modal.js
+++ b/blocks/Modal/Modal.js
@@ -65,7 +65,7 @@ export class Modal extends Block {
     } else {
       this.setAttribute('dialog-fallback', '');
       let backdrop = document.createElement('div');
-      backdrop.className = 'backdrop';
+      backdrop.className = 'uc-backdrop';
       this.appendChild(backdrop);
       backdrop.addEventListener('click', this._handleBackdropClick);
     }


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated class names to include the `uc-` prefix for consistency across the application.
  - This change affects the slider elements (`minor-step`, `border-step`, `zero-dot`) and modal backdrop elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->