### PR TITLE
fix(regular-mode): disable done button until group created

### DIFF
--- a/blocks/UploadList/UploadList.js
+++ b/blocks/UploadList/UploadList.js
@@ -89,7 +89,8 @@ export class UploadList extends UploaderBlock {
       uploadBtnVisible = true;
     } else {
       allDone = true;
-      doneBtnEnabled = summary.total === summary.succeed && fitCountRestrictions && validationOk;
+      const groupOk = this.cfg.groupOutput ? !!collectionState.group : true;
+      doneBtnEnabled = summary.total === summary.succeed && fitCountRestrictions && validationOk && groupOk;
     }
 
     this.set$({
@@ -142,6 +143,11 @@ export class UploadList extends UploaderBlock {
     this.subConfigValue('multiple', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMin', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMax', this._throttledHandleCollectionUpdate);
+    this.sub('*groupInfo', (groupInfo) => {
+      if (groupInfo) {
+        this._throttledHandleCollectionUpdate();
+      }
+    });
 
     this.sub('*currentActivity', (currentActivity) => {
       if (!this.couldOpenActivity && currentActivity === this.activityType) {


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced logic for the "done" button, ensuring it is only enabled when all conditions, including group validation, are met.
  - Introduced a new subscription for group information updates, improving the component's responsiveness to changes.

- **Bug Fixes**
  - Refined control flow in the `UploadList` component, leading to a more robust user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->