### PR TITLE
fix(camera-tab): added mimeType fallback for safari

### DIFF
--- a/blocks/CameraSource/CameraSource.js
+++ b/blocks/CameraSource/CameraSource.js
@@ -216,15 +216,13 @@ export class CameraSource extends UploaderBlock {
       };
 
       const { mimeType } = this.cfg.mediaRecorerOptions || {};
-      const isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
-      const isIOS = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
 
       if (mimeType && MediaRecorder.isTypeSupported(mimeType)) {
         this._options.mimeType = mimeType;
-      } else if (isSafari || isIOS) {
-        this._options.mimeType = 'video/mp4';
-      } else {
+      } else if (MediaRecorder.isTypeSupported(DEFAULT_VIDEO_FORMAT)) {
         this._options.mimeType = DEFAULT_VIDEO_FORMAT;
+      } else {
+        this._options.mimeType = 'video/mp4';
       }
 
       if (this._stream) {


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced video recording functionality with improved MIME type handling.
	- Default MIME type set to 'video/mp4' for better compatibility.

- **Bug Fixes**
	- Maintained robust error handling during the video recording process.

- **Chores**
	- Adjusted audio selection UI to respond more effectively to available audio devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->