### PR TITLE
fix: close ui slider when click on the editor toolbar

### DIFF
--- a/blocks/CloudImageEditor/src/EditorToolbar.js
+++ b/blocks/CloudImageEditor/src/EditorToolbar.js
@@ -402,6 +402,10 @@ export class EditorToolbar extends Block {
 
     this._updateInfoTooltip();
   }
+
+  destroyCallback() {
+    this.$['*showSlider'] = false;
+  }
 }
 
 EditorToolbar.template = /* HTML */ `


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved the image editing experience by ensuring interface elements reset correctly when the editor is closed, delivering a more consistent user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->