### PR TITLE
fix: prevent desktop safari from heic to jpeg conversion

### DIFF
--- a/abstract/UploaderPublicApi.js
+++ b/abstract/UploaderPublicApi.js
@@ -2,16 +2,22 @@
 import { ActivityBlock } from './ActivityBlock.js';
 
 import { applyStyles, Data } from '@symbiotejs/symbiote';
+import { calcCameraModes } from '../blocks/CameraSource/calcCameraModes.js';
+import { CameraSourceTypes } from '../blocks/CameraSource/constants.js';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter.js';
 import { UploadSource } from '../blocks/utils/UploadSource.js';
 import { serializeCsv } from '../blocks/utils/comma-separated.js';
-import { IMAGE_ACCEPT_LIST, fileIsImage, mergeFileTypes } from '../utils/fileTypes.js';
+import { browserFeatures } from '../utils/browser-info.js';
+import {
+  BASIC_IMAGE_WILDCARD,
+  BASIC_VIDEO_WILDCARD,
+  fileIsImage,
+  IMAGE_ACCEPT_LIST,
+  mergeFileTypes,
+} from '../utils/fileTypes.js';
 import { parseCdnUrl } from '../utils/parseCdnUrl.js';
-import { buildOutputCollectionState } from './buildOutputCollectionState.js';
 import { stringToArray } from '../utils/stringToArray.js';
-import { calcCameraModes } from '../blocks/CameraSource/calcCameraModes.js';
-import { CameraSourceTypes } from '../blocks/CameraSource/constants.js';
-import { isSupportCapture } from '../blocks/utils/supportCapture.js';
+import { buildOutputCollectionState } from './buildOutputCollectionState.js';
 
 export class UploaderPublicApi {
   /**
@@ -160,11 +166,13 @@ export class UploaderPublicApi {
       const { isPhotoEnabled, isVideoRecordingEnabled } = calcCameraModes(this.cfg);
 
       if (options.modeCamera === CameraSourceTypes.PHOTO && isPhotoEnabled) {
-        fileInput.accept = 'image/*';
+        fileInput.accept = BASIC_IMAGE_WILDCARD;
       } else if (options.modeCamera === CameraSourceTypes.VIDEO && isVideoRecordingEnabled) {
-        fileInput.accept = 'video/*';
+        fileInput.accept = BASIC_VIDEO_WILDCARD;
       } else {
-        fileInput.accept = ['image/*', isVideoRecordingEnabled && 'video/*'].filter(Boolean).join(',');
+        fileInput.accept = [BASIC_IMAGE_WILDCARD, isVideoRecordingEnabled && BASIC_VIDEO_WILDCARD]
+          .filter(Boolean)
+          .join(',');
       }
     } else {
       fileInput.accept = accept;
@@ -273,7 +281,7 @@ export class UploaderPublicApi {
           return;
         }
 
-        if (srcKey === 'camera' && isSupportCapture()) {
+        if (srcKey === 'camera' && browserFeatures.htmlMediaCapture) {
           const { isPhotoEnabled, isVideoRecordingEnabled } = calcCameraModes(this.cfg);
 
           if (isPhotoEnabled && isVideoRecordingEnabled) {

--- a/blocks/DropArea/drop-area.css
+++ b/blocks/DropArea/drop-area.css
@@ -37,7 +37,8 @@
   border-color: var(--uc-primary-transparent);
 }
 
-:where(.uc-contrast) :where([uc-drop-area]):is([drag-state='active'], [drag-state='near'], [drag-state='over'], :hover) {
+:where(.uc-contrast)
+  :where([uc-drop-area]):is([drag-state='active'], [drag-state='near'], [drag-state='over'], :hover) {
   color: var(--uc-foreground);
   background: transparent;
   border-color: var(--uc-foreground);
@@ -122,7 +123,8 @@
   color: var(--uc-foreground);
 }
 
-:where(.uc-contrast) :where([uc-drop-area])[with-icon]
+:where(.uc-contrast)
+  :where([uc-drop-area])[with-icon]
   > .uc-content-wrapper:is([drag-state='active'], [drag-state='near'], [drag-state='over'])
   .uc-text {
   color: var(--uc-foreground);

--- a/blocks/Img/ImgBase.js
+++ b/blocks/Img/ImgBase.js
@@ -103,8 +103,8 @@ export class ImgBase extends ImgConfig {
         createCdnUrl(
           //
           createOriginalUrl(this.$$('cdn-cname'), this.$$('uuid')),
-          cdnModifiers
-        )
+          cdnModifiers,
+        ),
       );
     }
 
@@ -114,8 +114,8 @@ export class ImgBase extends ImgConfig {
         createCdnUrl(
           //
           createOriginalUrl(this.$$('cdn-cname'), this.$$('uuid')),
-          cdnModifiers
-        )
+          cdnModifiers,
+        ),
       );
     }
 
@@ -126,8 +126,8 @@ export class ImgBase extends ImgConfig {
           //
           this.$$('proxy-cname'),
           cdnModifiers,
-          this._fmtAbs(this.$$('src'))
-        )
+          this._fmtAbs(this.$$('src')),
+        ),
       );
     }
 
@@ -138,8 +138,8 @@ export class ImgBase extends ImgConfig {
           //
           `https://${this.$$('pubkey')}.ucr.io/`,
           cdnModifiers,
-          this._fmtAbs(this.$$('src'))
-        )
+          this._fmtAbs(this.$$('src')),
+        ),
       );
     }
   }
@@ -157,7 +157,7 @@ export class ImgBase extends ImgConfig {
     return applyTemplateData(
       this.$$('secure-delivery-proxy'),
       { previewUrl: url },
-      { transform: (value) => window.encodeURIComponent(value) }
+      { transform: (value) => window.encodeURIComponent(value) },
     );
   }
 

--- a/blocks/SourceBtn/SourceBtn.js
+++ b/blocks/SourceBtn/SourceBtn.js
@@ -1,9 +1,9 @@
 // @ts-check
-import { UploaderBlock } from '../../abstract/UploaderBlock.js';
 import { ActivityBlock } from '../../abstract/ActivityBlock.js';
-import { ExternalUploadSource, UploadSource, UploadSourceMobile } from '../utils/UploadSource.js';
+import { UploaderBlock } from '../../abstract/UploaderBlock.js';
+import { browserFeatures } from '../../utils/browser-info.js';
 import { CameraSourceTypes } from '../CameraSource/constants.js';
-import { isSupportCapture } from '../utils/supportCapture.js';
+import { ExternalUploadSource, UploadSource, UploadSourceMobile } from '../utils/UploadSource.js';
 
 const L10N_PREFIX = 'src-type-';
 
@@ -55,7 +55,7 @@ export class SourceBtn extends UploaderBlock {
       type: UploadSource.CAMERA,
       activity: ActivityBlock.activities.CAMERA,
       activate: () => {
-        const supportsCapture = isSupportCapture();
+        const supportsCapture = browserFeatures.htmlMediaCapture;
 
         if (supportsCapture) {
           this.api.openSystemDialog({ captureCamera: true });
@@ -75,7 +75,7 @@ export class SourceBtn extends UploaderBlock {
         type: mobileSourceType,
         activity: ActivityBlock.activities.CAMERA,
         activate: () => {
-          const supportsCapture = isSupportCapture();
+          const supportsCapture = browserFeatures.htmlMediaCapture;
           if (supportsCapture) {
             this.api.openSystemDialog({
               captureCamera: true,

--- a/blocks/SourceList/SourceList.js
+++ b/blocks/SourceList/SourceList.js
@@ -1,8 +1,8 @@
 // @ts-check
 import { Block } from '../../abstract/Block.js';
+import { browserFeatures } from '../../utils/browser-info.js';
 import { stringToArray } from '../../utils/stringToArray.js';
 import { deserializeCsv } from '../utils/comma-separated.js';
-import { isSupportCapture } from '../utils/supportCapture.js';
 
 export class SourceList extends Block {
   initCallback() {
@@ -22,7 +22,7 @@ export class SourceList extends Block {
           return;
         }
 
-        if (srcName === 'camera' && isSupportCapture()) {
+        if (srcName === 'camera' && browserFeatures.htmlMediaCapture) {
           this.subConfigValue('cameraModes', (/** @type {String} */ val) => {
             const cameraModes = deserializeCsv(val);
 

--- a/blocks/utils/supportCapture.js
+++ b/blocks/utils/supportCapture.js
@@ -1,3 +1,0 @@
-export const isSupportCapture = () => {
-  return 'capture' in document.createElement('input');
-};

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,7 @@
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.15.11",
         "@types/react": "^18.2.34",
+        "@types/sinon": "^17.0.4",
         "@web/test-runner": "^0.19.0",
         "esbuild": "^0.25.1",
         "eslint": "^8.56.0",
@@ -3752,6 +3753,23 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "node_modules/@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/triple-beam": {
       "version": "1.3.5",
@@ -17986,6 +18004,21 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "@types/sinon": {
+      "version": "17.0.4",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-17.0.4.tgz",
+      "integrity": "sha512-RHnIrhfPO3+tJT0s7cFaXGZvsL4bbR3/k7z3P312qMS4JaS2Tk+KiwiLx1S0rQ56ERj00u1/BtdyVd0FY+Pdew==",
+      "dev": true,
+      "requires": {
+        "@types/sinonjs__fake-timers": "*"
+      }
+    },
+    "@types/sinonjs__fake-timers": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
+      "dev": true
     },
     "@types/triple-beam": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.15.11",
     "@types/react": "^18.2.34",
+    "@types/sinon": "^17.0.4",
     "@web/test-runner": "^0.19.0",
     "esbuild": "^0.25.1",
     "eslint": "^8.56.0",

--- a/utils/browser-info.js
+++ b/utils/browser-info.js
@@ -1,0 +1,22 @@
+// @ts-check
+
+const calcIsDesktopSafari = () => {
+  const ua = navigator.userAgent;
+  return /Macintosh|Windows/.test(ua) && /Version\/[\d\.]+.*Safari/.test(ua) && !/Chrome|Chromium|Edg|OPR/.test(ua);
+};
+
+const calcHtmlMediaCaptureSupport = () => {
+  return 'capture' in document.createElement('input');
+};
+
+export const calcBrowserInfo = () => ({
+  safariDesktop: calcIsDesktopSafari(),
+});
+
+export const calcBrowserFeatures = () => ({
+  htmlMediaCapture: calcHtmlMediaCaptureSupport(),
+});
+
+export const browserInfo = calcBrowserInfo();
+
+export const browserFeatures = calcBrowserFeatures();

--- a/utils/browser-info.test.js
+++ b/utils/browser-info.test.js
@@ -1,0 +1,109 @@
+// @ts-check
+import { expect } from '@esm-bundle/chai';
+import { calcBrowserFeatures, calcBrowserInfo } from './browser-info';
+import * as sinon from 'sinon';
+
+const DESKTOP_SAFARI_USER_AGENTS = [
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.1 Safari/605.1.15',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_6) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.2 Safari/605.1.15',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 11_2_3) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.3 Safari/605.1.15',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 12_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Safari/605.1.15',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 13_0) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Safari/605.1.15',
+  'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6; en-US) AppleWebKit/533.18.1 (KHTML, like Gecko) Version/5.0.4 Safari/533.18.5',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/601.7.8 (KHTML, like Gecko) Version/9.1.2 Safari/601.7.8',
+  'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_7_5; en-US) AppleWebKit/534.57.2 (KHTML, like Gecko) Version/5.1.10 Safari/534.57.2',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/602.3.12 (KHTML, like Gecko) Version/10.0.3 Safari/602.4.8',
+];
+
+const MOBILE_SAFARI_USER_AGENTS = [
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 14_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15A5365e Safari/604.1',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 13_5 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.1.1 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPad; CPU OS 15_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/15.0 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPod touch; CPU iPhone OS 12_4_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.1.2 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 16_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/16.0 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPad; CPU OS 14_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 12_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/16A366 Safari/602.1',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 11_4 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15G77 Safari/604.1',
+  'Mozilla/5.0 (iPad; CPU OS 13_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0 Mobile/15E148 Safari/604.1',
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) Version/10.0 Mobile/14E5239e Safari/602.1',
+];
+
+const OTHER_DESKTOP_USER_AGENTS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 Edg/112.0.1722.64',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:112.0) Gecko/20100101 Firefox/112.0',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:112.0) Gecko/20100101 Firefox/112.0',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64; rv:112.0) Gecko/20100101 Firefox/112.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.5615.49 Safari/537.36 OPR/98.0.4759.82',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36 OPR/98.0.4759.82',
+  'Mozilla/5.0 (Windows NT 10.0; WOW64; Trident/7.0; rv:11.0) like Gecko',
+];
+
+const OTHER_MOBILE_USER_AGENTS = [
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:115.0) Gecko/20100101 Firefox/115.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 Edg/115.0.0.0',
+  'Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko',
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36',
+  'Mozilla/5.0 (X11; Linux x86_64; rv:115.0) Gecko/20100101 Firefox/115.0',
+  'Mozilla/5.0 (Linux; Android 11; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36',
+  'Mozilla/5.0 (Android 11; Mobile; rv:115.0) Gecko/115.0 Firefox/115.0',
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36 OPR/100.0.0.0',
+];
+
+describe('browser-info', () => {
+  describe('safariDesktop flag', () => {
+    it('should be true for desktop safari', () => {
+      const sandbox = sinon.createSandbox();
+      for (const ua of DESKTOP_SAFARI_USER_AGENTS) {
+        sandbox.replaceGetter(window.navigator, 'userAgent', () => ua);
+        const browserInfo = calcBrowserInfo();
+        expect(browserInfo.safariDesktop).to.be.true;
+        sandbox.restore();
+      }
+    });
+
+    it('should be false for other browsers', () => {
+      const sandbox = sinon.createSandbox();
+      for (const ua of [...OTHER_DESKTOP_USER_AGENTS, ...OTHER_MOBILE_USER_AGENTS, ...MOBILE_SAFARI_USER_AGENTS]) {
+        sandbox.replaceGetter(window.navigator, 'userAgent', () => ua);
+        const browserInfo = calcBrowserInfo();
+        expect(browserInfo.safariDesktop).to.be.false;
+        sandbox.restore();
+      }
+    });
+  });
+});
+
+describe('browser-features', () => {
+  describe('htmlMediaCapture', () => {
+    it('should be true if capture is supported', () => {
+      const sandbox = sinon.createSandbox();
+      const originalDocumentCreateElement = document.createElement.bind(document);
+      sandbox.replace(document, 'createElement', () => {
+        const input = originalDocumentCreateElement('input');
+        input.capture = '';
+        return input;
+      });
+      const browserFeatures = calcBrowserFeatures();
+      expect(browserFeatures.htmlMediaCapture).to.be.true;
+      sandbox.restore();
+    });
+    it('should be false if capture is not supported', () => {
+      const sandbox = sinon.createSandbox();
+      const originalDocumentCreateElement = document.createElement.bind(document);
+      sandbox.replace(document, 'createElement', () => {
+        const input = originalDocumentCreateElement('input');
+        // @ts-ignore
+        delete input.capture;
+        return input;
+      });
+      const browserFeatures = calcBrowserFeatures();
+      expect(browserFeatures.htmlMediaCapture).to.be.false;
+      sandbox.restore();
+    });
+  });
+});

--- a/utils/fileTypes.js
+++ b/utils/fileTypes.js
@@ -1,8 +1,10 @@
 // @ts-check
+import { browserInfo } from './browser-info.js';
 import { stringToArray } from './stringToArray.js';
 
-export const IMAGE_ACCEPT_LIST = [
-  'image/*',
+export const BASIC_IMAGE_WILDCARD = 'image/*';
+export const BASIC_VIDEO_WILDCARD = 'video/*';
+export const HEIC_IMAGE_MIME_LIST = [
   'image/heif',
   'image/heif-sequence',
   'image/heic',
@@ -16,6 +18,20 @@ export const IMAGE_ACCEPT_LIST = [
   '.avif',
   '.avifs',
 ];
+
+export const calcImageAcceptList = () => {
+  // Desktop Safari allows selecting HEIC images with simple image/* wildcard
+  // But if we provide a more specific HEIC types - safari starts to convert any images to HEIC
+  if (browserInfo.safariDesktop) {
+    return [BASIC_IMAGE_WILDCARD];
+  }
+  // Other browsers allows to select HEIC images with more specific HEIC types only
+  // Mobile Safari will allow to select HEIC images even with simple image/* wildcard and it will convert them to JPEG by default (behaviour could be changed in file picker UI)
+  // Hope it will be fixed in the future so we'll add specific types so that Mobile Safari will know that we're supporting HEIC images
+  return [BASIC_IMAGE_WILDCARD, ...HEIC_IMAGE_MIME_LIST];
+};
+
+export const IMAGE_ACCEPT_LIST = calcImageAcceptList();
 
 /**
  * @param {string[]} [fileTypes]


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced the file uploader to better detect device media capture capabilities and enforce more accurate file type acceptance for images and videos.
  
- **Refactor**
  - Streamlined internal logic for media handling to offer a more consistent and reliable upload experience.
  
- **Tests and Chores**
  - Expanded browser feature tests and updated development tools for improved quality assurance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->