### PR TITLE
fix(types): add `headless` property type for `uc-file-uploader-regular`

### DIFF
--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -54,7 +54,7 @@ declare namespace JSX {
     >;
     'uc-cloud-image-editor': CustomElement<CloudImageEditorBlock, JSX.IntrinsicElements['uc-cloud-image-editor-block']>;
     'uc-form-input': CustomElement<FormInput, CtxAttributes>;
-    'uc-file-uploader-regular': CustomElement<FileUploaderRegular, CtxAttributes>;
+    'uc-file-uploader-regular': CustomElement<FileUploaderRegular, CtxAttributes & { headless: boolean }>;
     'uc-file-uploader-minimal': CustomElement<FileUploaderMinimal, CtxAttributes>;
     'uc-file-uploader-inline': CustomElement<FileUploaderInline, CtxAttributes>;
     'uc-upload-ctx-provider': CustomElement<InstanceType<UploadCtxProvider>, CtxAttributes>;


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added support for a new `headless` boolean attribute on the `<uc-file-uploader-regular>` component, allowing for enhanced customization in usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->