### PR TITLE
fix: added emit events for open/close modal

### DIFF
--- a/abstract/CTX.js
+++ b/abstract/CTX.js
@@ -12,7 +12,7 @@ export const activityBlockCtx = (fnCtx) => ({
   '*history': [],
   '*historyBack': null,
   '*closeModal': () => {
-    fnCtx.modalManager.closeAll();
+    fnCtx.modalManager.close(fnCtx.$['*currentActivity']);
 
     fnCtx.set$({
       '*currentActivity': null,

--- a/abstract/ModalManager.js
+++ b/abstract/ModalManager.js
@@ -9,7 +9,7 @@ export const ModalEvents = Object.freeze({
   DESTROY: 'modal:destroy',
 });
 
-/** @typedef {string} ModalId */
+/** @typedef {import('../abstract/ActivityBlock').ActivityType} ModalId */
 
 /** @typedef {import('../blocks/Modal/Modal.js').Modal} ModalNode */
 

--- a/blocks/Modal/Modal.js
+++ b/blocks/Modal/Modal.js
@@ -1,6 +1,10 @@
 // @ts-check
 import { Block } from '../../abstract/Block.js';
 import { ModalEvents } from '../../abstract/ModalManager.js';
+import { EventType } from '../UploadCtxProvider/EventEmitter.js';
+
+/** @type {import('../../abstract/ModalManager.js').ModalId | null} */
+let LAST_ACTIVE_MODAL_ID = null;
 
 export class Modal extends Block {
   static styleAttrs = [...super.styleAttrs, 'uc-modal'];
@@ -71,10 +75,13 @@ export class Modal extends Block {
    */
   _handleModalOpen({ id }) {
     if (id === this.id) {
+      LAST_ACTIVE_MODAL_ID = id;
       this.show();
     } else {
       this.hide();
     }
+
+    this.emit(EventType.MODAL_OPEN, { modalId: id }, { debounce: true });
   }
 
   /**
@@ -85,11 +92,17 @@ export class Modal extends Block {
     if (id === this.id) {
       this.hide();
     }
+
+    this.emit(EventType.MODAL_CLOSE, { modalId: id }, { debounce: true });
   }
 
   /** @private */
   _handleModalCloseAll() {
     this.hide();
+
+    if (LAST_ACTIVE_MODAL_ID === this.id) {
+      this.emit(EventType.MODAL_CLOSE, { modalId: LAST_ACTIVE_MODAL_ID }, { debounce: true });
+    }
   }
 
   initCallback() {

--- a/blocks/UploadCtxProvider/EventEmitter.js
+++ b/blocks/UploadCtxProvider/EventEmitter.js
@@ -35,8 +35,8 @@ export const EventType = Object.freeze({
  *   [EventType.FILE_UPLOAD_SUCCESS]: import('../../index.js').OutputFileEntry<'success'>;
  *   [EventType.FILE_UPLOAD_FAILED]: import('../../index.js').OutputFileEntry<'failed'>;
  *   [EventType.FILE_URL_CHANGED]: import('../../index.js').OutputFileEntry<'success'>;
- *   [EventType.MODAL_OPEN]: void;
- *   [EventType.MODAL_CLOSE]: void;
+ *   [EventType.MODAL_OPEN]: { modalId: import('../../abstract/ModalManager.js').ModalId };
+ *   [EventType.MODAL_CLOSE]: { modalId: import('../../abstract/ModalManager.js').ModalId };
  *   [EventType.ACTIVITY_CHANGE]: {
  *     activity: import('../../abstract/ActivityBlock.js').ActivityType;
  *   };

--- a/types/test/uc-upload-ctx-provider.test-d.tsx
+++ b/types/test/uc-upload-ctx-provider.test-d.tsx
@@ -9,9 +9,10 @@ import {
   OutputError,
   OutputFileEntry,
   OutputFileErrorType,
-  UploadCtxProvider
+  UploadCtxProvider,
 } from '../../index.js';
 import { SourceTypes } from '../../blocks/utils/UploadSource.js';
+import { type ModalId } from '../../abstract/ModalManager.js';
 
 const instance = new UploadCtxProvider();
 instance.uploadCollection.size;
@@ -196,12 +197,16 @@ instance.addEventListener('common-upload-success', (e) => {
 
 instance.addEventListener('modal-close', (e) => {
   const payload = e.detail;
-  expectType<void>(payload);
+  expectType<{
+    modalId: ModalId;
+  }>(payload);
 });
 
 instance.addEventListener('modal-open', (e) => {
   const payload = e.detail;
-  expectType<void>(payload);
+  expectType<{
+    modalId: ModalId;
+  }>(payload);
 });
 
 instance.addEventListener('activity-change', (e) => {


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Modal open and close actions now emit events with details about the specific modal involved.
- **Bug Fixes**
	- Closing a modal now only affects the current activity's modal, rather than closing all modals.
- **Refactor**
	- Improved event payload structure for modal events to include modal identifiers.
	- Enhanced type safety for modal identifiers across the application.
- **Tests**
	- Updated tests to verify event payloads now include modal identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->