### PR TITLE
Fix/modal-manager-close-event-on-history-back

### DIFF
--- a/abstract/ActivityBlock.js
+++ b/abstract/ActivityBlock.js
@@ -187,8 +187,10 @@ export class ActivityBlock extends Block {
         couldOpenActivity = /** @type {ActivityBlock} */ (nextActivityBlock)?.couldOpenActivity ?? false;
       }
 
-      nextActivity = couldOpenActivity ? nextActivity : undefined;
+      const currentActivity = this.$['*currentActivity'];
+      if (currentActivity) this.modalManager.close(currentActivity);
 
+      nextActivity = couldOpenActivity ? nextActivity : undefined;
       if (nextActivity) this.modalManager.open(nextActivity);
 
       this.$['*currentActivity'] = nextActivity;

--- a/demo/raw-regular.html
+++ b/demo/raw-regular.html
@@ -18,5 +18,5 @@
 </head>
 
 <uc-file-uploader-regular ctx-name="my-uploader"></uc-file-uploader-regular>
-<uc-config ctx-name="my-uploader" pubkey="demopublickey"></uc-config>
+<uc-config debug ctx-name="my-uploader" pubkey="demopublickey"></uc-config>
 <uc-upload-ctx-provider ctx-name="my-uploader"></uc-upload-ctx-provider>


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved modal management when navigating activity history to ensure the current modal is always closed before opening a new one.

- **Chores**
  - Enabled debug mode in the configuration for the file uploader in the demo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->