### PR TITLE
feat: add `retryNetworkErrorMaxTimes` option

### DIFF
--- a/abstract/UploaderBlock.js
+++ b/abstract/UploaderBlock.js
@@ -437,6 +437,7 @@ export class UploaderBlock extends ActivityBlock {
       secureSignature: secureToken?.secureSignature,
       secureExpire: secureToken?.secureExpire,
       retryThrottledRequestMaxTimes: this.cfg.retryThrottledRequestMaxTimes,
+      retryNetworkErrorMaxTimes: this.cfg.retryNetworkErrorMaxTimes,
       multipartMinFileSize: this.cfg.multipartMinFileSize,
       multipartChunkSize: this.cfg.multipartChunkSize,
       maxConcurrentRequests: this.cfg.multipartMaxConcurrentRequests,

--- a/blocks/Config/initialConfig.js
+++ b/blocks/Config/initialConfig.js
@@ -47,6 +47,7 @@ export const initialConfig = {
   secureExpire: '',
   secureDeliveryProxy: '',
   retryThrottledRequestMaxTimes: 10,
+  retryNetworkErrorMaxTimes: 3,
   multipartMinFileSize: 26214400,
   multipartChunkSize: 5242880,
   maxConcurrentRequests: 10,

--- a/blocks/Config/normalizeConfigValue.js
+++ b/blocks/Config/normalizeConfigValue.js
@@ -62,6 +62,7 @@ const mapping = {
   secureExpire: asString,
   secureDeliveryProxy: asString,
   retryThrottledRequestMaxTimes: asNumber,
+  retryNetworkErrorMaxTimes: asNumber,
   multipartMinFileSize: asNumber,
   multipartChunkSize: asNumber,
   maxConcurrentRequests: asNumber,

--- a/types/exported.d.ts
+++ b/types/exported.d.ts
@@ -167,6 +167,10 @@ export type ConfigType = {
    */
   retryThrottledRequestMaxTimes: number;
   /**
+   * Maximum number of retry attempts for network errors.
+   */
+  retryNetworkErrorMaxTimes: number;
+  /**
    * Minimum file size for multipart uploads.
    */
   multipartMinFileSize: number;


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new configuration option to set the maximum number of retry attempts for network errors during uploads. The default is set to 3 retries.
- **Documentation**
  - Updated configuration documentation to include the new retry option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->