### PR TITLE
fix(api): allow to use both configured cdnBase and ucarecdn.com as host when calling `addFileFromCdnUrl`

### DIFF
--- a/utils/parseCdnUrl.js
+++ b/utils/parseCdnUrl.js
@@ -1,12 +1,15 @@
+import { DEFAULT_CDN_CNAME } from '../blocks/Config/initialConfig.js';
+
 const uuidRegex = /[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}/i;
 const cdnUrlRegex = new RegExp(`^/?(${uuidRegex.source})(?:/(-/(?:[^/]+/)+)?([^/]*))?$`, 'i');
 
 /** @param {{ url: string; cdnBase: string }} options */
 export const parseCdnUrl = ({ url, cdnBase }) => {
   const cdnBaseUrlObj = new URL(cdnBase);
+  const fallbackCdnBaseUrlObj = new URL(DEFAULT_CDN_CNAME);
   const urlObj = new URL(url);
 
-  if (cdnBaseUrlObj.host !== urlObj.host) {
+  if (cdnBaseUrlObj.host !== urlObj.host && fallbackCdnBaseUrlObj.host !== urlObj.host) {
     return null;
   }
 

--- a/utils/parseCdnUrl.test.js
+++ b/utils/parseCdnUrl.test.js
@@ -75,4 +75,17 @@ describe('parseCdnUrl', () => {
       filename: null,
     });
   });
+
+  it('should fallback to ucarecdn.com if cdnBase is not matched', () => {
+    expect(
+      parseCdnUrl({
+        url: 'https://ucarecdn.com/12345678-1234-5678-1234-567812345678/',
+        cdnBase: 'https://cdn.example.com',
+      }),
+    ).to.deep.equal({
+      uuid: '12345678-1234-5678-1234-567812345678',
+      cdnUrlModifiers: '',
+      filename: null,
+    });
+  });
 });


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CDN URL parsing to accept URLs from an additional fallback CDN hostname (allowing previously-rejected CDN links to be parsed and UUIDs extracted).
* **Tests**
  * Added a test case to verify correct handling of URLs from the fallback CDN domain to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->