### PR TITLE
fix: prevent event duplication when uploader is remounted multiple times

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ TMP
 index.ssr.js
 web
 tests/__coverage__
+tsconfig.types.tsbuildinfo

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "nano-jsx": "^0.1.0",
         "node-watch": "^0.7.3",
         "npm-run-all": "^4.1.5",
-        "playwright": "^1.51.1",
+        "playwright": "^1.55.0",
         "postcss": "^8.4.21",
         "prettier": "^3.2.4",
         "prettier-plugin-jsdoc": "1.3.0",
@@ -13112,13 +13112,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.55.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -13131,9 +13131,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -26543,19 +26543,19 @@
       "dev": true
     },
     "playwright": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.52.0.tgz",
-      "integrity": "sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.0.tgz",
+      "integrity": "sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==",
       "dev": true,
       "requires": {
         "fsevents": "2.3.2",
-        "playwright-core": "1.52.0"
+        "playwright-core": "1.55.0"
       }
     },
     "playwright-core": {
-      "version": "1.52.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.52.0.tgz",
-      "integrity": "sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.0.tgz",
+      "integrity": "sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==",
       "dev": true
     },
     "plur": {

--- a/package.json
+++ b/package.json
@@ -119,7 +119,7 @@
     "nano-jsx": "^0.1.0",
     "node-watch": "^0.7.3",
     "npm-run-all": "^4.1.5",
-    "playwright": "^1.51.1",
+    "playwright": "^1.55.0",
     "postcss": "^8.4.21",
     "prettier": "^3.2.4",
     "prettier-plugin-jsdoc": "1.3.0",

--- a/tests/utils/test-renderer.tsx
+++ b/tests/utils/test-renderer.tsx
@@ -6,10 +6,16 @@ export const renderer = new CommonDOMRenderer();
 
 const containers = new Set<HTMLElement>();
 
-export const render = (jsx: any) => {
+export const render = (arg: any) => {
   const container = document.createElement('div');
   containers.add(container);
-  renderer.render(jsx).on(container);
+
+  if (arg instanceof Element) {
+    container.appendChild(arg);
+  } else {
+    renderer.render(arg).on(container);
+  }
+
   document.body.appendChild(container);
 };
 


### PR DESCRIPTION
## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Bug Fixes
  - Prevents duplicate upload events and ensures events continue to emit correctly after uploader re-mounts by tying observer lifecycles to element connection state.

- Chores
  - Excludes transient build-info file from version control.
  - Updates Playwright to ^1.55.0.

- Tests
  - Adds E2E tests verifying event emission stability across re-mounts and add/removal.
  - Adjusts test renderer to accept direct DOM elements for broader test scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->