### PR TITLE
fix: correct capitalization from "Onedrive" to "OneDrive" in locale files

### DIFF
--- a/locales/file-uploader/ar.js
+++ b/locales/file-uploader/ar.js
@@ -63,7 +63,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'أخرى',
   'src-type-mobile-video-camera': 'فيديو',

--- a/locales/file-uploader/az.js
+++ b/locales/file-uploader/az.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Digər',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/ca.js
+++ b/locales/file-uploader/ca.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Altres',
   'src-type-mobile-video-camera': 'Vídeo',

--- a/locales/file-uploader/cs.js
+++ b/locales/file-uploader/cs.js
@@ -59,7 +59,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Jiné',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/da.js
+++ b/locales/file-uploader/da.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Andet',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/de.js
+++ b/locales/file-uploader/de.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Andere',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/el.js
+++ b/locales/file-uploader/el.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Άλλο',
   'src-type-mobile-video-camera': 'Βίντεο',

--- a/locales/file-uploader/en.js
+++ b/locales/file-uploader/en.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Other',
   'caption-from-url': 'Import from link',

--- a/locales/file-uploader/es.js
+++ b/locales/file-uploader/es.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Otro',
   'src-type-mobile-video-camera': 'Vídeo',

--- a/locales/file-uploader/et.js
+++ b/locales/file-uploader/et.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Muu',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/fi.js
+++ b/locales/file-uploader/fi.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Muu',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/fr.js
+++ b/locales/file-uploader/fr.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Autre',
   'src-type-mobile-video-camera': 'Vidéo',

--- a/locales/file-uploader/he.js
+++ b/locales/file-uploader/he.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'אחר',
   'src-type-mobile-video-camera': 'וידאו',

--- a/locales/file-uploader/hy.js
+++ b/locales/file-uploader/hy.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Այլ',
   'src-type-mobile-video-camera': 'Տեսանյութ',

--- a/locales/file-uploader/is.js
+++ b/locales/file-uploader/is.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Annað',
   'src-type-mobile-video-camera': 'Myndband',

--- a/locales/file-uploader/it.js
+++ b/locales/file-uploader/it.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Altro',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/ja.js
+++ b/locales/file-uploader/ja.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'その他',
   'src-type-mobile-video-camera': 'ビデオ',

--- a/locales/file-uploader/ka.js
+++ b/locales/file-uploader/ka.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'სხვა',
   'src-type-mobile-video-camera': 'ვიდეო',

--- a/locales/file-uploader/kk.js
+++ b/locales/file-uploader/kk.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Басқа',
   'src-type-mobile-video-camera': 'Бейне',

--- a/locales/file-uploader/ko.js
+++ b/locales/file-uploader/ko.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': '기타',
   'src-type-mobile-video-camera': '비디오',

--- a/locales/file-uploader/lv.js
+++ b/locales/file-uploader/lv.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Cits',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/nb.js
+++ b/locales/file-uploader/nb.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Annet',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/nl.js
+++ b/locales/file-uploader/nl.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Andere',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/pl.js
+++ b/locales/file-uploader/pl.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Inne',
   'src-type-mobile-video-camera': 'Wideo',

--- a/locales/file-uploader/pt.js
+++ b/locales/file-uploader/pt.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Outro',
   'src-type-mobile-video-camera': 'Vídeo',

--- a/locales/file-uploader/ro.js
+++ b/locales/file-uploader/ro.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Altele',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/ru.js
+++ b/locales/file-uploader/ru.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'ВКонтакте',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Другое',
   'src-type-mobile-video-camera': 'Видео',

--- a/locales/file-uploader/sk.js
+++ b/locales/file-uploader/sk.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Iné',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/sr.js
+++ b/locales/file-uploader/sr.js
@@ -55,7 +55,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Остало',
   'src-type-mobile-video-camera': 'Видео',

--- a/locales/file-uploader/sv.js
+++ b/locales/file-uploader/sv.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Annat',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/tr.js
+++ b/locales/file-uploader/tr.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Diğer',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/uk.js
+++ b/locales/file-uploader/uk.js
@@ -57,7 +57,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Інше',
   'src-type-mobile-video-camera': 'Відео',

--- a/locales/file-uploader/vi.js
+++ b/locales/file-uploader/vi.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': 'Khác',
   'src-type-mobile-video-camera': 'Video',

--- a/locales/file-uploader/zh-TW.js
+++ b/locales/file-uploader/zh-TW.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': '其他',
   'src-type-mobile-video-camera': '影片',

--- a/locales/file-uploader/zh.js
+++ b/locales/file-uploader/zh.js
@@ -53,7 +53,7 @@ export default {
   'src-type-vk': 'VK',
   'src-type-evernote': 'Evernote',
   'src-type-box': 'Box',
-  'src-type-onedrive': 'Onedrive',
+  'src-type-onedrive': 'OneDrive',
   'src-type-huddle': 'Huddle',
   'src-type-other': '其他',
   'src-type-mobile-video-camera': '视频',


### PR DESCRIPTION
## Description

Correct capitalization from "Onedrive" to "OneDrive" in locale files

## Checklist

- [x] Tests (if applicable)
- [x] Documentation (if applicable)
- [x] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected capitalization of the OneDrive source label across the file uploader in 30+ locales (including English, Spanish, French, German, Italian, Portuguese, Dutch, Swedish, Danish, Norwegian, Finnish, Czech, Slovak, Polish, Romanian, Russian, Ukrainian, Greek, Turkish, Hebrew, Arabic, Japanese, Korean, Chinese, Vietnamese, and more).
  - Improves consistency with official branding and clarity in source selection for all affected languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->