### PR TITLE
fix: let plugin activities control their own modal height

### DIFF
--- a/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
+++ b/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
@@ -85,10 +85,7 @@ export class PluginActivityHost extends LitActivityBlock {
   }
 
   public override render() {
-    return html`<div
-      style="display: flex; flex-direction: column; width: 100%; min-height: 0;"
-      ${ref(this._containerRef)}
-    ></div>`;
+    return html`<div style="display: contents;" ${ref(this._containerRef)}></div>`;
   }
 }
 

--- a/src/blocks/PluginActivityRenderer/uc-plugin-activity-host.css
+++ b/src/blocks/PluginActivityRenderer/uc-plugin-activity-host.css
@@ -1,9 +1,5 @@
 @layer uc.components {
   uc-plugin-activity-host {
-    position: relative;
-    display: flex;
-    width: 100%;
-    height: 100%;
-    overflow: hidden;
+    display: contents;
   }
 }

--- a/tests/validation.e2e.test.tsx
+++ b/tests/validation.e2e.test.tsx
@@ -448,11 +448,27 @@ describe('Custom file validation', () => {
           expect.anything(),
         );
 
-      await page.getByLabelText('Edit', { exact: true }).click();
-      await delay(1000);
-      await page.getByLabelText('Apply mirror operation', { exact: true }).click();
-      await delay(1000);
-      await page.getByRole('button', { name: /apply/i }).click();
+      const waitForEditorChange = () =>
+        new Promise<void>((resolve) => {
+          document.querySelector('uc-cloud-image-editor')?.addEventListener('change', () => resolve(), { once: true });
+        });
+
+      const editButton = page.getByLabelText('Edit', { exact: true });
+      await expect.element(editButton).toBeVisible();
+      await editButton.click();
+
+      const mirrorButton = page.getByLabelText('Apply mirror operation', { exact: true });
+      await expect.element(mirrorButton).toBeVisible();
+      // Wait for initial crop to commit so the editor is ready to accept operations
+      await waitForEditorChange();
+
+      const changeAfterMirror = waitForEditorChange();
+      await mirrorButton.click();
+      await changeAfterMirror;
+
+      const applyButton = page.getByRole('button', { name: /apply/i });
+      await expect.element(applyButton).toBeEnabled();
+      await applyButton.click();
 
       await expect
         .poll(() => validator, {


### PR DESCRIPTION
## Summary

- Plugin activity host used `height: 100%` which resolved to 0 in Safari when the dialog only had `max-height` (no explicit `height`). Short activities like URL source collapsed to header-only with content clipped by `overflow: hidden`.
- Host (`uc-plugin-activity-host`) and its inner wrapper are now `display: contents`, so the plugin's activity element is effectively a direct layout child of the `<dialog>`. Percentage heights, flex sizing, and containing blocks chain through transparently, and `:has()` / `[activity][active]` selectors keep matching through the host.
- Plugin authors now control modal sizing **purely via CSS on their own element** — no registration flag, no framework attribute. Built-in activities (Camera, ExternalSource, CloudImageEditor) continue to use their existing `:has()`-based `height: 100%` rules, unchanged.

## Test plan

- [ ] Safari: URL activity modal opens with input + Import button visible (not collapsed to header)
- [ ] Safari: Camera activity fills the modal (video preview sizes correctly)
- [ ] Safari: External source activity fills the modal (iframe sizes correctly)
- [ ] Safari: Cloud image editor fills the modal
- [ ] Chrome: no regression in any of the above
- [ ] Verify `start-from` and `upload-list` modals (non-plugin) still size correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted the plugin activity renderer’s layout to improve positioning and visual spacing of child elements.

* **Refactor**
  * Simplified the container wrapper to reduce unnecessary layout constraints while preserving functionality.

* **Tests**
  * Improved end-to-end test flow for the image editor to make validations more reliable and reduce flaky timing issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->