### PR TITLE
Add Context7 configuration

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://context7.com/schema/context7.json",
+  "projectTitle": "Uploadcare File Uploader",
+  "description": "Web Components based Uploadcare file upload widget with configurable sources, validation, image editing, secure uploads, and CDN delivery.",
+  "url": "https://context7.com/uploadcare/file-uploader",
+  "public_key": "pk_WoigIc3LrHKMjLxnI0IA2",
+  "branch": "main",
+  "folders": ["demo", "src/types", "types"],
+  "excludeFolders": ["demo/bundles", "types/test"],
+  "excludeFiles": [
+    "CHANGELOG*",
+    "CODE_OF_CONDUCT*",
+    "CONTRIBUTING*",
+    "LICENSE",
+    "pull_request_template.md"
+  ],
+  "rules": [
+    "Import from @uploadcare/file-uploader or the versioned CDN module and call UC.defineComponents(UC) before using uploader elements.",
+    "Configure uploads with a uc-config element containing pubkey; its ctx-name must match the uploader solution element.",
+    "Use the public Web Components API rather than assuming framework-specific adapters.",
+    "Include the CSS for the selected uploader solution when using CDN or package web assets.",
+    "Use secure uploads with server-generated secureSignature and secureExpire values; do not expose private API keys in client code."
+  ]
+}


### PR DESCRIPTION
## Summary

- Add root `context7.json` for Context7 ownership verification and indexing configuration.
- Scope indexed content to examples and public type surfaces while excluding generated demo bundles and type tests.
- Add usage rules for the public File Uploader integration path.

## Validation

- Parsed `context7.json` as JSON.
- Ran a local sanity check for supported keys, paired ownership fields, unique arrays, filename-only `excludeFiles`, and schema field length limits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a configuration manifest for the Uploadcare File Uploader with user-facing setup guidance: component initialization, configuring uploads via the uploader element, using the public Web Components API, ensuring correct uploader styling, and performing secure uploads with server-provided signatures to avoid exposing private keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->