### PR TITLE
Migrate npm publish to staged publishing

### DIFF
--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
           node-version: 24
+      - name: Pin npm with staged publishing support
+        run: npm install -g npm@">=11.15.0"
       - run: npm ci
       - run: |
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
@@ -26,3 +28,19 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
           SLACK_INCOMING_HOOK: ${{ secrets.SLACK_INCOMING_HOOK }}
+      - name: Read package metadata
+        id: pkg
+        run: |
+          {
+            echo "name=$(node -p "require('./package.json').name")"
+            echo "version=$(node -p "require('./package.json').version")"
+          } >> "$GITHUB_OUTPUT"
+      - name: Notify Slack about staged release
+        uses: slackapi/slack-github-action@v1.27.0
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        with:
+          channel-id: ${{ secrets.SLACK_NPM_RELEASE_CHANNEL }}
+          slack-message: |
+            :package: *${{ steps.pkg.outputs.name }}@${{ steps.pkg.outputs.version }}* staged for review
+            Review & approve (2FA required): https://www.npmjs.com/package/${{ steps.pkg.outputs.name }}?activeTab=staged

--- a/ship.config.mjs
+++ b/ship.config.mjs
@@ -1,4 +1,4 @@
 export default {
   buildCommand: () => 'npm run build',
-  publishCommand: ({ defaultCommand }) => `${defaultCommand} --access public`,
+  publishCommand: ({ tag }) => `npm stage publish --tag ${tag}`,
 };


### PR DESCRIPTION
https://docs.npmjs.com/staged-publishing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release workflow to implement staged publishing with required two-factor authentication approval before releases go live
  * Added automatic Slack notifications that alert the team when package releases are staged for review, including direct links to staged releases
  * Enhanced npm CLI version management by pinning to version 11.15.0 or higher for improved workflow reliability and consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/uploadcare/file-uploader/pull/968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->