### PR TITLE
feat: add addFileFromUploadcareFile to the uploader public API

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup
+description: Set up Node 24 and install dependencies, restoring node_modules from cache when possible.
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
+      with:
+        node-version: 24
+        cache: npm
+    # Cache the whole install (incl. Vite's dep pre-bundle in node_modules/.vite)
+    # so jobs restore it instead of reinstalling. Keyed on the lockfile + node.
+    - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
+      id: node-modules
+      with:
+        path: node_modules
+        key: ${{ runner.os }}-node24-node_modules-${{ hashFiles('package-lock.json') }}
+    - if: steps.node-modules.outputs.cache-hit != 'true'
+      shell: bash
+      run: npm ci

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,8 +11,12 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Build
         run: npm run build
+      # test:types (tsd vs dist/index.d.ts) and tsc (tsconfig.test references the
+      # generated types/jsx.d.ts) both need the build output, so they run here.
       - name: Validate type definitions
         run: npm run test:types
+      - name: Typecheck
+        run: npm run tsc
 
   lint:
     runs-on: ubuntu-latest
@@ -21,14 +25,6 @@ jobs:
       - uses: ./.github/actions/setup
       - name: Lint
         run: npm run lint
-
-  tsc:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: ./.github/actions/setup
-      - name: Typecheck
-        run: npm run tsc
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,30 +8,49 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
-      - uses: actions/setup-node@395ad3262231945c25e8478fd5baf05154b1d79f # v6.1.0
-        with:
-          node-version: 24
-          cache: "npm"
+      - uses: ./.github/actions/setup
+      - name: Build
+        run: npm run build
+      - name: Validate type definitions
+        run: npm run test:types
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/setup
+      - name: Lint
+        run: npm run lint
+
+  tsc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/setup
+      - name: Typecheck
+        run: npm run tsc
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+      - uses: ./.github/actions/setup
       - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         id: playwright-cache
         with:
-          path: |
-            ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/package-lock.json') }}
-      - name: Install dependencies
-        working-directory: ./
-        run: npm ci
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
       - name: Install playwright deps
-        run: npm run playwright:install
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-      - name: Run build
-        run: npm run build
-      - name: Run lint
-        run: npm run lint
-      - name: Run test
-        run: npm run test
-      - name: Run tsc
-        run: npm run tsc
+        timeout-minutes: 10
+        env:
+          # `playwright install --with-deps` shells out to apt-get; keep it from
+          # stalling for hours on an interactive prompt (e.g. Ubuntu's needrestart).
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        run: npm run playwright:install
+      - name: Run tests
+        run: npm run test:specs && npm run test:locales && npm run test:e2e
       - name: Archive artifacts
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         if: always()

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,11 +3,18 @@ name: checks
 on:
   pull_request:
 
+# The checks only read the repo; keep the GITHUB_TOKEN least-privilege
+# (the repo default is write-all).
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Build
         run: npm run build
@@ -22,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
       - name: Lint
         run: npm run lint
@@ -30,21 +39,28 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup
+      # System packages aren't covered by the browser cache, so install them
+      # unconditionally; only the browser binaries below are cache-gated.
+      - name: Install playwright system deps
+        timeout-minutes: 10
+        env:
+          # `playwright install-deps` shells out to apt-get; keep it from
+          # stalling for hours on an interactive prompt (e.g. Ubuntu's needrestart).
+          DEBIAN_FRONTEND: noninteractive
+          NEEDRESTART_MODE: a
+        run: npx playwright install-deps chromium
       - uses: actions/cache@9255dc7a253b0ccc959486e2bca901246202afeb # v5.0.1
         id: playwright-cache
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}
-      - name: Install playwright deps
+      - name: Install playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         timeout-minutes: 10
-        env:
-          # `playwright install --with-deps` shells out to apt-get; keep it from
-          # stalling for hours on an interactive prompt (e.g. Ubuntu's needrestart).
-          DEBIAN_FRONTEND: noninteractive
-          NEEDRESTART_MODE: a
-        run: npm run playwright:install
+        run: npx playwright install chromium
       # specs/npm imports the published package (dist/ + web/), so tests need
       # the build output too.
       - name: Build

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -45,6 +45,10 @@ jobs:
           DEBIAN_FRONTEND: noninteractive
           NEEDRESTART_MODE: a
         run: npm run playwright:install
+      # specs/npm imports the published package (dist/ + web/), so tests need
+      # the build output too.
+      - name: Build
+        run: npm run build
       - name: Run tests
         run: npm run test:specs && npm run test:locales && npm run test:e2e
       - name: Archive artifacts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,15 +27,15 @@ jobs:
         uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3.36.1
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v3
+        uses: github/codeql-action/autobuild@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3.36.1
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@d77b13a0df3134d64a457ea9003f600b09fa1c8a # v3.36.1
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/shipjs-trigger.yml
+++ b/.github/workflows/shipjs-trigger.yml
@@ -36,7 +36,7 @@ jobs:
             echo "version=$(node -p "require('./package.json').version")"
           } >> "$GITHUB_OUTPUT"
       - name: Notify Slack about staged release
-        uses: slackapi/slack-github-action@v1.27.0
+        uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "lit-analyzer": "^2.0.3",
         "node-watch": "^0.7.4",
         "npm-run-all": "^4.1.5",
-        "playwright": "^1.58.2",
+        "playwright": "^1.60.0",
         "postcss": "^8.5.8",
         "publint": "^0.3.18",
         "render-jsx": "^0.2.4",
@@ -10427,13 +10427,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.2"
+        "playwright-core": "1.60.0"
       },
       "bin": {
         "playwright": "cli.js"
@@ -10446,9 +10446,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "lit-analyzer": "^2.0.3",
     "node-watch": "^0.7.4",
     "npm-run-all": "^4.1.5",
-    "playwright": "^1.58.2",
+    "playwright": "^1.60.0",
     "postcss": "^8.5.8",
     "publint": "^0.3.18",
     "render-jsx": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "clean": "run-s clean:*",
     "format": "biome check --write",
     "prepare": "husky install",
-    "playwright:install": "npx playwright install && npx playwright install --with-deps chromium"
+    "playwright:install": "npx playwright install --with-deps chromium"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "^0.18.2",

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -128,6 +128,25 @@ export class UploaderPublicApi extends SharedInstance {
     return this.getOutputItem(internalId);
   };
 
+  public addFileFromUploadcareFile = (
+    file: UploadcareFile,
+    { silent, fileName, source }: ApiAddFileCommonOptions = {},
+  ): OutputFileEntry<'success'> => {
+    const internalId = this._uploadCollection.add({
+      fileInfo: file,
+      uuid: file.uuid,
+      cdnUrl: file.cdnUrl,
+      fileName: fileName ?? file.originalFilename,
+      fileSize: file.size,
+      isImage: file.isImage ?? false,
+      mimeType: file.contentInfo?.mime?.mime ?? file.mimeType,
+      uploadProgress: 100,
+      silent: silent ?? false,
+      source: source ?? UploadSource.API,
+    });
+    return this.getOutputItem(internalId);
+  };
+
   public removeFileByInternalId = (internalId: string): void => {
     if (!this._uploadCollection.read(internalId as Uid)) {
       throw new Error(`File with internalId ${internalId} not found`);

--- a/src/abstract/managers/plugin/PluginManager.ts
+++ b/src/abstract/managers/plugin/PluginManager.ts
@@ -12,7 +12,7 @@ export class PluginManager extends SharedInstance {
   private _subscribers: Set<Unsubscriber> = new Set();
   private _pluginsUpdate: Promise<void> = Promise.resolve();
   private _lazyPluginLoader: LazyPluginLoader;
-  public readonly registry = new PluginRegistry();
+  public readonly registry = new PluginRegistry(() => this._notifySubscribers());
 
   public get configRegistry() {
     return this.registry.config;
@@ -170,6 +170,7 @@ export class PluginManager extends SharedInstance {
     for (const pluginId of Array.from(this._plugins.keys())) {
       this._unregisterPlugin(pluginId);
     }
+    this.registry.destroy();
     this._lazyPluginLoader.destroy();
     super.destroy();
   }

--- a/src/abstract/managers/plugin/PluginRegistry.test.ts
+++ b/src/abstract/managers/plugin/PluginRegistry.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PluginRegistry } from './PluginRegistry';
+
+// The notification is batched via `debounce(onChange, 0)`, i.e. a 0ms timer —
+// flush a macrotask to let it fire.
+const flushBatch = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+/**
+ * The registry notifies (batched) on every successful registration.
+ * Registrations can happen lazily, long after a plugin's setup() ran (e.g.
+ * registering a locale's strings when `localeName` changes), so consumers must
+ * be told to re-apply the new state — without this, late `addL10n` calls never
+ * reach rendered labels. A synchronous burst coalesces into a single call.
+ */
+describe('PluginRegistry — batched change notification', () => {
+  it('notifies once for a synchronous burst of registrations, on the next microtask', async () => {
+    const onChange = vi.fn();
+    const registry = new PluginRegistry(onChange);
+
+    registry.addL10n('p', { en: { 'my-key': 'My value' } });
+    registry.addIcon('p', { name: 'my-icon', svg: '<svg/>' });
+    registry.addFileAction('p', {
+      id: 'fa',
+      label: 'Action',
+      icon: 'my-icon',
+      shouldRender: () => true,
+      onClick: () => {},
+    });
+    registry.addSource('p', { id: 's', label: 'Source', onSelect: () => {} });
+
+    // Batched: nothing fired synchronously.
+    expect(onChange).not.toHaveBeenCalled();
+
+    await flushBatch();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(registry.snapshot().l10n).toHaveLength(1);
+  });
+
+  it('notifies again for a later (separate-tick) registration', async () => {
+    const onChange = vi.fn();
+    const registry = new PluginRegistry(onChange);
+
+    registry.addL10n('p', { en: { a: '1' } });
+    await flushBatch();
+    expect(onChange).toHaveBeenCalledTimes(1);
+
+    // A registration in a later tick (e.g. a locale loaded on demand) re-notifies.
+    registry.addL10n('p', { de: { a: 'eins' } });
+    await flushBatch();
+    expect(onChange).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not notify when a duplicate source is skipped', async () => {
+    const onChange = vi.fn();
+    const registry = new PluginRegistry(onChange);
+
+    registry.addSource('p', { id: 's', label: 'Source', onSelect: () => {} });
+    registry.addSource('p2', { id: 's', label: 'Other', onSelect: () => {} }); // duplicate id → skipped
+
+    await flushBatch();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(registry.snapshot().sources).toHaveLength(1);
+  });
+});

--- a/src/abstract/managers/plugin/PluginRegistry.ts
+++ b/src/abstract/managers/plugin/PluginRegistry.ts
@@ -1,3 +1,4 @@
+import { debounce } from '../../../utils/debounce';
 import { type CustomConfigDefinition, CustomConfigRegistry } from '../../customConfigOptions';
 import type {
   Owned,
@@ -19,6 +20,25 @@ export class PluginRegistry {
   private _l10n: Owned<PluginL10nRegistration>[] = [];
   public readonly config = new CustomConfigRegistry();
 
+  /**
+   * Notify consumers (LocaleManager, SourceListController, …) that the registry
+   * changed so they re-apply the new state. Coalesces a synchronous burst of
+   * registrations — a plugin's setup() typically registers an icon, a source,
+   * several l10n maps, … in one tick — into a single, deferred notification.
+   * Registrations can also happen lazily, long after setup() ran (e.g. a locale's
+   * strings loaded when `localeName` changes), which is why this exists.
+   */
+  private readonly _scheduleNotify: ReturnType<typeof debounce>;
+
+  public constructor(onChange: () => void = () => {}) {
+    this._scheduleNotify = debounce(onChange, 0);
+  }
+
+  /** Drop any pending notification (call on teardown). */
+  public destroy(): void {
+    this._scheduleNotify.cancel();
+  }
+
   private _own<T>(pluginId: string, item: T): Owned<T> {
     return { ...item, pluginId } as Owned<T>;
   }
@@ -32,6 +52,7 @@ export class PluginRegistry {
       return;
     }
     this._sources.push(this._own(pluginId, item));
+    this._scheduleNotify();
   }
 
   public addActivity(pluginId: string, item: PluginActivityRegistration): void {
@@ -43,26 +64,32 @@ export class PluginRegistry {
       return;
     }
     this._activities.push(this._own(pluginId, item));
+    this._scheduleNotify();
   }
 
   public addFileAction(pluginId: string, item: PluginFileActionRegistration): void {
     this._fileActions.push(this._own(pluginId, item));
+    this._scheduleNotify();
   }
 
   public addFileHook(pluginId: string, item: PluginFileHookRegistration): void {
     this._fileHooks.push(this._own(pluginId, { timeout: 30_000, ...item }));
+    this._scheduleNotify();
   }
 
   public addIcon(pluginId: string, item: PluginIconRegistration): void {
     this._icons.push(this._own(pluginId, item));
+    this._scheduleNotify();
   }
 
   public addL10n(pluginId: string, item: PluginL10nRegistration): void {
     this._l10n.push(this._own(pluginId, item));
+    this._scheduleNotify();
   }
 
   public addConfig<T>(pluginId: string, definition: CustomConfigDefinition<T>): void {
     this.config.register(pluginId, definition);
+    this._scheduleNotify();
   }
 
   public purge(pluginId: string): void {

--- a/tests/api.e2e.test.tsx
+++ b/tests/api.e2e.test.tsx
@@ -42,17 +42,21 @@ describe('API', () => {
     expect(eventPayload).toMatchObject(expect.objectContaining({ status: 'idle', externalUrl: url }));
   });
 
-  it('should add an already-uploaded file from an UploadcareFile instance without re-uploading it', async () => {
+  it('should add an already-uploaded file from an UploadcareFile instance and fire the success events without uploading', async () => {
     // Upload a real local image via the upload client to get a genuine UploadcareFile.
     const file = await uploadFile(IMAGE.PIXEL, { publicKey: 'demopublickey', store: false });
 
     const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
     const api = uploadCtxProvider.api;
 
+    const fileAddedHandler = vi.fn<(e: CustomEvent<EventPayload['file-added']>) => void>();
     const uploadStartHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-start']>) => void>();
     const uploadSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-success']>) => void>();
+    const commonSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['common-upload-success']>) => void>();
+    uploadCtxProvider.addEventListener('file-added', fileAddedHandler);
     uploadCtxProvider.addEventListener('file-upload-start', uploadStartHandler);
     uploadCtxProvider.addEventListener('file-upload-success', uploadSuccessHandler);
+    uploadCtxProvider.addEventListener('common-upload-success', commonSuccessHandler);
 
     const entry = api.addFileFromUploadcareFile(file);
 
@@ -65,16 +69,22 @@ describe('API', () => {
     // `fileInfo` being set is what marks the entry as already uploaded.
     expect(entry.fileInfo?.uuid).toBe(file.uuid);
 
-    // Triggering the upload flow must not re-upload an already-uploaded file.
-    api.uploadAll();
-
-    // It settles as successful (it already carries fileInfo)...
+    // Adding an already-uploaded file fires the success events on its own — no `uploadAll()` needed.
     const successPayload = await vi.waitFor(() => {
       expect(uploadSuccessHandler).toHaveBeenCalled();
       return uploadSuccessHandler.mock.calls[0][0].detail;
     });
     expect(successPayload).toMatchObject(expect.objectContaining({ uuid: file.uuid }));
-    // ...without ever starting an upload.
+
+    // The collection reaches the success state as a whole.
+    const commonPayload = await vi.waitFor(() => {
+      expect(commonSuccessHandler).toHaveBeenCalled();
+      return commonSuccessHandler.mock.calls[0][0].detail;
+    });
+    expect(commonPayload.status).toBe('success');
+
+    // The file was announced as added, and was never uploaded (it already carried fileInfo).
+    expect(fileAddedHandler).toHaveBeenCalled();
     expect(uploadStartHandler).not.toHaveBeenCalled();
   }, 30_000);
 

--- a/tests/api.e2e.test.tsx
+++ b/tests/api.e2e.test.tsx
@@ -1,6 +1,8 @@
+import { uploadFile } from '@uploadcare/upload-client';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { Config, EventPayload } from '@/index.js';
+import { IMAGE } from './fixtures/files';
 import { TEST_IMAGE_URL } from './utils/constants';
 import '../types/jsx';
 
@@ -39,6 +41,42 @@ describe('API', () => {
 
     expect(eventPayload).toMatchObject(expect.objectContaining({ status: 'idle', externalUrl: url }));
   });
+
+  it('should add an already-uploaded file from an UploadcareFile instance without re-uploading it', async () => {
+    // Upload a real local image via the upload client to get a genuine UploadcareFile.
+    const file = await uploadFile(IMAGE.PIXEL, { publicKey: 'demopublickey', store: false });
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const uploadStartHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-start']>) => void>();
+    const uploadSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-success']>) => void>();
+    uploadCtxProvider.addEventListener('file-upload-start', uploadStartHandler);
+    uploadCtxProvider.addEventListener('file-upload-success', uploadSuccessHandler);
+
+    const entry = api.addFileFromUploadcareFile(file);
+
+    // Added in its completed state, referencing the existing file.
+    expect(entry.uuid).toBe(file.uuid);
+    expect(entry.cdnUrl).toBe(file.cdnUrl);
+    expect(entry.name).toBe(file.originalFilename);
+    expect(entry.size).toBe(file.size);
+    expect(entry.isImage).toBe(file.isImage);
+    // `fileInfo` being set is what marks the entry as already uploaded.
+    expect(entry.fileInfo?.uuid).toBe(file.uuid);
+
+    // Triggering the upload flow must not re-upload an already-uploaded file.
+    api.uploadAll();
+
+    // It settles as successful (it already carries fileInfo)...
+    const successPayload = await vi.waitFor(() => {
+      expect(uploadSuccessHandler).toHaveBeenCalled();
+      return uploadSuccessHandler.mock.calls[0][0].detail;
+    });
+    expect(successPayload).toMatchObject(expect.objectContaining({ uuid: file.uuid }));
+    // ...without ever starting an upload.
+    expect(uploadStartHandler).not.toHaveBeenCalled();
+  }, 30_000);
 
   it('should not duplicate events after uploader add/removal', async () => {
     for (let i = 0; i < 5; i++) {

--- a/tests/plugins/icon-and-l10n.e2e.test.tsx
+++ b/tests/plugins/icon-and-l10n.e2e.test.tsx
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
-import { defineLocale } from '@/index.ts';
+import { defineLocale } from '@/index';
 import { delay } from '@/utils/delay';
 import { TEST_IMAGE_URL } from '../utils/constants';
 import { addSource, createTestPlugin, getApi, openModal, renderUploader } from './utils';

--- a/tests/plugins/icon-and-l10n.e2e.test.tsx
+++ b/tests/plugins/icon-and-l10n.e2e.test.tsx
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
+import { defineLocale } from '@/index.ts';
+import { delay } from '@/utils/delay';
 import { TEST_IMAGE_URL } from '../utils/constants';
 import { addSource, createTestPlugin, getApi, openModal, renderUploader } from './utils';
 
@@ -57,6 +59,43 @@ describe('L10n Registration', () => {
 
     await openModal();
     await expect.element(page.getByText('My Translated Source')).toBeVisible();
+  });
+
+  it('applies l10n registered asynchronously after a locale switch to a rendered source label', async () => {
+    // The uploader needs a `de` definition so the locale switch resolves cleanly.
+    defineLocale('de', {} as never);
+
+    const plugin = createTestPlugin({
+      id: 'lazy-l10n',
+      setup: ({ pluginApi }) => {
+        pluginApi.registry.registerL10n({ en: { 'lazy-source-label': 'Generate' } });
+        pluginApi.registry.registerSource({
+          id: 'lazy-source',
+          label: 'lazy-source-label',
+          onSelect: () => {},
+        });
+        // Register the locale's strings lazily — AFTER the LocaleManager has
+        // already applied plugin locales for the switch (mimics a real plugin
+        // awaiting a dynamic locale import). This only reaches the rendered
+        // label if `registerL10n` notifies subscribers.
+        pluginApi.config.subscribe('localeName', (name) => {
+          if (name === 'de') {
+            void delay(0).then(() => {
+              pluginApi.registry.registerL10n({ de: { 'lazy-source-label': 'Erzeugen' } });
+            });
+          }
+        });
+      },
+    });
+
+    const { config } = await renderUploader([plugin]);
+    addSource(config, 'lazy-source');
+
+    await openModal();
+    await expect.element(page.getByText('Generate')).toBeVisible();
+
+    config.localeName = 'de';
+    await expect.element(page.getByText('Erzeugen')).toBeVisible();
   });
 
   it('should keep plugin l10n overrides even after plugin is unregistered (current behavior)', async () => {

--- a/tests/validation.e2e.test.tsx
+++ b/tests/validation.e2e.test.tsx
@@ -438,7 +438,9 @@ describe('Custom file validation', () => {
 
       await expect
         .poll(() => validator, {
-          timeout: 5000,
+          // The validator fires with `cdnUrlModifiers: ''` only once the real
+          // upload completes; 5s is flaky, match the upload waits above.
+          timeout: 10000,
         })
         .toHaveBeenLastCalledWith(
           expect.objectContaining({ cdnUrlModifiers: '' }),


### PR DESCRIPTION
Adds `UploaderPublicApi.addFileFromUploadcareFile(file, options?)` which adds an already-uploaded file from an `UploadcareFile` instance (e.g. the result of `uploadFile()` from `@uploadcare/upload-client`). The entry is created in its completed state (`fileInfo` set, `uploadProgress: 100`), mirroring the shape a finished upload produces, so it is not uploaded again.

Covered by an e2e test that uploads a real local image via the upload client, adds it through the new method, and asserts it settles as a successful entry (file-upload-success) without ever firing file-upload-start.

## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Add pre-uploaded files directly into the uploader while preserving metadata and marking them as completed.

* **Improvements**
  * Plugin registry now batches change notifications; plugin manager teardown ensures registry cleanup.
  * CI workflow refactored into modular jobs with cached dependency setup; Playwright install streamlined.

* **Tests**
  * Added e2e and unit tests for pre-uploaded-file flows, plugin registry notifications, and locale/plugin registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->