### PR TITLE
M0: v2 controller primitives + agent docs (foundations)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  auto_review:
+    # By default CodeRabbit only auto-reviews PRs whose base is the default
+    # branch. The v2 strangler migration uses stacked PRs that target the
+    # `feat/v2-migration` integration branch and its per-milestone branches
+    # (feat/v2-mN-*), so opt those bases in too — otherwise CodeRabbit skips
+    # them. Matched as regex against the PR base branch name.
+    base_branches:
+      - "feat/v2-.*"
   # Exclude demo pages from CodeRabbit reviews.
   # Patterns are glob-style; entries starting with '!' are ignored.
   path_filters:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,40 @@
+# GitHub Copilot instructions
+
+Full project conventions are in [`AGENTS.md`](../AGENTS.md) at the repo root —
+treat it as the source of truth. Key rules for code generation and PR review:
+
+## Project
+`@uploadcare/file-uploader` — a framework-agnostic Web Components file uploader
+built on **Lit**, with state via a **nanostores**-backed shim
+(`SymbioteCompatMixin`). Single package; canonical source is root `src/`. A
+v2 **strangler migration** is in progress (see `MIGRATION-PLAN.md`): DOM-free
+`UploaderController` + sub-controllers / `EventBus` / `Listeners` under the
+existing public tags, one milestone per PR.
+
+## Conventions
+- TypeScript + Lit; custom-element tags prefixed `uc-`.
+- TS experimental decorators (`useDefineForClassFields: false`) — not standard
+  decorators.
+- Formatting is **Biome**: single quotes, space indent, line width 120.
+- Domain-based file names; light-DOM rendering (`LightDomMixin`).
+- **Conventional Commits** (drives lerna releases): `feat:`, `fix:`, `chore:`,
+  `docs:`, `refactor:`, optional scope.
+- v2 controllers (`src/abstract/controllers/*`, `EventBus`, `host-subscription`)
+  must **not** import `lit` or touch the DOM.
+
+## Build & test (for reviewing CI-affecting changes)
+- Run a full `npm run build` **before** `npm run test:specs` and
+  `npm run test:e2e` — they consume built `dist/`+`web/` and self-resolve the
+  package (needs `dist/index.ssr.js` from `build:ssr-stubs`).
+- e2e needs `npx playwright install chromium`. The e2e project has `retry: 1`
+  for a known cloud-image-editor flake — don't loosen assertions to "fix" flakes.
+- Gate: `tsc:app` + `build` + `test:specs` + `test:locales` + `test:e2e` + `lint`.
+
+## Review focus
+- **Don't break the documented public API** (tags, `<uc-config>` options,
+  `getAPI()` methods, events, `--uc-*` CSS vars, plugin API, `OutputFileEntry`/
+  `OutputCollectionState` shapes — documented in the `fern-docs` repo).
+  Undocumented internals (`$` proxy, `*`-keys, `--cfg-*`) may change freely.
+- Flag swallowed errors and silent fallbacks. Fan-out paths should
+  isolate-and-warn (cf. `EventBus.emit`, `Listeners.notify`), not hide failures.
+- Keep PRs to one concern with the gate green.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,178 @@
+# AGENTS.md
+
+Guidance for AI coding agents (Claude Code, Copilot, Cursor, etc.) working in
+this repository. Humans: see also [`CONTRIBUTING.md`](./CONTRIBUTING.md) and
+[`README.md`](./README.md). This file is the single source of truth for agent
+conventions; tool-specific files (`CLAUDE.md`, `.github/copilot-instructions.md`)
+just point here.
+
+---
+
+## What this is
+
+`@uploadcare/file-uploader` — a framework-agnostic **Web Components** file
+upload widget (works with React/Vue/Angular/Svelte/plain HTML, no adapters).
+Built on **Lit**, with state managed through a **nanostores**-backed
+compatibility shim (`SymbioteCompatMixin`). Ships as ESM library (`dist/`) and
+bundled browser builds (`web/`).
+
+The public API is documented in a **separate repo**, `fern-docs`
+(`~/workspace/fern-docs/fern/pages/file-uploader/*`). That documented surface is
+a contract — see [Do not break](#do-not-break).
+
+---
+
+## Setup
+
+```bash
+npm ci                      # install deps
+npx playwright install chromium   # one-time: required for e2e (browser tests)
+```
+
+---
+
+## Build, test, and the green gate
+
+> [!IMPORTANT]
+> **Run a full `npm run build` before `test:specs` and `test:e2e`.** Those
+> suites consume the built `dist/` + `web/` artifacts and self-resolve the
+> package via its `package.json` `exports` (which point at `dist/index.ssr.js`,
+> produced by the separate `build:ssr-stubs` step). Running only `build:lib`
+> leaves the package unresolvable and the npm-surface / e2e tests fail with
+> confusing errors. `dist/` and `web/` are gitignored.
+
+| Command | What it does |
+|---------|--------------|
+| `npm run tsc:app` | App typecheck (`tsconfig.app.json`, `noEmit`). Fast first check. |
+| `npm run build` | `svg-sprites → lib → ssr-stubs → jsx:types`, then `attw` + `publint` + `size-limit`. **Prereq for specs/e2e.** |
+| `npm run test:specs` | Vitest **specs** project (happy-dom). Colocated `**/*.test.{ts,js}` + `specs/npm/*.test.ts`. |
+| `npm run test:e2e` | Vitest **e2e** project — real Chromium via `@vitest/browser-playwright`. Needs playwright + built `web/`. |
+| `npm run test:e2e:dev` | Same, headed, for debugging. |
+| `npm run test:locales` | Validates locale dictionaries. |
+| `npm run lint` | `biome lint` + `eslint` + `stylelint` + `lit-analyzer --strict`. |
+| `npm run lint:js:fix` / `lint:css:fix` | Autofix. |
+
+**The green gate (run all before declaring work done / opening a PR):**
+
+```bash
+npm run tsc:app && \
+npm run build && \
+npm run test:specs && \
+npm run test:locales && \
+npm run test:e2e && \
+npm run lint
+```
+
+Pre-commit (husky + lint-staged) runs `biome check --write` on staged
+`*.{ts,js,cjs,tsx}`. The husky "DEPRECATED" warning on commit is benign.
+
+### Known e2e flake
+`tests/cloud-image-editor.e2e.test.tsx` (`getByTestId('uc-crop-frame')`) can
+lose a render race under full parallel load but passes in isolation. The e2e
+project has `retry: 1` so a transient flake won't fail the gate while a genuine
+regression still fails both attempts. Don't "fix" it by loosening assertions.
+
+---
+
+## Code conventions
+
+- **TypeScript + Lit.** Custom-element tags are prefixed `uc-`.
+- **TS experimental decorators** (`@state()`, `@property()`); `tsconfig.app.json`
+  sets `experimentalDecorators: true`, `useDefineForClassFields: false`,
+  `target: esnext`. Don't switch to standard/ECMA decorators.
+- **Formatting = Biome.** Single quotes, space indent, line width 120. Let
+  `biome` format; don't hand-format against it.
+- **Domain-based file names** (`UploadCollectionController.ts`,
+  `fetch-profile.ts`) over technical-role names (`utils.ts`, `types.ts`).
+- **Light DOM** rendering (`LightDomMixin`) — components render into their own
+  light DOM, not shadow DOM. CSS theming relies on this.
+- **Conventional Commits** (lerna `conventionalCommits` drives releases):
+  `feat:`, `fix:`, `chore:`, `docs:`, `refactor:` … Scope when useful
+  (`fix(thumb): …`). This determines the changelog and version bump.
+
+---
+
+## Repository layout
+
+Single package on `main` (root `package.json` = `@uploadcare/file-uploader`,
+**no** workspaces; canonical source is root `src/`).
+
+> [!NOTE]
+> A `packages/` directory may appear in the working tree — it is **untracked
+> stray cruft** from a `feat/monorepo` checkout (0 tracked files). Ignore it;
+> it is safe to `rm -rf packages/`. All work targets root `src/`.
+
+```
+src/
+  abstract/        Logic layer: managers/, controllers/, UploaderPublicApi, EventBus, …
+  lit/             Base element classes + state shim (LitBlock, SymbioteCompatMixin, PubSubCompat)
+  blocks/          Custom elements (Modal, DropArea, UploadList, Config, CloudImageEditor, …)
+  solutions/       Presets (file-uploader regular/minimal/inline)
+  plugins/         Built-in plugins (camera, url, external-sources, cloud-image-editor, …)
+  locales/         Locale dictionaries
+  types/           Public/shared types (types/exported.ts = public data shapes)
+  utils/           Internal utilities
+tests/             Browser e2e (*.e2e.test.tsx)
+*.test.ts          Unit specs, colocated next to source
+```
+
+---
+
+## Architecture (current)
+
+- **Composition:** documented multi-tag model — `<uc-config>` +
+  `<uc-file-uploader-regular|minimal|inline>` + `<uc-upload-ctx-provider>` +
+  `<uc-form-input>`, wired by a shared `ctx-name` string and `@lit/context`.
+- **State:** one nanostores `MapStore` per `ctx-name` (`PubSubCompat`), reached
+  through the `$` proxy and `sub`/`pub`/`read`/`cfg` on `SymbioteCompatMixin`.
+  Flat string keys (`*cfg/<key>`, `*currentActivity`, `*uploadList`, …).
+- **Base classes:** `LitBlock` → `LitActivityBlock` → `LitUploaderBlock` →
+  `LitSolutionBlock`. Singleton managers (`ModalManager`, `EventEmitter`,
+  `PluginManager`, `ValidationManager`, …) live in the shared store.
+- **Public JS API:** `element.getAPI()` → `UploaderPublicApi`. Events dispatch
+  on `<uc-upload-ctx-provider>` (`EventType` in `EventEmitter.ts`).
+
+Symbiote is **gone at runtime** — `SymbioteCompatMixin` is a Lit + nanostores
+shim, not a dependency on `@symbiotejs/symbiote`.
+
+---
+
+## v2 migration (in progress)
+
+A **strangler migration** is underway, incrementally adopting a v2 architecture
+(DOM-free `UploaderController` + sub-controllers, `EventBus`, the `Listeners`
+primitive, a central router) under the existing v1 public tags — one testable
+milestone per PR. **Full plan: [`MIGRATION-PLAN.md`](./MIGRATION-PLAN.md).**
+
+- Integration branch: **`feat/v2-migration`**; each milestone branches off it
+  and PRs back into it (`feat/v2-m<N>-<name>` → `feat/v2-migration`).
+- The DOM-free controller layer lives in `src/abstract/` (e.g.
+  `controllers/UploaderController.ts`, `EventBus.ts`, `host-subscription.ts`,
+  `UploaderRegistry.ts`). Controllers must **not** import `lit` or touch the
+  DOM — UI bridging belongs in the element/adapter layer.
+- Every milestone must pass the **full green gate including e2e** before merge.
+
+---
+
+## Do not break
+
+- **Documented public API** (tags, ~55 `<uc-config>` options, `getAPI()`
+  methods, 19 events, `--uc-*` CSS variables, the plugin API, and the
+  `OutputFileEntry`/`OutputCollectionState` data shapes) defined in `fern-docs`.
+  Until a future major, keep it working — add compat shims rather than breaking.
+- **Undocumented** surface (the `$` proxy, `*`-prefixed keys, internal managers,
+  `--cfg-*` CSS vars, `static template` setter) **may** change freely.
+
+---
+
+## Working agreements for agents
+
+1. **Verify, don't claim.** Run the relevant gate commands and report real
+   output. "Tests pass" requires having run them.
+2. **Don't loosen tests or swallow errors** to make something pass. Fan-out
+   paths isolate-and-warn (see `EventBus.emit` / `Listeners.notify`); follow
+   that pattern rather than hiding failures.
+3. **One concern per PR**, with a Conventional-Commit title and the gate green.
+4. **Match surrounding code** — comment density, naming, idioms.
+5. **Don't `git stash pop` blindly** — a pre-existing user stash
+   (`temp-package-json-before-release-branch`) conflicts on `package.json`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,14 @@
+# CLAUDE.md
+
+Project conventions for this repository live in **[AGENTS.md](./AGENTS.md)** —
+the single source of truth for build/test commands, the green gate, code
+conventions, architecture, and the in-progress v2 migration.
+
+@AGENTS.md
+
+> Quick reminders (full detail in AGENTS.md):
+> - Run a full `npm run build` **before** `test:specs` / `test:e2e`.
+> - `npx playwright install chromium` is required once for e2e.
+> - Don't break the documented public API (see `fern-docs`); undocumented
+>   internals are fair game.
+> - Conventional Commits; one concern per PR; full green gate before merge.

--- a/src/abstract/EventBus.test.ts
+++ b/src/abstract/EventBus.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { EventBus, UploaderEventType } from './EventBus';
+
+describe('EventBus', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('delivers an emitted payload to its listener', () => {
+    const bus = new EventBus();
+    const handler = vi.fn();
+    bus.on(UploaderEventType.UPLOAD_CLICK, handler);
+
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops delivery after unsubscribe', () => {
+    const bus = new EventBus();
+    const handler = vi.fn();
+    const off = bus.on(UploaderEventType.UPLOAD_CLICK, handler);
+
+    off();
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('isolates a throwing listener so others still run', () => {
+    const bus = new EventBus();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    bus.on(UploaderEventType.UPLOAD_CLICK, bad);
+    bus.on(UploaderEventType.UPLOAD_CLICK, good);
+
+    expect(() => bus.emit(UploaderEventType.UPLOAD_CLICK, undefined)).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('onAny receives the type and payload of every event', () => {
+    const bus = new EventBus();
+    const any = vi.fn();
+    bus.onAny(any);
+
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(any).toHaveBeenCalledWith(UploaderEventType.UPLOAD_CLICK, undefined);
+  });
+
+  it('emitDebounced fires once after the window and evaluates the thunk lazily', () => {
+    vi.useFakeTimers();
+    const bus = new EventBus();
+    const handler = vi.fn();
+    const thunk = vi.fn(() => undefined);
+    bus.on(UploaderEventType.UPLOAD_CLICK, handler);
+
+    bus.emitDebounced(UploaderEventType.UPLOAD_CLICK, thunk, 20);
+    bus.emitDebounced(UploaderEventType.UPLOAD_CLICK, thunk, 20);
+    expect(handler).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(thunk).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() clears listeners and pending debounced emits', () => {
+    vi.useFakeTimers();
+    const bus = new EventBus();
+    const handler = vi.fn();
+    bus.on(UploaderEventType.UPLOAD_CLICK, handler);
+    bus.emitDebounced(UploaderEventType.UPLOAD_CLICK, () => undefined, 20);
+
+    bus.destroy();
+    vi.advanceTimersByTime(20);
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/EventBus.ts
+++ b/src/abstract/EventBus.ts
@@ -1,0 +1,153 @@
+import type { UploadcareGroup } from '@uploadcare/upload-client';
+import type { OutputCollectionState, OutputFileEntry } from '../types/exported';
+
+/**
+ * v2 event surface. Mirrors v1's `EventType` from
+ * `src/blocks/UploadCtxProvider/EventEmitter.ts` so consumers can swap
+ * v1 → v2 without touching their event handlers.
+ */
+export const UploaderEventType = Object.freeze({
+  FILE_ADDED: 'file-added',
+  FILE_REMOVED: 'file-removed',
+  FILE_UPLOAD_START: 'file-upload-start',
+  FILE_UPLOAD_PROGRESS: 'file-upload-progress',
+  FILE_UPLOAD_SUCCESS: 'file-upload-success',
+  FILE_UPLOAD_FAILED: 'file-upload-failed',
+  FILE_URL_CHANGED: 'file-url-changed',
+
+  MODAL_OPEN: 'modal-open',
+  MODAL_CLOSE: 'modal-close',
+  DONE_CLICK: 'done-click',
+  UPLOAD_CLICK: 'upload-click',
+  ACTIVITY_CHANGE: 'activity-change',
+
+  COMMON_UPLOAD_START: 'common-upload-start',
+  COMMON_UPLOAD_PROGRESS: 'common-upload-progress',
+  COMMON_UPLOAD_SUCCESS: 'common-upload-success',
+  COMMON_UPLOAD_FAILED: 'common-upload-failed',
+
+  CHANGE: 'change',
+  GROUP_CREATED: 'group-created',
+} as const);
+
+export type UploaderEventKey = (typeof UploaderEventType)[keyof typeof UploaderEventType];
+
+export type { OutputFileEntry, OutputCollectionState };
+
+export type UploaderEventPayload = {
+  'file-added': OutputFileEntry<'idle'>;
+  'file-removed': OutputFileEntry<'removed'>;
+  'file-upload-start': OutputFileEntry<'uploading'>;
+  'file-upload-progress': OutputFileEntry<'uploading'>;
+  'file-upload-success': OutputFileEntry<'success'>;
+  'file-upload-failed': OutputFileEntry<'failed'>;
+  'file-url-changed': OutputFileEntry<'success'>;
+
+  /**
+   * `modalId` is the v1 name for the modal/activity. `activity` is the v2
+   * name. Both fields carry the same value; consumers may use either.
+   */
+  'modal-open': { activity: string; modalId: string };
+  /**
+   * `modalId` is the v1 name; `activity` is the v2 equivalent (both null
+   * after a close). `hasActiveModals` is v1-compat — always `false` in v2
+   * since the router has a single foreground slot that just closed.
+   */
+  'modal-close': {
+    activity: string | null;
+    modalId: string | null;
+    hasActiveModals: boolean;
+  };
+  'activity-change': { activity: string | null };
+
+  'upload-click': undefined;
+  'done-click': OutputCollectionState;
+
+  'common-upload-start': OutputCollectionState<'uploading'>;
+  'common-upload-progress': OutputCollectionState<'uploading'>;
+  'common-upload-success': OutputCollectionState<'success'>;
+  'common-upload-failed': OutputCollectionState<'failed'>;
+
+  change: OutputCollectionState;
+  'group-created': OutputCollectionState<'success', 'has-group'> & { groupInfo: UploadcareGroup };
+};
+
+/**
+ * Pure pub/sub. No DOM, no CustomEvent — the UI layer bridges this to DOM
+ * events on an element when one is desired (added in the events milestone).
+ *
+ * Introduced as a standalone primitive in M0; wired to nothing yet.
+ */
+export class EventBus {
+  private _listeners = new Map<string, Set<(payload: unknown) => void>>();
+  private _debounceTimers = new Map<string, number>();
+  private static readonly DEFAULT_DEBOUNCE_MS = 20;
+
+  public on<K extends UploaderEventKey>(type: K, handler: (payload: UploaderEventPayload[K]) => void): () => void {
+    let set = this._listeners.get(type);
+    if (!set) {
+      set = new Set();
+      this._listeners.set(type, set);
+    }
+    set.add(handler as (payload: unknown) => void);
+    return () => set.delete(handler as (payload: unknown) => void);
+  }
+
+  /**
+   * Fire to every listener for `type`. Each handler runs in its own
+   * try/catch — a single throwing listener must not cancel the emit loop or
+   * bubble back to the code that triggered the event.
+   */
+  public emit<K extends UploaderEventKey>(type: K, payload: UploaderEventPayload[K]): void {
+    const set = this._listeners.get(type);
+    if (!set) return;
+    for (const handler of set) {
+      try {
+        handler(payload);
+      } catch (err) {
+        console.warn(`[v2/events] listener for "${type}" threw`, err);
+      }
+    }
+  }
+
+  /**
+   * Debounced emit. `payload` is a thunk so a heavy
+   * `buildOutputCollectionState` is only built once per debounce window.
+   * Mirrors v1's `EventEmitter.emit(type, fn, { debounce })`.
+   */
+  public emitDebounced<K extends UploaderEventKey>(
+    type: K,
+    payload: () => UploaderEventPayload[K],
+    ms: number = EventBus.DEFAULT_DEBOUNCE_MS,
+  ): void {
+    const existing = this._debounceTimers.get(type);
+    if (existing) window.clearTimeout(existing);
+    const timeoutId = window.setTimeout(() => {
+      this._debounceTimers.delete(type);
+      try {
+        this.emit(type, payload());
+      } catch (err) {
+        console.warn(`[v2/events] payload thunk for "${type}" threw`, err);
+      }
+    }, ms);
+    this._debounceTimers.set(type, timeoutId);
+  }
+
+  /** Catch-all subscription — receives every emitted event with its type. */
+  public onAny(handler: (type: string, payload: unknown) => void): () => void {
+    const wrap = (type: string) => (payload: unknown) => handler(type, payload);
+    const unsubs: Array<() => void> = [];
+    for (const type of Object.values(UploaderEventType)) {
+      unsubs.push(this.on(type as UploaderEventKey, wrap(type) as never));
+    }
+    return () => {
+      for (const u of unsubs) u();
+    };
+  }
+
+  public destroy(): void {
+    for (const id of this._debounceTimers.values()) window.clearTimeout(id);
+    this._debounceTimers.clear();
+    this._listeners.clear();
+  }
+}

--- a/src/abstract/EventBus.ts
+++ b/src/abstract/EventBus.ts
@@ -90,7 +90,13 @@ export class EventBus {
       this._listeners.set(type, set);
     }
     set.add(handler as (payload: unknown) => void);
-    return () => set.delete(handler as (payload: unknown) => void);
+    return () => {
+      set.delete(handler as (payload: unknown) => void);
+      // Drop the empty Set so unused event keys don't linger. The key space
+      // is a fixed enum so this is bounded either way, but it keeps the map
+      // tidy and consistent with `UploaderRegistry`.
+      if (set.size === 0) this._listeners.delete(type);
+    };
   }
 
   /**

--- a/src/abstract/UploaderRegistry.test.ts
+++ b/src/abstract/UploaderRegistry.test.ts
@@ -67,6 +67,26 @@ describe('UploaderRegistry', () => {
     warn.mockRestore();
   });
 
+  it('isolates a throwing consumer so other consumers are still notified on register', () => {
+    const name = uniqueName();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    UploaderRegistry.whenAvailable(name, bad);
+    const off = UploaderRegistry.whenAvailable(name, good);
+
+    const controller = new UploaderController();
+    expect(() => UploaderRegistry.register(name, controller)).not.toThrow();
+    expect(good).toHaveBeenCalledWith(controller);
+    expect(warn).toHaveBeenCalled();
+
+    off();
+    UploaderRegistry.unregister(name, controller);
+    warn.mockRestore();
+  });
+
   it('unregister only deletes when the controller identity matches', () => {
     const name = uniqueName();
     const current = new UploaderController();

--- a/src/abstract/UploaderRegistry.test.ts
+++ b/src/abstract/UploaderRegistry.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from 'vitest';
+import { UploaderController } from './controllers/UploaderController';
+import { UploaderRegistry } from './UploaderRegistry';
+
+// The registry is a module-level singleton, so each test uses a unique
+// ctx-name and unregisters what it created to avoid cross-test bleed.
+let seq = 0;
+const uniqueName = () => `test-ctx-${seq++}`;
+
+describe('UploaderRegistry', () => {
+  it('register then get returns the controller', () => {
+    const name = uniqueName();
+    const controller = new UploaderController();
+
+    UploaderRegistry.register(name, controller);
+    expect(UploaderRegistry.get(name)).toBe(controller);
+
+    UploaderRegistry.unregister(name, controller);
+    expect(UploaderRegistry.get(name)).toBeUndefined();
+  });
+
+  it('whenAvailable fires synchronously when already registered', () => {
+    const name = uniqueName();
+    const controller = new UploaderController();
+    UploaderRegistry.register(name, controller);
+
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+
+    expect(cb).toHaveBeenCalledWith(controller);
+    off();
+    UploaderRegistry.unregister(name, controller);
+  });
+
+  it('whenAvailable fires when a controller registers later', () => {
+    const name = uniqueName();
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    expect(cb).not.toHaveBeenCalled();
+
+    const controller = new UploaderController();
+    UploaderRegistry.register(name, controller);
+
+    expect(cb).toHaveBeenCalledWith(controller);
+    off();
+    UploaderRegistry.unregister(name, controller);
+  });
+
+  it('re-registering under the same name re-notifies consumers (remount)', () => {
+    const name = uniqueName();
+    const first = new UploaderController();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    UploaderRegistry.register(name, first);
+
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    cb.mockClear();
+
+    const second = new UploaderController();
+    UploaderRegistry.register(name, second);
+
+    expect(cb).toHaveBeenCalledWith(second);
+    expect(warn).toHaveBeenCalled();
+
+    off();
+    UploaderRegistry.unregister(name, second);
+    warn.mockRestore();
+  });
+
+  it('unregister only deletes when the controller identity matches', () => {
+    const name = uniqueName();
+    const current = new UploaderController();
+    const stale = new UploaderController();
+    UploaderRegistry.register(name, current);
+
+    // A stale element's deferred unregister must not evict the new owner.
+    UploaderRegistry.unregister(name, stale);
+    expect(UploaderRegistry.get(name)).toBe(current);
+
+    UploaderRegistry.unregister(name, current);
+    expect(UploaderRegistry.get(name)).toBeUndefined();
+  });
+
+  it('unsubscribe stops further notifications', () => {
+    const name = uniqueName();
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    off();
+
+    const controller = new UploaderController();
+    UploaderRegistry.register(name, controller);
+
+    expect(cb).not.toHaveBeenCalled();
+    UploaderRegistry.unregister(name, controller);
+  });
+});

--- a/src/abstract/UploaderRegistry.ts
+++ b/src/abstract/UploaderRegistry.ts
@@ -1,0 +1,70 @@
+import type { UploaderController } from './controllers/UploaderController';
+
+/**
+ * Global registry of uploader instances keyed by `ctx-name`. Children that
+ * live outside the uploader's DOM subtree resolve their controller through
+ * this registry (the cross-DOM equivalent of `@lit/context`).
+ *
+ * The lookup is reactive — `whenAvailable(ctxName, cb)` fires synchronously
+ * if a controller is already registered, immediately when one registers, and
+ * AGAIN whenever the registration changes (e.g. the owning element is removed
+ * and a new one with the same `ctx-name` is rendered). This lets consumers
+ * re-adopt across a remount without losing their bindings.
+ *
+ * Introduced as a standalone primitive in M0; wired to nothing yet.
+ */
+class UploaderRegistryImpl {
+  private _map = new Map<string, UploaderController>();
+  private _consumers = new Map<string, Set<(c: UploaderController) => void>>();
+
+  public register(ctxName: string, controller: UploaderController): void {
+    const existing = this._map.get(ctxName);
+    if (existing && existing !== controller) {
+      // Common case: the previous owning element disconnected and its
+      // deferred unregister hasn't fired yet. The new element takes over; the
+      // deferred unregister becomes a no-op (it checks identity before
+      // deleting).
+      console.warn(
+        `[uc] Replacing the controller registered under ctx-name="${ctxName}". If two uploaders share this name simultaneously the second one wins.`,
+      );
+    }
+    this._map.set(ctxName, controller);
+    // Notify every subscriber for this ctxName so they re-adopt the new
+    // controller.
+    const set = this._consumers.get(ctxName);
+    if (set) {
+      for (const cb of set) cb(controller);
+    }
+  }
+
+  public unregister(ctxName: string, controller: UploaderController): void {
+    if (this._map.get(ctxName) === controller) {
+      this._map.delete(ctxName);
+    }
+  }
+
+  public get(ctxName: string): UploaderController | undefined {
+    return this._map.get(ctxName);
+  }
+
+  /**
+   * Subscribe to the controller under `ctxName`. Fires synchronously with the
+   * current controller (if registered), then again each time a new controller
+   * registers under the same name. Returns an unsubscribe.
+   */
+  public whenAvailable(ctxName: string, cb: (c: UploaderController) => void): () => void {
+    let set = this._consumers.get(ctxName);
+    if (!set) {
+      set = new Set();
+      this._consumers.set(ctxName, set);
+    }
+    set.add(cb);
+    const existing = this._map.get(ctxName);
+    if (existing) cb(existing);
+    return () => {
+      set?.delete(cb);
+    };
+  }
+}
+
+export const UploaderRegistry = new UploaderRegistryImpl();

--- a/src/abstract/UploaderRegistry.ts
+++ b/src/abstract/UploaderRegistry.ts
@@ -33,7 +33,15 @@ class UploaderRegistryImpl {
     // controller.
     const set = this._consumers.get(ctxName);
     if (set) {
-      for (const cb of set) cb(controller);
+      // Isolate each consumer: a single throwing callback must not abort
+      // notification of the others or bubble out of `register()`.
+      for (const cb of set) {
+        try {
+          cb(controller);
+        } catch (err) {
+          console.warn(`[uc] a whenAvailable consumer for ctx-name="${ctxName}" threw`, err);
+        }
+      }
     }
   }
 
@@ -62,7 +70,10 @@ class UploaderRegistryImpl {
     const existing = this._map.get(ctxName);
     if (existing) cb(existing);
     return () => {
-      set?.delete(cb);
+      set.delete(cb);
+      // Drop the empty consumer Set so unused ctx-names don't accumulate in
+      // this module-level singleton over the app's lifetime.
+      if (set.size === 0) this._consumers.delete(ctxName);
     };
   }
 }

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { EventBus } from '../EventBus';
+import { UploaderController } from './UploaderController';
+
+describe('UploaderController', () => {
+  it('constructs with an event bus', () => {
+    const controller = new UploaderController();
+    expect(controller.events).toBeInstanceOf(EventBus);
+  });
+
+  it('destroy() tears down without throwing', () => {
+    const controller = new UploaderController();
+    expect(() => controller.destroy()).not.toThrow();
+  });
+
+  it('is DOM-free — constructing touches no element APIs', () => {
+    // The controller must never reach into the document. Constructing it
+    // with `document` made unavailable proves it (the UI adapter layer owns
+    // all DOM concerns, not the controller).
+    const realDocument = globalThis.document;
+    // @ts-expect-error intentionally removing document for this assertion
+    delete globalThis.document;
+    try {
+      expect(() => new UploaderController()).not.toThrow();
+    } finally {
+      globalThis.document = realDocument;
+    }
+  });
+});

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,0 +1,19 @@
+import { EventBus } from '../EventBus';
+
+/**
+ * Root controller — one instance per uploader scope (keyed by `ctx-name` in
+ * `UploaderRegistry`). Pure logic: it does NOT import from `lit` or touch the
+ * DOM, so it is constructible and testable in isolation.
+ *
+ * This is the strangler engine that v1's `PubSub` facade will eventually
+ * delegate to. It starts minimal and grows by one sub-controller per
+ * migration milestone (M1 `config`, M2 `locale`, M3 `collection`, …). For
+ * now it owns only the event bus and is wired to nothing.
+ */
+export class UploaderController {
+  public readonly events = new EventBus();
+
+  public destroy(): void {
+    this.events.destroy();
+  }
+}

--- a/src/abstract/controllers/index.ts
+++ b/src/abstract/controllers/index.ts
@@ -1,1 +1,2 @@
 export * from './SourceListController';
+export * from './UploaderController';

--- a/src/abstract/host-subscription.test.ts
+++ b/src/abstract/host-subscription.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { Listeners } from './host-subscription';
+
+describe('Listeners', () => {
+  it('notifies every subscribed listener', () => {
+    const listeners = new Listeners();
+    const a = vi.fn();
+    const b = vi.fn();
+    listeners.subscribe(a);
+    listeners.subscribe(b);
+
+    listeners.notify();
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops notifying after the returned unsubscribe is called', () => {
+    const listeners = new Listeners();
+    const a = vi.fn();
+    const unsubscribe = listeners.subscribe(a);
+
+    unsubscribe();
+    listeners.notify();
+
+    expect(a).not.toHaveBeenCalled();
+  });
+
+  it('clear() removes all listeners', () => {
+    const listeners = new Listeners();
+    const a = vi.fn();
+    listeners.subscribe(a);
+
+    listeners.clear();
+    listeners.notify();
+
+    expect(a).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/host-subscription.test.ts
+++ b/src/abstract/host-subscription.test.ts
@@ -26,6 +26,22 @@ describe('Listeners', () => {
     expect(a).not.toHaveBeenCalled();
   });
 
+  it('isolates a throwing listener so the others still run', () => {
+    const listeners = new Listeners();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    listeners.subscribe(bad);
+    listeners.subscribe(good);
+
+    expect(() => listeners.notify()).not.toThrow();
+    expect(good).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it('clear() removes all listeners', () => {
     const listeners = new Listeners();
     const a = vi.fn();

--- a/src/abstract/host-subscription.ts
+++ b/src/abstract/host-subscription.ts
@@ -1,0 +1,23 @@
+/**
+ * Generic, framework-agnostic listener set.
+ *
+ * Controllers use this to publish state changes without knowing anything
+ * about Lit, the DOM, or the host that consumes them. The UI layer adapts
+ * by passing `() => host.requestUpdate()` (or any other callback).
+ */
+export class Listeners {
+  private _set = new Set<() => void>();
+
+  public subscribe(listener: () => void): () => void {
+    this._set.add(listener);
+    return () => this._set.delete(listener);
+  }
+
+  public notify(): void {
+    for (const listener of this._set) listener();
+  }
+
+  public clear(): void {
+    this._set.clear();
+  }
+}

--- a/src/abstract/host-subscription.ts
+++ b/src/abstract/host-subscription.ts
@@ -14,7 +14,16 @@ export class Listeners {
   }
 
   public notify(): void {
-    for (const listener of this._set) listener();
+    // Isolate each listener: one throwing subscriber must not prevent the
+    // rest from being notified (e.g. block a sibling component's re-render).
+    // Mirrors `EventBus.emit`'s fan-out semantics.
+    for (const listener of this._set) {
+      try {
+        listener();
+      } catch (err) {
+        console.warn('[uc] a state-change listener threw', err);
+      }
+    }
   }
 
   public clear(): void {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -40,6 +40,12 @@ export default defineConfig({
         test: {
           name: 'e2e',
           include: ['./**/*.e2e.test.ts', './**/*.e2e.test.tsx'],
+          // Browser e2e tests can flake under full parallel load (e.g. the
+          // cloud-image-editor `uc-crop-frame` locator loses a render race
+          // that passes reliably in isolation). Retry once so a transient
+          // flake can't fail the gate; a genuine regression still fails both
+          // attempts.
+          retry: 1,
           expect: {
             poll: {
               timeout: 20_000,


### PR DESCRIPTION
First milestone of the **v1 → v2 strangler migration** (see `MIGRATION-PLAN.md`).

Introduces the DOM-free foundation the migration is built on, **wired to nothing yet** — zero behavior change, fully additive — plus repo-wide agent docs and an e2e-gate hardening.

## What's in

### v2 controller primitives (additive, unwired)
- **`Listeners`** (`host-subscription.ts`) — minimal framework-agnostic reactive cell that replaces nanostores in the controller layer.
- **`EventBus`** — typed pub/sub mirroring v1 `EventType`; isolates throwing listeners; debounced emit + `onAny`.
- **`UploaderController`** — minimal DOM-free root-controller shell that grows one sub-controller per milestone (M1 config, M2 locale, …); for now owns only the event bus.
- **`UploaderRegistry`** — reactive cross-DOM registry keyed by `ctx-name`.

### e2e gate hardening
- `retry: 1` on the e2e vitest project so the known cloud-image-editor `uc-crop-frame` flake (fails under full parallel load, passes 5/5 in isolation) can't fail the gate, while genuine regressions still fail both attempts.

### Agent / LLM docs
- **`AGENTS.md`** — single source of truth for AI coding agents: setup, build/test commands + green gate (incl. the *full-build-before-specs/e2e* gotcha and the e2e flake), conventions, repo layout, architecture, the v2 migration, and the documented-API do-not-break contract.
- **`CLAUDE.md`** and **`.github/copilot-instructions.md`** — thin pointers to `AGENTS.md` (DRY) so Claude Code and Copilot share the same rules.

## Review fixes (Copilot on this PR)
- `Listeners.notify()` / `UploaderRegistry.register()` now isolate each callback (one throwing subscriber can't block the rest), matching `EventBus.emit`.
- `UploaderRegistry.whenAvailable()` and `EventBus.on()` drop their backing `Set` when it empties so unused keys/ctx-names don't accumulate.
- Added isolation tests for `Listeners` and `UploaderRegistry`.

## Reconciliation notes
- `src/abstract/controllers/` already held a Lit `ReactiveController` (`SourceListController`); the new DOM-free `UploaderController` coexists (different pattern/name) and will absorb sources work in M6.
- Nothing imports the new modules; `index.ts` public surface and bundle sizes are unchanged.

## Green gate
- `tsc:app` ✅
- `test:specs` — 325 passed (incl. 20 new) ✅
- `test:locales` ✅
- `build` (attw / publint / size-limit) ✅ — bundle sizes unchanged
- `test:e2e` — 187/187 ✅
- `lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added foundational event bus infrastructure for improved state management and communication.

* **Tests**
  * Added comprehensive test coverage for core event handling, registry management, and controller lifecycle.

* **Chores**
  * Updated Vitest configuration to automatically retry failed browser tests to reduce flakiness.
  * Enhanced code review automation configuration.

* **Documentation**
  * Added contributor guidelines and development conventions documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->