### PR TITLE
M1: route config through ConfigController (strangler facade)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  auto_review:
+    # By default CodeRabbit only auto-reviews PRs whose base is the default
+    # branch. The v2 strangler migration uses stacked PRs that target the
+    # `feat/v2-migration` integration branch and its per-milestone branches
+    # (feat/v2-mN-*), so opt those bases in too — otherwise CodeRabbit skips
+    # them. Matched as regex against the PR base branch name.
+    base_branches:
+      - "feat/v2-.*"
   # Exclude demo pages from CodeRabbit reviews.
   # Patterns are glob-style; entries starting with '!' are ignored.
   path_filters:

--- a/src/abstract/controllers/ConfigController.test.ts
+++ b/src/abstract/controllers/ConfigController.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from 'vitest';
+import { initialConfig } from '../../blocks/Config/initialConfig';
+import { ConfigController } from './ConfigController';
+
+describe('ConfigController', () => {
+  it('seeds built-in defaults from initialConfig', () => {
+    const config = new ConfigController();
+    expect(config.get('multiple')).toBe(initialConfig.multiple);
+    expect(config.get('maxConcurrentRequests')).toBe(initialConfig.maxConcurrentRequests);
+    expect(config.hasKey('multiple')).toBe(true);
+  });
+
+  it('set() stores the value and notifies, deduping unchanged writes', () => {
+    const config = new ConfigController();
+    const listener = vi.fn();
+    config.subscribe(listener);
+
+    config.set('multiple', false);
+    expect(config.get('multiple')).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    config.set('multiple', false); // unchanged — no notify
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const config = new ConfigController();
+    const listener = vi.fn();
+    const off = config.subscribe(listener);
+    off();
+
+    config.set('multiple', false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('register() seeds a custom key with its default and reports it as known', () => {
+    const config = new ConfigController();
+    expect(config.hasKey('unsplashApiKey')).toBe(false);
+
+    config.register('unsplashApiKey', 'default-key');
+
+    expect(config.hasKey('unsplashApiKey')).toBe(true);
+    expect(config.getCustom('unsplashApiKey')).toBe('default-key');
+  });
+
+  it('register() keeps a value that was set before registration', () => {
+    const config = new ConfigController();
+    config.setCustom('unsplashApiKey', 'preset');
+
+    config.register('unsplashApiKey', 'default-key');
+
+    expect(config.getCustom('unsplashApiKey')).toBe('preset');
+  });
+
+  it('re-register is idempotent and does not clobber the current value', () => {
+    const config = new ConfigController();
+    config.register('unsplashApiKey', 'default-key');
+    config.setCustom('unsplashApiKey', 'changed');
+
+    config.register('unsplashApiKey', 'default-key');
+
+    expect(config.getCustom('unsplashApiKey')).toBe('changed');
+  });
+
+  it('destroy() clears custom keys and listeners', () => {
+    const config = new ConfigController();
+    config.register('unsplashApiKey', 'x');
+    // Subscribe after registering so the listener only sees post-destroy activity.
+    const listener = vi.fn();
+    config.subscribe(listener);
+
+    config.destroy();
+
+    expect(config.hasKey('unsplashApiKey')).toBe(false);
+    config.setCustom('unsplashApiKey', 'y');
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/controllers/ConfigController.test.ts
+++ b/src/abstract/controllers/ConfigController.test.ts
@@ -62,6 +62,34 @@ describe('ConfigController', () => {
     expect(config.getCustom('unsplashApiKey')).toBe('changed');
   });
 
+  it('hasKey uses own-property semantics, not the prototype chain', () => {
+    const config = new ConfigController();
+    expect(config.hasKey('toString')).toBe(false);
+    expect(config.hasKey('constructor')).toBe(false);
+    expect(config.hasKey('__proto__')).toBe(false);
+  });
+
+  it('does not pollute the prototype when a custom key is named __proto__', () => {
+    const config = new ConfigController();
+    config.setCustom('__proto__', { polluted: true });
+    config.register('__proto__', { polluted: true });
+
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+    expect(Object.hasOwn(Object.prototype, 'polluted')).toBe(false);
+  });
+
+  it('register preserves a custom key that was explicitly cleared to undefined', () => {
+    const config = new ConfigController();
+    // Set then clear so an own property with value `undefined` exists — the
+    // case where own-property vs `=== undefined` detection diverges.
+    config.setCustom('unsplashApiKey', 'preset');
+    config.setCustom('unsplashApiKey', undefined);
+
+    config.register('unsplashApiKey', 'default-key');
+
+    expect(config.getCustom('unsplashApiKey')).toBeUndefined();
+  });
+
   it('destroy() clears custom keys and listeners', () => {
     const config = new ConfigController();
     config.register('unsplashApiKey', 'x');

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -19,7 +19,10 @@ import { Listeners } from '../host-subscription';
  * — `register()` adds them, `getCustom`/`setCustom` access them.
  */
 export class ConfigController {
-  private _values: ConfigType = { ...initialConfig };
+  // Null-prototype backing object: custom (plugin-registered) key names flow
+  // into `getCustom`/`setCustom`, so a key like `__proto__` must create a
+  // plain own property here rather than mutate the prototype chain.
+  private _values: ConfigType = Object.assign(Object.create(null), initialConfig);
   private _customKeys = new Set<string>();
   private _customDefs = new Map<string, CustomConfigDefinition<unknown>>();
   private _listeners = new Listeners();
@@ -34,7 +37,9 @@ export class ConfigController {
 
   /** True for any known key — a built-in default or a registered custom key. */
   public hasKey(name: string): boolean {
-    return name in initialConfig || this._customKeys.has(name);
+    // Own-property check: `in` would walk the prototype chain and wrongly
+    // report `toString`, `constructor`, `__proto__`, etc. as known keys.
+    return Object.hasOwn(initialConfig, name) || this._customKeys.has(name);
   }
 
   public get<K extends keyof ConfigType>(key: K): ConfigType[K] {
@@ -65,8 +70,10 @@ export class ConfigController {
     this._customDefs.set(def.name, def as CustomConfigDefinition<unknown>);
     const bag = this._values as Record<string, unknown>;
     // Keep any value set before the plugin registered (e.g. an attribute that
-    // landed first); otherwise seed the registered default.
-    if (bag[def.name] === undefined) {
+    // landed first), otherwise seed the registered default. Own-property check
+    // (not `=== undefined`) mirrors the nanostores `key in store` semantics, so
+    // an explicit pre-registration write of `undefined` is preserved.
+    if (!Object.hasOwn(bag, def.name)) {
       bag[def.name] = def.defaultValue;
     }
     this._listeners.notify();

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -1,0 +1,95 @@
+import type { CustomConfigDefinition } from '../../abstract/customConfigOptions';
+import { initialConfig } from '../../blocks/Config/initialConfig';
+import type { ConfigType } from '../../types/exported';
+import { Listeners } from '../host-subscription';
+
+/**
+ * Pure-logic config store. Knows nothing about DOM, attributes, or Lit.
+ *
+ * In the v1 → v2 strangler this is the source of truth for the `*cfg/*` state
+ * that used to live in the per-ctx nanostores map; `PubSubCompat` routes those
+ * keys here (see its `*cfg/` facade). For now it is a raw typed container:
+ * value coercion (`normalizeConfigValue`), the `cdnCname`/`cameraModes`
+ * computed properties, and the attribute/property bridge all still live in the
+ * `<uc-config>` element, so behavior is byte-identical to v1. Those concerns
+ * migrate into this controller in later milestones (when `<uc-config>` is
+ * finally retired).
+ *
+ * Custom (plugin-registered) keys live in the same backing object as built-ins
+ * — `register()` adds them, `getCustom`/`setCustom` access them.
+ */
+export class ConfigController {
+  private _values: ConfigType = { ...initialConfig };
+  private _customKeys = new Set<string>();
+  private _customDefs = new Map<string, CustomConfigDefinition<unknown>>();
+  private _listeners = new Listeners();
+
+  public get values(): Readonly<ConfigType> {
+    return this._values;
+  }
+
+  public subscribe(listener: () => void): () => void {
+    return this._listeners.subscribe(listener);
+  }
+
+  /** True for any known key — a built-in default or a registered custom key. */
+  public hasKey(name: string): boolean {
+    return name in initialConfig || this._customKeys.has(name);
+  }
+
+  public get<K extends keyof ConfigType>(key: K): ConfigType[K] {
+    return this._values[key];
+  }
+
+  /**
+   * Raw write — no coercion (v1 `PubSub.pub` parity; `<uc-config>` normalizes
+   * upstream). Notifies only when the value actually changes, matching the
+   * per-key change semantics of the nanostores map it replaces.
+   */
+  public set<K extends keyof ConfigType>(key: K, value: ConfigType[K]): void {
+    if (this._values[key] === value) return;
+    this._values[key] = value;
+    this._listeners.notify();
+  }
+
+  // ─── Custom (plugin-registered) keys ───────────────────────────────────
+
+  public register<T>(nameOrDef: string | CustomConfigDefinition<T>, defaultValue?: T): void {
+    const def: CustomConfigDefinition<T> =
+      typeof nameOrDef === 'string' ? { name: nameOrDef, defaultValue: defaultValue as T } : nameOrDef;
+    if (this._customKeys.has(def.name)) {
+      // Already registered — keep the existing value (idempotent re-register).
+      return;
+    }
+    this._customKeys.add(def.name);
+    this._customDefs.set(def.name, def as CustomConfigDefinition<unknown>);
+    const bag = this._values as Record<string, unknown>;
+    // Keep any value set before the plugin registered (e.g. an attribute that
+    // landed first); otherwise seed the registered default.
+    if (bag[def.name] === undefined) {
+      bag[def.name] = def.defaultValue;
+    }
+    this._listeners.notify();
+  }
+
+  public customDefinition(name: string): CustomConfigDefinition<unknown> | undefined {
+    return this._customDefs.get(name);
+  }
+
+  public getCustom<T = unknown>(name: string): T {
+    return (this._values as Record<string, unknown>)[name] as T;
+  }
+
+  public setCustom(name: string, value: unknown): void {
+    const bag = this._values as Record<string, unknown>;
+    if (bag[name] === value) return;
+    bag[name] = value;
+    this._listeners.notify();
+  }
+
+  public destroy(): void {
+    this._customKeys.clear();
+    this._customDefs.clear();
+    this._listeners.clear();
+  }
+}

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { EventBus } from '../EventBus';
+import { ConfigController } from './ConfigController';
 import { UploaderController } from './UploaderController';
 
 describe('UploaderController', () => {
-  it('constructs with an event bus', () => {
+  it('constructs with an event bus and a config controller', () => {
     const controller = new UploaderController();
     expect(controller.events).toBeInstanceOf(EventBus);
+    expect(controller.config).toBeInstanceOf(ConfigController);
   });
 
   it('destroy() tears down without throwing', () => {

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,19 +1,25 @@
 import { EventBus } from '../EventBus';
+import { ConfigController } from './ConfigController';
 
 /**
  * Root controller — one instance per uploader scope (keyed by `ctx-name` in
  * `UploaderRegistry`). Pure logic: it does NOT import from `lit` or touch the
  * DOM, so it is constructible and testable in isolation.
  *
- * This is the strangler engine that v1's `PubSub` facade will eventually
- * delegate to. It starts minimal and grows by one sub-controller per
- * migration milestone (M1 `config`, M2 `locale`, M3 `collection`, …). For
- * now it owns only the event bus and is wired to nothing.
+ * This is the strangler engine that v1's `PubSub` facade delegates to. It
+ * grows by one sub-controller per migration milestone (M1 `config`, M2
+ * `locale`, M3 `collection`, …).
+ *
+ * - `events`: the typed event bus (wired to DOM events in a later milestone).
+ * - `config`: source of truth for `*cfg/*` state — `PubSubCompat` routes the
+ *   config namespace here.
  */
 export class UploaderController {
   public readonly events = new EventBus();
+  public readonly config = new ConfigController();
 
   public destroy(): void {
     this.events.destroy();
+    this.config.destroy();
   }
 }

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { UploaderRegistry } from '../abstract/UploaderRegistry';
+import { initialConfig } from '../blocks/Config/initialConfig';
+import { PubSub } from './PubSubCompat';
+
+// Each test uses a unique ctx id and tears it down so the module-level
+// context/controller maps and the global UploaderRegistry don't leak.
+let seq = 0;
+const ids: string[] = [];
+const freshCtx = () => {
+  const id = `pubsub-test-${seq++}`;
+  ids.push(id);
+  return PubSub.registerCtx<Record<string, unknown>>({ plain: 'seed' }, id);
+};
+
+afterEach(() => {
+  for (const id of ids.splice(0)) PubSub.deleteCtx(id);
+});
+
+describe('PubSub config (*cfg/*) facade', () => {
+  it('reads built-in config defaults from the controller without touching the nanostores store', () => {
+    const ctx = freshCtx();
+    expect(ctx.read('*cfg/multiple')).toBe(initialConfig.multiple);
+    // Routed away from nanostores — the key never lands in the raw store.
+    expect('*cfg/multiple' in ctx.store).toBe(false);
+  });
+
+  it('round-trips a config write through the controller', () => {
+    const ctx = freshCtx();
+    ctx.pub('*cfg/multiple', false);
+    expect(ctx.read('*cfg/multiple')).toBe(false);
+  });
+
+  it('sub fires immediately when init=true and on subsequent changes to that key', () => {
+    const ctx = freshCtx();
+    const cb = vi.fn();
+    ctx.sub('*cfg/multiple', cb, true);
+    expect(cb).toHaveBeenLastCalledWith(initialConfig.multiple);
+
+    ctx.pub('*cfg/multiple', false);
+    expect(cb).toHaveBeenLastCalledWith(false);
+    expect(cb).toHaveBeenCalledTimes(2);
+  });
+
+  it('sub with init=false does not fire immediately', () => {
+    const ctx = freshCtx();
+    const cb = vi.fn();
+    ctx.sub('*cfg/multiple', cb, false);
+    expect(cb).not.toHaveBeenCalled();
+
+    ctx.pub('*cfg/multiple', false);
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('a config sub does NOT fire when a different config key changes', () => {
+    const ctx = freshCtx();
+    const cb = vi.fn();
+    ctx.sub('*cfg/multiple', cb, false);
+
+    ctx.pub('*cfg/thumbSize', 120);
+    expect(cb).not.toHaveBeenCalled();
+  });
+
+  it('has() is true for built-ins, false for unknown custom keys until added', () => {
+    const ctx = freshCtx();
+    expect(ctx.has('*cfg/multiple')).toBe(true);
+    expect(ctx.has('*cfg/myPluginKey')).toBe(false);
+
+    ctx.add('*cfg/myPluginKey', 'def');
+    expect(ctx.has('*cfg/myPluginKey')).toBe(true);
+    expect(ctx.read('*cfg/myPluginKey')).toBe('def');
+  });
+
+  it('add() is first-write-wins for known keys and overwrites only on rewrite', () => {
+    const ctx = freshCtx();
+    ctx.pub('*cfg/multiple', false);
+
+    ctx.add('*cfg/multiple', true); // no rewrite — keeps current
+    expect(ctx.read('*cfg/multiple')).toBe(false);
+
+    ctx.add('*cfg/multiple', true, true); // rewrite
+    expect(ctx.read('*cfg/multiple')).toBe(true);
+  });
+
+  it('registers the controller in UploaderRegistry on first config access and shares it across wrappers', () => {
+    const ctx = freshCtx();
+    const id = ctx.id;
+    ctx.read('*cfg/multiple'); // triggers lazy controller creation
+
+    const controller = UploaderRegistry.get(id);
+    expect(controller).toBeDefined();
+
+    // A second wrapper for the same ctx sees the same config state.
+    const ctx2 = PubSub.getCtx<Record<string, unknown>>(id)!;
+    ctx2.pub('*cfg/multiple', false);
+    expect(controller?.config.get('multiple')).toBe(false);
+    expect(ctx.read('*cfg/multiple')).toBe(false);
+  });
+
+  it('deleteCtx destroys and unregisters the controller', () => {
+    const id = freshCtx().id;
+    PubSub.getCtx<Record<string, unknown>>(id)!.read('*cfg/multiple');
+    expect(UploaderRegistry.get(id)).toBeDefined();
+
+    PubSub.deleteCtx(id);
+    expect(UploaderRegistry.get(id)).toBeUndefined();
+  });
+
+  it('non-config keys still use the nanostores store', () => {
+    const ctx = freshCtx();
+    expect(ctx.read('plain')).toBe('seed');
+
+    const cb = vi.fn();
+    ctx.sub('plain', cb, false);
+    ctx.pub('plain', 'changed');
+
+    expect(ctx.read('plain')).toBe('changed');
+    expect(cb).toHaveBeenCalledWith('changed');
+  });
+});

--- a/src/lit/PubSubCompat.ts
+++ b/src/lit/PubSubCompat.ts
@@ -1,11 +1,25 @@
 import { listenKeys, type MapStore, map, subscribeKeys } from 'nanostores';
+import type { ConfigController } from '../abstract/controllers/ConfigController';
+import { UploaderController } from '../abstract/controllers/UploaderController';
+import { UploaderRegistry } from '../abstract/UploaderRegistry';
 
 export type Unsubscriber = () => void;
 
 type PubSubStore<T extends Record<string, unknown>> = MapStore<T>;
 
+/** Namespace for config keys (`*cfg/<configKey>`). Routed to the controller. */
+const CFG_PREFIX = '*cfg/';
+
 export class PubSub<T extends Record<string, unknown>> {
   private static _contexts = new Map<string, PubSubStore<Record<string, unknown>>>();
+  /**
+   * One `UploaderController` per ctx-name. Created lazily the first time a
+   * `*cfg/*` key is touched on a context (so per-upload-entry stores, which
+   * never carry config keys, never get a controller). This is the v1 → v2
+   * strangler seam: config state lives in `controller.config`, not in the
+   * nanostores map, while the rest of the shared state stays on nanostores.
+   */
+  private static _controllers = new Map<string, UploaderController>();
 
   private _store: PubSubStore<T>;
   private _ctxId: string;
@@ -19,7 +33,31 @@ export class PubSub<T extends Record<string, unknown>> {
     return this._ctxId;
   }
 
+  /** Strip the `*cfg/` prefix, or return null if `key` is not a config key. */
+  private _cfgName(key: PropertyKey): string | null {
+    if (typeof key === 'string' && key.startsWith(CFG_PREFIX)) {
+      return key.slice(CFG_PREFIX.length);
+    }
+    return null;
+  }
+
+  /** Get (or lazily create + register) the config controller for this ctx. */
+  private _config(): ConfigController {
+    let controller = PubSub._controllers.get(this._ctxId);
+    if (!controller) {
+      controller = new UploaderController();
+      PubSub._controllers.set(this._ctxId, controller);
+      UploaderRegistry.register(this._ctxId, controller);
+    }
+    return controller.config;
+  }
+
   public pub<K extends keyof T>(key: K, value: T[K]): void {
+    const name = this._cfgName(key);
+    if (name !== null) {
+      this._config().setCustom(name, value);
+      return;
+    }
     if (!(key in this._store.get())) {
       console.warn(`PubSub#pub: Key "${String(key)}" not found`);
     }
@@ -27,6 +65,22 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public sub<K extends keyof T>(key: K, callback: (value: T[K]) => void, init = true): Unsubscriber {
+    const name = this._cfgName(key);
+    if (name !== null) {
+      // The controller notifies on ANY config change; re-derive this key's
+      // value and only invoke `callback` when it actually changes, preserving
+      // the per-key subscription semantics of the nanostores map.
+      const cfg = this._config();
+      let last = cfg.getCustom(name);
+      if (init) callback(last as T[K]);
+      return cfg.subscribe(() => {
+        const next = cfg.getCustom(name);
+        if (!Object.is(next, last)) {
+          last = next;
+          callback(next as T[K]);
+        }
+      });
+    }
     const unsubscribe = (init ? subscribeKeys : listenKeys)(this._store, [key as any], (values: Partial<T>) => {
       callback(values[key] as T[K]);
     });
@@ -35,6 +89,10 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public read<K extends keyof T>(key: K): T[K] {
+    const name = this._cfgName(key);
+    if (name !== null) {
+      return this._config().getCustom(name) as T[K];
+    }
     if (!(key in this._store.get())) {
       console.warn(`PubSub#read: Key "${String(key)}" not found`);
     }
@@ -42,6 +100,21 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public add<K extends keyof T>(key: K, value: T[K], rewrite = false): void {
+    const name = this._cfgName(key);
+    if (name !== null) {
+      const cfg = this._config();
+      if (cfg.hasKey(name)) {
+        // Built-in keys always carry a default, and registered custom keys
+        // their seeded value — only an explicit rewrite overwrites them
+        // (mirrors nanostores `add`'s first-write-wins).
+        if (rewrite) cfg.setCustom(name, value);
+      } else {
+        // First sighting of a custom key (e.g. plugin `registerConfig`): seed
+        // it as a registered custom config with this default.
+        cfg.register(name, value);
+      }
+      return;
+    }
     const exists = key in this._store.get();
 
     if (!exists || rewrite) {
@@ -51,6 +124,10 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public has(key: keyof T): boolean {
+    const name = this._cfgName(key);
+    if (name !== null) {
+      return this._config().hasKey(name);
+    }
     return key in this._store.get();
   }
 
@@ -71,6 +148,12 @@ export class PubSub<T extends Record<string, unknown>> {
 
   public static deleteCtx(ctxId: string): void {
     PubSub._contexts.delete(ctxId);
+    const controller = PubSub._controllers.get(ctxId);
+    if (controller) {
+      PubSub._controllers.delete(ctxId);
+      UploaderRegistry.unregister(ctxId, controller);
+      controller.destroy();
+    }
   }
 
   public static getCtx<T extends Record<string, unknown> = Record<string, unknown>>(ctxId: string): PubSub<T> | null {


### PR DESCRIPTION
Second milestone of the **v1 → v2 strangler migration** (see `MIGRATION-PLAN.md`). The facade proof-of-concept.

> **Stacked on #985 (M0).** Base is `feat/v2-m0-foundations`; review M0 first. Will retarget to `feat/v2-migration` once M0 merges.

## What it does
`*cfg/*` config state now lives in a DOM-free **`ConfigController`** (owned by `UploaderController`) instead of the per-ctx nanostores map — with **zero change to documented `<uc-config>` behavior**.

The entire facade lives in **`PubSubCompat`**: `read`/`pub`/`sub`/`add`/`has` detect the `*cfg/` namespace and delegate to the controller, lazily creating one `UploaderController` per `ctx-name` (registered in `UploaderRegistry`) on first config access. Per-key `sub` diffing preserves nanostores' per-key change semantics over the controller's coarse notify. Every other shared key stays on nanostores.

Because **every config choke point funnels through `PubSub`**, the seam covers them all — `<uc-config>`, the `cfg` proxy, `subConfigValue`, and plugin `registerConfig` are **untouched**.

## Deliberately deferred (kept in `<uc-config>` for byte-identical behavior)
- Value coercion (`normalizeConfigValue`)
- `cdnCname` / `cameraModes` computed properties
- The attribute ↔ property ↔ store bridge

These migrate into the controller when `<uc-config>` is retired in a later milestone. M1 establishes the *source-of-truth* seam; it does not yet move logic.

## Why this validates the whole migration
The 24-file e2e suite exercises the documented contract (config attrs/props, custom config, all presets) and passes unchanged — proving the strangler facade is transparent. M2–M8 reuse this exact pattern for the other domains.

## Green gate
- `tsc:app` ✅
- `test:specs` — 344 passed (incl. 20 new across ConfigController / UploaderController / PubSubCompat) ✅
- `test:locales` ✅
- `build` (attw / publint / size-limit) ✅ — bundle sizes unchanged
- `test:e2e` — 187/187 ✅ (incl. `config.e2e`, `custom-config.e2e`)
- `lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced a new configuration management system supporting read, write, and change subscriptions for both standard and custom configuration keys.
  * Configuration changes are now properly tracked and notified to all subscribers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->