### PR TITLE
M2: route locale through LocaleController (strangler facade)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  auto_review:
+    # By default CodeRabbit only auto-reviews PRs whose base is the default
+    # branch. The v2 strangler migration uses stacked PRs that target the
+    # `feat/v2-migration` integration branch and its per-milestone branches
+    # (feat/v2-mN-*), so opt those bases in too — otherwise CodeRabbit skips
+    # them. Matched as regex against the PR base branch name.
+    base_branches:
+      - "feat/v2-.*"
   # Exclude demo pages from CodeRabbit reviews.
   # Patterns are glob-style; entries starting with '!' are ignored.
   path_filters:

--- a/src/abstract/controllers/LocaleController.test.ts
+++ b/src/abstract/controllers/LocaleController.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest';
+import { LocaleController } from './LocaleController';
+
+describe('LocaleController', () => {
+  it('starts empty and stores values', () => {
+    const locale = new LocaleController();
+    expect(locale.has('upload')).toBe(false);
+    expect(locale.get('upload')).toBeUndefined();
+
+    locale.set('upload', 'Upload');
+    expect(locale.has('upload')).toBe(true);
+    expect(locale.get('upload')).toBe('Upload');
+  });
+
+  it('notifies on change and dedupes unchanged writes', () => {
+    const locale = new LocaleController();
+    const listener = vi.fn();
+    locale.subscribe(listener);
+
+    locale.set('upload', 'Upload');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    locale.set('upload', 'Upload'); // unchanged
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    locale.set('upload', 'Send');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const locale = new LocaleController();
+    const listener = vi.fn();
+    const off = locale.subscribe(listener);
+    off();
+
+    locale.set('upload', 'Upload');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('destroy() clears values and listeners', () => {
+    const locale = new LocaleController();
+    locale.set('upload', 'Upload');
+    const listener = vi.fn();
+    locale.subscribe(listener);
+
+    locale.destroy();
+
+    expect(locale.has('upload')).toBe(false);
+    locale.set('upload', 'Upload');
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/controllers/LocaleController.test.ts
+++ b/src/abstract/controllers/LocaleController.test.ts
@@ -37,6 +37,19 @@ describe('LocaleController', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 
+  it('has() uses own-property semantics, not the prototype chain', () => {
+    const locale = new LocaleController();
+    expect(locale.has('toString')).toBe(false);
+    expect(locale.has('__proto__')).toBe(false);
+  });
+
+  it('does not pollute the prototype for a key named __proto__', () => {
+    const locale = new LocaleController();
+    locale.set('__proto__', 'evil');
+    expect(({} as Record<string, unknown>).evil).toBeUndefined();
+    expect(locale.get('__proto__')).toBe('evil');
+  });
+
   it('destroy() clears values and listeners', () => {
     const locale = new LocaleController();
     locale.set('upload', 'Upload');

--- a/src/abstract/controllers/LocaleController.ts
+++ b/src/abstract/controllers/LocaleController.ts
@@ -14,7 +14,10 @@ import { Listeners } from '../host-subscription';
  * controller when `LocaleManager` is retired.
  */
 export class LocaleController {
-  private _values: Record<string, string> = {};
+  // Null-prototype backing object: locale keys can be plugin-supplied, so a
+  // key like `__proto__` must create a plain own property here rather than
+  // touch the prototype chain.
+  private _values: Record<string, string> = Object.create(null);
   private _listeners = new Listeners();
 
   public get values(): Readonly<Record<string, string>> {
@@ -26,7 +29,9 @@ export class LocaleController {
   }
 
   public has(key: string): boolean {
-    return key in this._values;
+    // Own-property check: `in` would walk the prototype chain and wrongly
+    // report `toString`, `__proto__`, etc. as present.
+    return Object.hasOwn(this._values, key);
   }
 
   public get(key: string): string | undefined {
@@ -41,7 +46,7 @@ export class LocaleController {
   }
 
   public destroy(): void {
-    this._values = {};
+    this._values = Object.create(null);
     this._listeners.clear();
   }
 }

--- a/src/abstract/controllers/LocaleController.ts
+++ b/src/abstract/controllers/LocaleController.ts
@@ -1,0 +1,47 @@
+import { Listeners } from '../host-subscription';
+
+/**
+ * Pure-logic locale string store. Knows nothing about DOM or Lit.
+ *
+ * In the v1 → v2 strangler this is the source of truth for the `*l10n/*` state
+ * that used to live in the per-ctx nanostores map; `PubSubCompat` routes those
+ * keys here. For now it is a raw string container: `LocaleManager` still owns
+ * the orchestration (resolving the active dictionary from `localeName`,
+ * `defineLocale` registry lookups, async resolvers, `localeDefinitionOverride`,
+ * and plugin `registerL10n` merges) and writes the resolved strings here, and
+ * `l10n.ts` reads from here to do ICU-plural + template substitution — so
+ * behavior is byte-identical to v1. That orchestration migrates into this
+ * controller when `LocaleManager` is retired.
+ */
+export class LocaleController {
+  private _values: Record<string, string> = {};
+  private _listeners = new Listeners();
+
+  public get values(): Readonly<Record<string, string>> {
+    return this._values;
+  }
+
+  public subscribe(listener: () => void): () => void {
+    return this._listeners.subscribe(listener);
+  }
+
+  public has(key: string): boolean {
+    return key in this._values;
+  }
+
+  public get(key: string): string | undefined {
+    return this._values[key];
+  }
+
+  /** Notifies only when the value actually changes (per-key change semantics). */
+  public set(key: string, value: string): void {
+    if (this._values[key] === value) return;
+    this._values[key] = value;
+    this._listeners.notify();
+  }
+
+  public destroy(): void {
+    this._values = {};
+    this._listeners.clear();
+  }
+}

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,13 +1,15 @@
 import { describe, expect, it } from 'vitest';
 import { EventBus } from '../EventBus';
 import { ConfigController } from './ConfigController';
+import { LocaleController } from './LocaleController';
 import { UploaderController } from './UploaderController';
 
 describe('UploaderController', () => {
-  it('constructs with an event bus and a config controller', () => {
+  it('constructs with event, config, and locale controllers', () => {
     const controller = new UploaderController();
     expect(controller.events).toBeInstanceOf(EventBus);
     expect(controller.config).toBeInstanceOf(ConfigController);
+    expect(controller.locale).toBeInstanceOf(LocaleController);
   });
 
   it('destroy() tears down without throwing', () => {

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,5 +1,6 @@
 import { EventBus } from '../EventBus';
 import { ConfigController } from './ConfigController';
+import { LocaleController } from './LocaleController';
 
 /**
  * Root controller — one instance per uploader scope (keyed by `ctx-name` in
@@ -13,13 +14,17 @@ import { ConfigController } from './ConfigController';
  * - `events`: the typed event bus (wired to DOM events in a later milestone).
  * - `config`: source of truth for `*cfg/*` state — `PubSubCompat` routes the
  *   config namespace here.
+ * - `locale`: source of truth for `*l10n/*` state — `PubSubCompat` routes the
+ *   locale namespace here.
  */
 export class UploaderController {
   public readonly events = new EventBus();
   public readonly config = new ConfigController();
+  public readonly locale = new LocaleController();
 
   public destroy(): void {
     this.events.destroy();
     this.config.destroy();
+    this.locale.destroy();
   }
 }

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -165,4 +165,19 @@ describe('PubSub locale (*l10n/*) facade', () => {
     const controller = UploaderRegistry.get(id);
     expect(controller?.locale.get('upload')).toBe('Upload');
   });
+
+  it('warns when reading a missing locale key but not a present one (typo surfacing)', () => {
+    const ctx = freshCtx();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    ctx.read('*l10n/typoKey');
+    expect(warn).toHaveBeenCalledWith('PubSub#read: Key "*l10n/typoKey" not found');
+
+    warn.mockClear();
+    ctx.add('*l10n/upload', 'Upload');
+    ctx.read('*l10n/upload');
+    expect(warn).not.toHaveBeenCalled();
+
+    warn.mockRestore();
+  });
 });

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -118,3 +118,51 @@ describe('PubSub config (*cfg/*) facade', () => {
     expect(cb).toHaveBeenCalledWith('changed');
   });
 });
+
+describe('PubSub locale (*l10n/*) facade', () => {
+  it('routes locale keys to the controller, not the nanostores store', () => {
+    const ctx = freshCtx();
+    expect(ctx.has('*l10n/upload')).toBe(false);
+
+    ctx.add('*l10n/upload', 'Upload');
+
+    expect(ctx.has('*l10n/upload')).toBe(true);
+    expect(ctx.read('*l10n/upload')).toBe('Upload');
+    expect('*l10n/upload' in ctx.store).toBe(false);
+  });
+
+  it('add() is first-write-wins; rewrite overwrites (LocaleManager seeding semantics)', () => {
+    const ctx = freshCtx();
+    ctx.add('*l10n/upload', 'Upload');
+
+    ctx.add('*l10n/upload', 'Send'); // no rewrite — keeps
+    expect(ctx.read('*l10n/upload')).toBe('Upload');
+
+    ctx.add('*l10n/upload', 'Send', true); // rewrite (override / plugin l10n)
+    expect(ctx.read('*l10n/upload')).toBe('Send');
+  });
+
+  it('sub fires on that key only, with per-key change semantics', () => {
+    const ctx = freshCtx();
+    ctx.add('*l10n/upload', 'Upload');
+    const cb = vi.fn();
+    ctx.sub('*l10n/upload', cb, false);
+
+    ctx.add('*l10n/cancel', 'Cancel', true); // different key — no fire
+    expect(cb).not.toHaveBeenCalled();
+
+    ctx.add('*l10n/upload', 'Send', true);
+    expect(cb).toHaveBeenLastCalledWith('Send');
+    expect(cb).toHaveBeenCalledTimes(1);
+  });
+
+  it('config and locale share one controller per ctx', () => {
+    const ctx = freshCtx();
+    const id = ctx.id;
+    ctx.read('*cfg/multiple');
+    ctx.add('*l10n/upload', 'Upload', true);
+
+    const controller = UploaderRegistry.get(id);
+    expect(controller?.locale.get('upload')).toBe('Upload');
+  });
+});

--- a/src/lit/PubSubCompat.ts
+++ b/src/lit/PubSubCompat.ts
@@ -1,5 +1,6 @@
 import { listenKeys, type MapStore, map, subscribeKeys } from 'nanostores';
 import type { ConfigController } from '../abstract/controllers/ConfigController';
+import type { LocaleController } from '../abstract/controllers/LocaleController';
 import { UploaderController } from '../abstract/controllers/UploaderController';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 
@@ -7,8 +8,13 @@ export type Unsubscriber = () => void;
 
 type PubSubStore<T extends Record<string, unknown>> = MapStore<T>;
 
-/** Namespace for config keys (`*cfg/<configKey>`). Routed to the controller. */
+/**
+ * Namespaces routed to the per-ctx `UploaderController` instead of the
+ * nanostores map: config (`*cfg/<key>`) → `controller.config`, locale
+ * (`*l10n/<key>`) → `controller.locale`. Everything else stays on nanostores.
+ */
 const CFG_PREFIX = '*cfg/';
+const L10N_PREFIX = '*l10n/';
 
 export class PubSub<T extends Record<string, unknown>> {
   private static _contexts = new Map<string, PubSubStore<Record<string, unknown>>>();
@@ -35,27 +41,64 @@ export class PubSub<T extends Record<string, unknown>> {
 
   /** Strip the `*cfg/` prefix, or return null if `key` is not a config key. */
   private _cfgName(key: PropertyKey): string | null {
-    if (typeof key === 'string' && key.startsWith(CFG_PREFIX)) {
-      return key.slice(CFG_PREFIX.length);
-    }
-    return null;
+    return typeof key === 'string' && key.startsWith(CFG_PREFIX) ? key.slice(CFG_PREFIX.length) : null;
   }
 
-  /** Get (or lazily create + register) the config controller for this ctx. */
-  private _config(): ConfigController {
+  /** Strip the `*l10n/` prefix, or return null if `key` is not a locale key. */
+  private _l10nName(key: PropertyKey): string | null {
+    return typeof key === 'string' && key.startsWith(L10N_PREFIX) ? key.slice(L10N_PREFIX.length) : null;
+  }
+
+  /** Get (or lazily create + register) the controller for this ctx. */
+  private _uploader(): UploaderController {
     let controller = PubSub._controllers.get(this._ctxId);
     if (!controller) {
       controller = new UploaderController();
       PubSub._controllers.set(this._ctxId, controller);
       UploaderRegistry.register(this._ctxId, controller);
     }
-    return controller.config;
+    return controller;
+  }
+
+  private _config(): ConfigController {
+    return this._uploader().config;
+  }
+
+  private _locale(): LocaleController {
+    return this._uploader().locale;
+  }
+
+  /**
+   * Subscribe over a controller's coarse change notification but only invoke
+   * `callback` when the specific derived value changes — preserving the
+   * per-key subscription semantics of the nanostores map being replaced.
+   */
+  private _subDerived<V>(
+    read: () => V,
+    subscribe: (listener: () => void) => Unsubscriber,
+    callback: (value: V) => void,
+    init: boolean,
+  ): Unsubscriber {
+    let last = read();
+    if (init) callback(last);
+    return subscribe(() => {
+      const next = read();
+      if (!Object.is(next, last)) {
+        last = next;
+        callback(next);
+      }
+    });
   }
 
   public pub<K extends keyof T>(key: K, value: T[K]): void {
-    const name = this._cfgName(key);
-    if (name !== null) {
-      this._config().setCustom(name, value);
+    const cfg = this._cfgName(key);
+    if (cfg !== null) {
+      this._config().setCustom(cfg, value);
+      return;
+    }
+    const loc = this._l10nName(key);
+    if (loc !== null) {
+      this._locale().set(loc, value as unknown as string);
       return;
     }
     if (!(key in this._store.get())) {
@@ -65,21 +108,25 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public sub<K extends keyof T>(key: K, callback: (value: T[K]) => void, init = true): Unsubscriber {
-    const name = this._cfgName(key);
-    if (name !== null) {
-      // The controller notifies on ANY config change; re-derive this key's
-      // value and only invoke `callback` when it actually changes, preserving
-      // the per-key subscription semantics of the nanostores map.
-      const cfg = this._config();
-      let last = cfg.getCustom(name);
-      if (init) callback(last as T[K]);
-      return cfg.subscribe(() => {
-        const next = cfg.getCustom(name);
-        if (!Object.is(next, last)) {
-          last = next;
-          callback(next as T[K]);
-        }
-      });
+    const cfg = this._cfgName(key);
+    if (cfg !== null) {
+      const config = this._config();
+      return this._subDerived<T[K]>(
+        () => config.getCustom(cfg) as T[K],
+        (l) => config.subscribe(l),
+        callback,
+        init,
+      );
+    }
+    const loc = this._l10nName(key);
+    if (loc !== null) {
+      const locale = this._locale();
+      return this._subDerived<T[K]>(
+        () => locale.get(loc) as T[K],
+        (l) => locale.subscribe(l),
+        callback,
+        init,
+      );
     }
     const unsubscribe = (init ? subscribeKeys : listenKeys)(this._store, [key as any], (values: Partial<T>) => {
       callback(values[key] as T[K]);
@@ -89,10 +136,10 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public read<K extends keyof T>(key: K): T[K] {
-    const name = this._cfgName(key);
-    if (name !== null) {
-      return this._config().getCustom(name) as T[K];
-    }
+    const cfg = this._cfgName(key);
+    if (cfg !== null) return this._config().getCustom(cfg) as T[K];
+    const loc = this._l10nName(key);
+    if (loc !== null) return this._locale().get(loc) as T[K];
     if (!(key in this._store.get())) {
       console.warn(`PubSub#read: Key "${String(key)}" not found`);
     }
@@ -100,19 +147,27 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public add<K extends keyof T>(key: K, value: T[K], rewrite = false): void {
-    const name = this._cfgName(key);
-    if (name !== null) {
-      const cfg = this._config();
-      if (cfg.hasKey(name)) {
+    const cfg = this._cfgName(key);
+    if (cfg !== null) {
+      const config = this._config();
+      if (config.hasKey(cfg)) {
         // Built-in keys always carry a default, and registered custom keys
         // their seeded value — only an explicit rewrite overwrites them
         // (mirrors nanostores `add`'s first-write-wins).
-        if (rewrite) cfg.setCustom(name, value);
+        if (rewrite) config.setCustom(cfg, value);
       } else {
         // First sighting of a custom key (e.g. plugin `registerConfig`): seed
         // it as a registered custom config with this default.
-        cfg.register(name, value);
+        config.register(cfg, value);
       }
+      return;
+    }
+    const loc = this._l10nName(key);
+    if (loc !== null) {
+      // Locale keys have no built-in defaults — generic first-write-wins, as
+      // `LocaleManager` seeds the dictionary via `add(..., rewrite)`.
+      const locale = this._locale();
+      if (!locale.has(loc) || rewrite) locale.set(loc, value as unknown as string);
       return;
     }
     const exists = key in this._store.get();
@@ -124,10 +179,10 @@ export class PubSub<T extends Record<string, unknown>> {
   }
 
   public has(key: keyof T): boolean {
-    const name = this._cfgName(key);
-    if (name !== null) {
-      return this._config().hasKey(name);
-    }
+    const cfg = this._cfgName(key);
+    if (cfg !== null) return this._config().hasKey(cfg);
+    const loc = this._l10nName(key);
+    if (loc !== null) return this._locale().has(loc);
     return key in this._store.get();
   }
 

--- a/src/lit/PubSubCompat.ts
+++ b/src/lit/PubSubCompat.ts
@@ -137,9 +137,18 @@ export class PubSub<T extends Record<string, unknown>> {
 
   public read<K extends keyof T>(key: K): T[K] {
     const cfg = this._cfgName(key);
-    if (cfg !== null) return this._config().getCustom(cfg) as T[K];
+    if (cfg !== null) {
+      const config = this._config();
+      // Preserve the v1 missing-key warning — useful for surfacing typo'd keys.
+      if (!config.hasKey(cfg)) console.warn(`PubSub#read: Key "${String(key)}" not found`);
+      return config.getCustom(cfg) as T[K];
+    }
     const loc = this._l10nName(key);
-    if (loc !== null) return this._locale().get(loc) as T[K];
+    if (loc !== null) {
+      const locale = this._locale();
+      if (!locale.has(loc)) console.warn(`PubSub#read: Key "${String(key)}" not found`);
+      return locale.get(loc) as T[K];
+    }
     if (!(key in this._store.get())) {
       console.warn(`PubSub#read: Key "${String(key)}" not found`);
     }


### PR DESCRIPTION
Third milestone of the **v1 → v2 strangler migration** (see `MIGRATION-PLAN.md`). Reuses the M1 config pattern for localization.

> **Stacked on #986 (M1) → #985 (M0).** Review the stack bottom-up. Will retarget as each lands.

## What it does
`*l10n/*` localization state now lives in a DOM-free **`LocaleController`** (owned by `UploaderController`) instead of the per-ctx nanostores map — with **zero change to documented behavior** (`defineLocale`, `localeName`, `localeDefinitionOverride`, `api.l10n(key, params)`).

The `PubSubCompat` facade is **generalized to two namespaces**: `*cfg/` → `controller.config`, `*l10n/` → `controller.locale`, sharing one `UploaderController` per `ctx-name`. The per-key sub-diffing is factored into a reusable `_subDerived` helper. Locale keys use generic first-write-wins `add` semantics (v1 `LocaleManager` seeds the dictionary via `add(..., rewrite)`).

## Deliberately deferred (kept in `LocaleManager` / `l10n.ts` for byte-identical behavior)
- Active-dictionary resolution from `localeName`
- The `defineLocale` registry + async locale resolvers (+ stale-check)
- `localeDefinitionOverride` merging and plugin `registerL10n` merging
- ICU-plural (`Intl.PluralRules`) + `{{template}}` substitution

These migrate into the controller when `LocaleManager` is retired. M2 moves the *source of truth* for locale strings, not the orchestration.

## Green gate
- `tsc:app` ✅
- `test:specs` — 352 passed (incl. `LocaleController` + locale-facade tests) ✅
- `test:locales` ✅
- `build` (attw / publint / size-limit) ✅ — bundle sizes unchanged
- `test:e2e` — 187/187 ✅ (incl. `plugins/icon-and-l10n.e2e`)
- `lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added locale string management system with subscription support for reactive updates.
  * Locale data now persists and can be retrieved on-demand.
  * Missing locale keys trigger helpful warnings.

* **Tests**
  * Added comprehensive test coverage for locale management functionality.

* **Chores**
  * Updated CI configuration to support v2 development branches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->