### PR TITLE
M3a: de-PubSub per-entry upload storage (strangler)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,6 +1,14 @@
 # yaml-language-server: $schema=https://www.coderabbit.ai/integrations/schema.v2.json
 
 reviews:
+  auto_review:
+    # By default CodeRabbit only auto-reviews PRs whose base is the default
+    # branch. The v2 strangler migration uses stacked PRs that target the
+    # `feat/v2-migration` integration branch and its per-milestone branches
+    # (feat/v2-mN-*), so opt those bases in too — otherwise CodeRabbit skips
+    # them. Matched as regex against the PR base branch name.
+    base_branches:
+      - "feat/v2-.*"
   # Exclude demo pages from CodeRabbit reviews.
   # Patterns are glob-style; entries starting with '!' are ignored.
   path_filters:

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { PubSub } from '../lit/PubSubCompat';
 import { TypedData } from './TypedData';
 
 describe('TypedData', () => {
@@ -7,7 +6,7 @@ describe('TypedData', () => {
     vi.restoreAllMocks();
   });
 
-  it('creates a unique context id and registers a PubSub context', () => {
+  it('creates a unique uid and is discoverable via the registry', () => {
     const ctx1 = new TypedData<{ a: number }>({ a: 1 });
     const ctx2 = new TypedData<{ a: number }>({ a: 2 });
 
@@ -15,14 +14,23 @@ describe('TypedData', () => {
     expect(ctx2.uid).toBeTruthy();
     expect(ctx1.uid).not.toBe(ctx2.uid);
 
-    expect(PubSub.hasCtx(ctx1.uid)).toBe(true);
-    expect(PubSub.hasCtx(ctx2.uid)).toBe(true);
+    expect(TypedData.getByUid(ctx1.uid)).toBe(ctx1);
+    expect(TypedData.getByUid(ctx2.uid)).toBe(ctx2);
+    expect(TypedData.getByUid('nope')).toBeNull();
 
     ctx1.destroy();
     ctx2.destroy();
   });
 
-  it('getValue/setValue read and update values; setValue only publishes when changed', () => {
+  it('snapshot() returns the full current field object', () => {
+    const ctx = new TypedData<{ a: number; b: string }>({ a: 1, b: 'x' });
+    expect(ctx.snapshot()).toEqual({ a: 1, b: 'x' });
+    ctx.setValue('a', 2);
+    expect(ctx.snapshot().a).toBe(2);
+    ctx.destroy();
+  });
+
+  it('getValue/setValue read and update values; setValue only notifies when changed', () => {
     const ctx = new TypedData<{ a: number }>({ a: 1 });
 
     expect(ctx.getValue('a')).toBe(1);
@@ -30,20 +38,49 @@ describe('TypedData', () => {
     const handler = vi.fn();
     ctx.subscribe('a', handler);
 
-    // PubSub subscriptions emit the initial value.
+    // subscribe emits the initial value immediately (parity with the previous
+    // PubSub.sub(..., init=true) behavior).
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenLastCalledWith(1);
     handler.mockClear();
 
-    // Same value => no publish.
+    // Same value => no notify.
     ctx.setValue('a', 1);
     expect(handler).not.toHaveBeenCalled();
 
-    // Changed value => publish.
+    // Changed value => notify.
     ctx.setValue('a', 2);
     expect(ctx.getValue('a')).toBe(2);
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenLastCalledWith(2);
+
+    ctx.destroy();
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const ctx = new TypedData<{ a: number }>({ a: 1 });
+    const handler = vi.fn();
+    const off = ctx.subscribe('a', handler);
+    handler.mockClear();
+    off();
+
+    ctx.setValue('a', 2);
+    expect(handler).not.toHaveBeenCalled();
+    ctx.destroy();
+  });
+
+  it('only notifies subscribers of the changed property (per-key)', () => {
+    const ctx = new TypedData<{ a: number; b: number }>({ a: 1, b: 1 });
+    const onA = vi.fn();
+    const onB = vi.fn();
+    ctx.subscribe('a', onA);
+    ctx.subscribe('b', onB);
+    onA.mockClear();
+    onB.mockClear();
+
+    ctx.setValue('a', 2);
+    expect(onA).toHaveBeenCalledTimes(1);
+    expect(onB).not.toHaveBeenCalled();
 
     ctx.destroy();
   });
@@ -63,24 +100,22 @@ describe('TypedData', () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
 
     const ctx = new TypedData<{ a: number }>({ a: 1 });
+    // biome-ignore lint/suspicious/noExplicitAny: testing the unknown-key guard
     ctx.setValue('missing' as any, 123);
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0]?.[0]).toMatch(/\[Typed State\] Wrong property name:/);
-
-    // Original value is intact.
     expect(ctx.getValue('a')).toBe(1);
 
     ctx.destroy();
   });
 
-  it('destroy() unregisters the PubSub context', () => {
+  it('destroy() removes the entry from the registry', () => {
     const ctx = new TypedData<{ a: number }>({ a: 1 });
     const id = ctx.uid;
-
-    expect(PubSub.hasCtx(id)).toBe(true);
+    expect(TypedData.getByUid(id)).toBe(ctx);
 
     ctx.destroy();
-    expect(PubSub.hasCtx(id)).toBe(false);
+    expect(TypedData.getByUid(id)).toBeNull();
   });
 });

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -85,6 +85,25 @@ describe('TypedData', () => {
     ctx.destroy();
   });
 
+  it('isolates a throwing subscriber so other subscribers still run', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = new TypedData<{ a: number }>({ a: 1 });
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    ctx.subscribe('a', bad);
+    ctx.subscribe('a', good);
+    bad.mockClear();
+    good.mockClear();
+
+    expect(() => ctx.setValue('a', 2)).not.toThrow();
+    expect(good).toHaveBeenCalledWith(2);
+    expect(warn).toHaveBeenCalled();
+
+    ctx.destroy();
+  });
+
   it('setMultipleValues updates multiple properties via setValue', () => {
     const ctx = new TypedData<{ a: number; b: number }>({ a: 1, b: 10 });
 

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -59,7 +59,20 @@ export class TypedData<T extends Record<string, unknown>> {
     this._data[prop] = value;
     const set = this._subs.get(prop);
     if (set) {
-      for (const handler of [...set]) handler(value);
+      // Isolate each subscriber so one that throws can't abort notification of
+      // the rest — notably the `TypedCollection` watch-list observer, whose
+      // failure to run would stall collection/event updates. Matches the
+      // fan-out semantics of `Listeners.notify` / `EventBus.emit`.
+      for (const handler of [...set]) this._emit(prop, handler, value);
+    }
+  }
+
+  /** Invoke a subscriber, isolating (and logging) any error it throws. */
+  private _emit(prop: keyof T, handler: (value: unknown) => void, value: unknown): void {
+    try {
+      handler(value);
+    } catch (err) {
+      console.warn(`[Typed State] subscriber for "${String(prop)}" threw`, err);
     }
   }
 
@@ -85,8 +98,9 @@ export class TypedData<T extends Record<string, unknown>> {
     const wrapped = handler as (value: unknown) => void;
     set.add(wrapped);
     // Fire immediately with the current value (parity with the previous
-    // `PubSub.sub(..., init=true)` subscription semantics).
-    handler(this._data[prop]);
+    // `PubSub.sub(..., init=true)` subscription semantics), isolated like the
+    // notify path so a throwing subscriber can't break the subscribe call.
+    this._emit(prop, wrapped, this._data[prop]);
     return () => {
       set?.delete(wrapped);
     };

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -1,31 +1,65 @@
-import { PubSub } from '../lit/PubSubCompat';
 import type { Uid } from '../lit/Uid';
 import { UID } from '../utils/UID';
 
 const MSG_NAME = '[Typed State] Wrong property name: ';
 
+/**
+ * Per-entry reactive store. Each upload entry is one `TypedData`.
+ *
+ * As of the v1 → v2 strangler (M3a) this is self-contained — a plain
+ * null-prototype field object plus per-key listener sets — rather than a
+ * nanostores `PubSub` context per entry. A module-level registry keyed by the
+ * entry's `uid` replaces the old `PubSub.getCtx(uid)` lookup that hot paths
+ * (`getOutputItem`, event emission) used to read entry state by id; because
+ * `TypedCollection` defers `destroy()` ~10s after removal, `getByUid` keeps
+ * returning a removed entry's data during that window, exactly as the old
+ * per-entry context did.
+ *
+ * Public API (`uid`, `getValue`, `setValue`, `setMultipleValues`, `subscribe`,
+ * `destroy`) is unchanged, so `TypedCollection` and all consumers are
+ * untouched. `subscribe` fires immediately with the current value, matching
+ * the previous `PubSub.sub(..., init=true)` behavior.
+ */
 export class TypedData<T extends Record<string, unknown>> {
+  private static _registry = new Map<string, TypedData<Record<string, unknown>>>();
+
   private _ctxId: Uid;
-  private _data: PubSub<T>;
+  private _data: T;
+  private _subs = new Map<keyof T, Set<(value: unknown) => void>>();
 
   public constructor(initialValue: T) {
     this._ctxId = UID.generateFastUid();
-    this._data = PubSub.registerCtx(initialValue, this._ctxId);
+    // Null-prototype so a field name like `__proto__` can't touch the chain.
+    this._data = Object.assign(Object.create(null), initialValue);
+    TypedData._registry.set(this._ctxId, this as unknown as TypedData<Record<string, unknown>>);
+  }
+
+  /** Look up a live entry store by its uid (returns removed-but-not-yet-destroyed entries too). */
+  public static getByUid<T extends Record<string, unknown>>(uid: string): TypedData<T> | null {
+    return (TypedData._registry.get(uid) as TypedData<T> | undefined) ?? null;
   }
 
   public get uid(): Uid {
     return this._ctxId;
   }
 
+  /** Full current field object — the replacement for the old `PubSub#store`. */
+  public snapshot(): Readonly<T> {
+    return this._data;
+  }
+
   public setValue<K extends keyof T>(prop: K, value: T[K]): void {
-    if (!this._data.has(prop)) {
+    if (!Object.hasOwn(this._data, prop as PropertyKey)) {
       console.warn(`${MSG_NAME}${String(prop)}`);
       return;
     }
-
-    const isChanged = this._data.read(prop) !== value;
-    if (isChanged) {
-      this._data.pub(prop, value);
+    if (this._data[prop] === value) {
+      return;
+    }
+    this._data[prop] = value;
+    const set = this._subs.get(prop);
+    if (set) {
+      for (const handler of [...set]) handler(value);
     }
   }
 
@@ -36,17 +70,30 @@ export class TypedData<T extends Record<string, unknown>> {
   }
 
   public getValue<K extends keyof T>(prop: K): T[K] {
-    if (!this._data.has(prop)) {
+    if (!Object.hasOwn(this._data, prop as PropertyKey)) {
       console.warn(`${MSG_NAME}${String(prop)}`);
     }
-    return this._data.read(prop);
+    return this._data[prop];
   }
 
-  public subscribe<K extends keyof T>(prop: K, handler: (newVal: T[K]) => void) {
-    return this._data.sub(prop, handler);
+  public subscribe<K extends keyof T>(prop: K, handler: (newVal: T[K]) => void): () => void {
+    let set = this._subs.get(prop);
+    if (!set) {
+      set = new Set();
+      this._subs.set(prop, set);
+    }
+    const wrapped = handler as (value: unknown) => void;
+    set.add(wrapped);
+    // Fire immediately with the current value (parity with the previous
+    // `PubSub.sub(..., init=true)` subscription semantics).
+    handler(this._data[prop]);
+    return () => {
+      set?.delete(wrapped);
+    };
   }
 
   public destroy(): void {
-    PubSub.deleteCtx(this._ctxId);
+    TypedData._registry.delete(this._ctxId);
+    this._subs.clear();
   }
 }

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -8,7 +8,6 @@ import { findBlockInCtx } from '../lit/findBlockInCtx';
 import { waitForBlockInCtx } from '../lit/hasBlockInCtx';
 import type { ActivityParamsMap, ActivityType, LitActivityBlock } from '../lit/LitActivityBlock';
 import { createL10n } from '../lit/l10n';
-import { PubSub } from '../lit/PubSubCompat';
 import { SharedInstance } from '../lit/shared-instances';
 import type { Uid } from '../lit/Uid';
 import type {
@@ -31,6 +30,7 @@ import { parseCdnUrl } from '../utils/parseCdnUrl';
 import { stringToArray } from '../utils/stringToArray';
 import { UploadSource } from '../utils/UploadSource';
 import { buildOutputCollectionState } from './buildOutputCollectionState';
+import { TypedData } from './TypedData';
 import type { UploadEntryData } from './uploadEntrySchema';
 export type ApiAddFileCommonOptions = {
   silent?: boolean;
@@ -250,11 +250,11 @@ export class UploaderPublicApi extends SharedInstance {
   };
 
   public getOutputItem<TStatus extends OutputFileStatus>(entryId: string): OutputFileEntry<TStatus> {
-    const ctx = PubSub.getCtx<UploadEntryData>(entryId);
-    if (!ctx) {
+    const entry = TypedData.getByUid<UploadEntryData>(entryId);
+    if (!entry) {
       throw new Error(`UploaderPublicApi#getOutputItem: Entry with ID "${entryId}" not found in the upload collection`);
     }
-    const uploadEntryData = ctx.store;
+    const uploadEntryData = entry.snapshot();
     const fileInfo = uploadEntryData.fileInfo as UploadcareFile | null;
 
     const status: OutputFileEntry['status'] = uploadEntryData.isRemoved

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -6,6 +6,7 @@ import { SecureUploadsManager } from '../abstract/managers/SecureUploadsManager'
 import { ValidationManager } from '../abstract/managers/ValidationManager';
 import type { TypedCollectionObserverHandler } from '../abstract/TypedCollection';
 import { TypedCollection } from '../abstract/TypedCollection';
+import { TypedData } from '../abstract/TypedData';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
 import { initialUploadEntryData, type UploadEntryData } from '../abstract/uploadEntrySchema';
 import { calculateMaxCenteredCropFrame } from '../blocks/CloudImageEditor/src/crop-utils';
@@ -18,7 +19,6 @@ import { ExternalUploadSource, UploadSource } from '../utils/UploadSource';
 import { customUserAgent } from '../utils/userAgent';
 import { getOutputData } from './getOutputData';
 import { LitActivityBlock } from './LitActivityBlock';
-import { PubSub } from './PubSubCompat';
 import type { Uid } from './Uid';
 
 export class LitUploaderBlock extends LitActivityBlock {
@@ -246,7 +246,8 @@ export class LitUploaderBlock extends LitActivityBlock {
         if (!this.isConnected) return;
         // We can't modify entry properties in the same tick, so we need to wait a bit
         const entriesToRunOnUpload = entriesToRunValidation.filter(
-          (entryId) => changeMap.fileInfo?.has(entryId) && !!PubSub.getCtx(entryId)?.store.fileInfo,
+          (entryId) =>
+            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
         );
         if (entriesToRunOnUpload.length > 0) {
           this.validationManager.runFileValidators('upload', entriesToRunOnUpload);
@@ -256,9 +257,9 @@ export class LitUploaderBlock extends LitActivityBlock {
 
     if (changeMap.uploadProgress) {
       for (const entryId of changeMap.uploadProgress) {
-        const ctx = PubSub.getCtx<UploadEntryData>(entryId);
-        if (!ctx) continue;
-        const { isUploading, silent } = ctx.store;
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
         if (isUploading && !silent) {
           this.emit(EventType.FILE_UPLOAD_PROGRESS, this.api.getOutputItem(entryId));
         }
@@ -268,9 +269,9 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.isUploading) {
       for (const entryId of changeMap.isUploading) {
-        const ctx = PubSub.getCtx<UploadEntryData>(entryId);
-        if (!ctx) continue;
-        const { isUploading, silent } = ctx.store;
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
         if (isUploading && !silent) {
           this.emit(EventType.FILE_UPLOAD_START, this.api.getOutputItem(entryId));
         }
@@ -278,9 +279,9 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.fileInfo) {
       for (const entryId of changeMap.fileInfo) {
-        const ctx = PubSub.getCtx<UploadEntryData>(entryId);
-        if (!ctx) continue;
-        const { fileInfo, silent } = ctx.store;
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { fileInfo, silent } = entry.snapshot();
         if (fileInfo && !silent) {
           this.emit(EventType.FILE_UPLOAD_SUCCESS, this.api.getOutputItem(entryId));
         }
@@ -293,9 +294,9 @@ export class LitUploaderBlock extends LitActivityBlock {
       this.validationManager.runCollectionValidators();
 
       for (const entryId of changeMap.errors) {
-        const ctx = PubSub.getCtx<UploadEntryData>(entryId);
-        if (!ctx) continue;
-        const { errors } = ctx.store;
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { errors } = entry.snapshot();
         if (errors.length > 0) {
           this.emit(EventType.FILE_UPLOAD_FAILED, this.api.getOutputItem(entryId));
           this.emit(


### PR DESCRIPTION
First sub-step of **M3 (collection)** in the v1 → v2 strangler. M3 is split into **M3a (entry storage) → M3b (collection machinery) → M3c (validation)** because the upload collection is an object graph of per-entry PubSub contexts with hot raw reads — not a flat key namespace like config/locale, so it can't use the clean PubSubCompat prefix-facade.

> **Stacked on #987 → #986 → #985.** Review bottom-up.

## What M3a does
Each upload entry's `TypedData` is now a **self-contained reactive store** — a null-prototype field object + per-key listener sets — instead of allocating a **nanostores `PubSub` context per entry**. This removes one MapStore per upload entry and is the prerequisite for moving the collection into `UploadCollectionController` (M3b).

- A module-level **`uid → TypedData` registry** replaces the `PubSub.getCtx(entryUid)` lookup that hot paths used to read entry state by id.
- Because `TypedCollection` still defers `destroy()` ~10s after removal, **`TypedData.getByUid` keeps returning a removed entry's data during that window** — exactly as the per-entry context did (this preserved the `getOutputItem`-after-remove behavior for `file-removed` payloads).
- The **6 raw `PubSub.getCtx(entryId).store` reads** (`getOutputItem` + 5 in `LitUploaderBlock`'s event logic) now use `TypedData.getByUid(id).snapshot()`.

## Unchanged on purpose
`TypedData`'s public API (`uid`/`getValue`/`setValue`/`setMultipleValues`/`subscribe`/`destroy`) is identical, and `subscribe` still fires immediately with the current value (parity with the old `PubSub.sub(..., init=true)`). So `TypedCollection`, `FileItem`, `UploadList`, `ValidationManager`, and plugins are **untouched**. The collection's own machinery (observers, watch-list, delayed-destroy, `*uploadList`) moves in M3b.

## Green gate
- `tsc:app` ✅
- `test:specs` — 361 passed (rewrote `TypedData.test` for the registry; added `getByUid`/`snapshot`/per-key/destroy cases) ✅
- `test:locales` ✅
- `build` (attw / publint / size-limit) ✅ — bundle sizes unchanged
- `test:e2e` — 187/187 ✅ (incl. upload / validation / api / file-uploader flows)
- `lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added snapshot functionality to capture current state values
  * Subscribe callbacks now return explicit unsubscribe functions for cleaner cleanup

* **Bug Fixes**
  * Enhanced error isolation: subscriber exceptions no longer prevent other subscribers from receiving updates
  * Added warning logs when subscribers throw errors
<!-- end of auto-generated comment: release notes by coderabbit.ai -->