### PR TITLE
test: backfill coverage for v2 strangler controllers + facade

### DIFF
--- a/src/abstract/EventBus.test.ts
+++ b/src/abstract/EventBus.test.ts
@@ -83,4 +83,55 @@ describe('EventBus', () => {
 
     expect(handler).not.toHaveBeenCalled();
   });
+
+  it('emit is a no-op for a type with no listeners', () => {
+    const bus = new EventBus();
+    expect(() => bus.emit(UploaderEventType.UPLOAD_CLICK, undefined)).not.toThrow();
+  });
+
+  it('drops the listener set on full unsubscribe and re-subscribes cleanly', () => {
+    const bus = new EventBus();
+    const first = vi.fn();
+    const off = bus.on(UploaderEventType.UPLOAD_CLICK, first);
+    off(); // last listener removed → backing Set is deleted
+
+    const second = vi.fn();
+    bus.on(UploaderEventType.UPLOAD_CLICK, second);
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+
+  it('isolates a throwing payload thunk in emitDebounced', () => {
+    vi.useFakeTimers();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bus = new EventBus();
+    const handler = vi.fn();
+    bus.on(UploaderEventType.UPLOAD_CLICK, handler);
+
+    bus.emitDebounced(
+      UploaderEventType.UPLOAD_CLICK,
+      () => {
+        throw new Error('thunk boom');
+      },
+      10,
+    );
+
+    expect(() => vi.advanceTimersByTime(10)).not.toThrow();
+    expect(handler).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('onAny returns an unsubscribe that stops delivery', () => {
+    const bus = new EventBus();
+    const any = vi.fn();
+    const off = bus.onAny(any);
+
+    off();
+    bus.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+    expect(any).not.toHaveBeenCalled();
+  });
 });

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -137,4 +137,18 @@ describe('TypedData', () => {
     ctx.destroy();
     expect(TypedData.getByUid(id)).toBeNull();
   });
+
+  it('warns when reading an unknown property and returns undefined', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = new TypedData<{ a: number }>({ a: 1 });
+
+    // biome-ignore lint/suspicious/noExplicitAny: exercising the unknown-key read guard
+    const value = ctx.getValue('missing' as any);
+
+    expect(value).toBeUndefined();
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/\[Typed State\] Wrong property name:/));
+
+    ctx.destroy();
+    warn.mockRestore();
+  });
 });

--- a/src/abstract/controllers/ConfigController.test.ts
+++ b/src/abstract/controllers/ConfigController.test.ts
@@ -103,4 +103,35 @@ describe('ConfigController', () => {
     config.setCustom('unsplashApiKey', 'y');
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it('values exposes the live config object reflecting writes', () => {
+    const config = new ConfigController();
+    expect(config.values.multiple).toBe(initialConfig.multiple);
+
+    config.set('multiple', false);
+    expect(config.values.multiple).toBe(false);
+  });
+
+  it('customDefinition returns the registered definition (or undefined)', () => {
+    const config = new ConfigController();
+    const def = { name: 'unsplashApiKey', defaultValue: 'x', normalize: (v: unknown) => String(v) };
+    config.register(def);
+
+    expect(config.customDefinition('unsplashApiKey')).toBe(def);
+    expect(config.customDefinition('not-registered')).toBeUndefined();
+  });
+
+  it('setCustom does not notify when the value is unchanged', () => {
+    const config = new ConfigController();
+    config.setCustom('unsplashApiKey', 'v');
+
+    const listener = vi.fn();
+    config.subscribe(listener);
+
+    config.setCustom('unsplashApiKey', 'v'); // unchanged → no notify
+    expect(listener).not.toHaveBeenCalled();
+
+    config.setCustom('unsplashApiKey', 'w'); // changed → notify
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/abstract/controllers/LocaleController.test.ts
+++ b/src/abstract/controllers/LocaleController.test.ts
@@ -62,4 +62,12 @@ describe('LocaleController', () => {
     locale.set('upload', 'Upload');
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it('values exposes the stored dictionary reflecting writes', () => {
+    const locale = new LocaleController();
+    expect(Object.keys(locale.values)).toEqual([]);
+
+    locale.set('upload', 'Upload');
+    expect(locale.values.upload).toBe('Upload');
+  });
 });

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -181,3 +181,68 @@ describe('PubSub locale (*l10n/*) facade', () => {
     warn.mockRestore();
   });
 });
+
+describe('PubSub (additional coverage)', () => {
+  it('pub routes a locale key to the controller', () => {
+    const ctx = freshCtx();
+    ctx.pub('*l10n/upload', 'Upload');
+    expect(ctx.read('*l10n/upload')).toBe('Upload');
+  });
+
+  it('read warns for an unknown config key', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = freshCtx();
+
+    ctx.read('*cfg/totallyUnknownKey');
+
+    expect(warn).toHaveBeenCalledWith('PubSub#read: Key "*cfg/totallyUnknownKey" not found');
+    warn.mockRestore();
+  });
+
+  it('add for a non-facade key is first-write-wins and rewrites only on rewrite', () => {
+    const ctx = freshCtx();
+    ctx.add('extra', 'one');
+    expect(ctx.read('extra')).toBe('one');
+
+    ctx.add('extra', 'two'); // exists, no rewrite — kept
+    expect(ctx.read('extra')).toBe('one');
+
+    ctx.add('extra', 'two', true); // rewrite
+    expect(ctx.read('extra')).toBe('two');
+  });
+
+  it('pub warns for an unknown non-facade key', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const ctx = freshCtx();
+
+    ctx.pub('missingKey', 'v');
+
+    expect(warn).toHaveBeenCalledWith('PubSub#pub: Key "missingKey" not found');
+    warn.mockRestore();
+  });
+
+  it('has() routes namespaces and falls back to the nanostores store', () => {
+    const ctx = freshCtx();
+    expect(ctx.has('plain')).toBe(true); // non-facade key present in the store
+    expect(ctx.has('absent')).toBe(false);
+  });
+
+  it('registerCtx throws on a duplicate ctx id', () => {
+    const ctx = freshCtx();
+    expect(() => PubSub.registerCtx({}, ctx.id)).toThrow(/already exists/);
+  });
+
+  it('getCtx returns null for an unknown ctx; hasCtx reflects existence', () => {
+    const ctx = freshCtx();
+    expect(PubSub.getCtx('does-not-exist')).toBeNull();
+    expect(PubSub.hasCtx(ctx.id)).toBe(true);
+    expect(PubSub.hasCtx('does-not-exist')).toBe(false);
+  });
+
+  it('deleteCtx is a no-op for the controller when none was created', () => {
+    const ctx = freshCtx();
+    // Never touched a *cfg/ or *l10n/ key, so no UploaderController exists.
+    expect(() => PubSub.deleteCtx(ctx.id)).not.toThrow();
+    expect(PubSub.hasCtx(ctx.id)).toBe(false);
+  });
+});


### PR DESCRIPTION
Precursor to M3b: solidify unit coverage on the strangler-touched code before extending it.

> **Stacked on #988 (M3a).** Purely additive tests — **no existing test case was modified** (169 insertions, 0 deletions). New cases were merged into the existing spec files.

## Coverage before → after (statements)
| File | Before | After |
|------|--------|-------|
| `EventBus.ts` | 92.9% | **100%** |
| `TypedData.ts` | 97.4% | **100%** |
| `ConfigController.ts` | 90.3% | **100%** |
| `LocaleController.ts` | 91.7% | **100%** |
| `PubSubCompat.ts` | 92.5% | **100%** |
| `UploaderRegistry.ts` / `UploaderController.ts` / `host-subscription.ts` | 100% | 100% |

## New cases (behavioural, not padding)
- **EventBus**: empty-set cleanup on full unsubscribe; emit no-op with no listeners; throwing-thunk isolation in `emitDebounced`; `onAny` unsubscribe.
- **TypedData**: `getValue` unknown-property warning.
- **ConfigController**: `values` getter; `customDefinition`; `setCustom` dedup.
- **LocaleController**: `values` getter.
- **PubSubCompat**: `pub`→locale; `read` warning for unknown config key; non-facade `add` (first-write-wins + rewrite); `pub` warning for unknown key; `has()` store fallback; `registerCtx` duplicate throw; `getCtx` null; `hasCtx`; `deleteCtx` with no controller.

## Gate
`tsc:app` · `test:specs` (all green) · `lint`. Test-only change (no source touched), so e2e is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test cases for event handling operations, data property access, configuration management, locale settings, and pub/sub messaging to strengthen overall system reliability and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->