### PR TITLE
feat(events): collection→events derivation controller (M5b)

### DIFF
--- a/src/abstract/EventBus.ts
+++ b/src/abstract/EventBus.ts
@@ -1,10 +1,11 @@
-import type { UploadcareGroup } from '@uploadcare/upload-client';
+import type { ActivityType } from '../lit/activity-constants';
 import type { OutputCollectionState, OutputFileEntry } from '../types/exported';
 
 /**
- * v2 event surface. Mirrors v1's `EventType` from
- * `src/blocks/UploadCtxProvider/EventEmitter.ts` so consumers can swap
- * v1 → v2 without touching their event handlers.
+ * Canonical event surface for the whole library. `EventEmitter`
+ * (`src/blocks/UploadCtxProvider/EventEmitter.ts`) re-exports these as the
+ * documented `EventType`/`EventPayload`, so there is a single source of truth —
+ * the v1 and v2 names cannot drift apart.
  */
 export const UploaderEventType = Object.freeze({
   FILE_ADDED: 'file-added',
@@ -43,22 +44,9 @@ export type UploaderEventPayload = {
   'file-upload-failed': OutputFileEntry<'failed'>;
   'file-url-changed': OutputFileEntry<'success'>;
 
-  /**
-   * `modalId` is the v1 name for the modal/activity. `activity` is the v2
-   * name. Both fields carry the same value; consumers may use either.
-   */
-  'modal-open': { activity: string; modalId: string };
-  /**
-   * `modalId` is the v1 name; `activity` is the v2 equivalent (both null
-   * after a close). `hasActiveModals` is v1-compat — always `false` in v2
-   * since the router has a single foreground slot that just closed.
-   */
-  'modal-close': {
-    activity: string | null;
-    modalId: string | null;
-    hasActiveModals: boolean;
-  };
-  'activity-change': { activity: string | null };
+  'modal-open': { modalId: ActivityType };
+  'modal-close': { modalId: ActivityType; hasActiveModals: boolean };
+  'activity-change': { activity: ActivityType };
 
   'upload-click': undefined;
   'done-click': OutputCollectionState;
@@ -69,7 +57,7 @@ export type UploaderEventPayload = {
   'common-upload-failed': OutputCollectionState<'failed'>;
 
   change: OutputCollectionState;
-  'group-created': OutputCollectionState<'success', 'has-group'> & { groupInfo: UploadcareGroup };
+  'group-created': OutputCollectionState<'success', 'has-group'>;
 };
 
 /**

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -453,6 +453,27 @@ describe('UploadEventsController', () => {
       expect(t.emit).toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
     });
 
+    it('does not finalize the group if the controller is unobserved mid-flight', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockImplementation(async () => {
+        t.controller.unobserve(); // host disconnects while the group upload is in-flight
+        return { uuid: 'group~1' } as UploadcareGroup;
+      });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
     it('aborts group creation if the collection state changed mid-flight', async () => {
       const state = makeState({
         totalCount: 1,

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -1,0 +1,506 @@
+import type { FileFromOptions, UploadcareGroup } from '@uploadcare/upload-client';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState, OutputFileEntry } from '../../types';
+import { UploaderEventType } from '../EventBus';
+import type { TypedData } from '../TypedData';
+import type { UploadEntryData } from '../uploadEntrySchema';
+import { ConfigController } from './ConfigController';
+import type { CollectionObserver, PropertyObserver } from './UploadCollectionController';
+import { UploadCollectionController } from './UploadCollectionController';
+import { UploadEventsController, type UploadEventsControllerDeps } from './UploadEventsController';
+import type { ValidationController } from './ValidationController';
+
+vi.mock('@uploadcare/upload-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@uploadcare/upload-client')>();
+  return { ...actual, uploadFileGroup: vi.fn() };
+});
+
+import { uploadFileGroup } from '@uploadcare/upload-client';
+
+const mockUploadFileGroup = vi.mocked(uploadFileGroup);
+
+type Entry = TypedData<UploadEntryData>;
+
+const makeState = (overrides: Partial<OutputCollectionState> = {}): OutputCollectionState =>
+  ({ totalCount: 0, status: 'idle', allEntries: [], ...overrides }) as OutputCollectionState;
+
+const setup = (opts: { collectionState?: OutputCollectionState; outputDataLength?: number } = {}) => {
+  const collection = new UploadCollectionController();
+  const validation = {
+    runFileValidators: vi.fn(),
+    runCollectionValidators: vi.fn(),
+    cleanupValidationForEntry: vi.fn(),
+  } as unknown as ValidationController;
+
+  // Invoke thunk payloads like the real emit does, so deferred-payload bodies run.
+  const emit = vi.fn((_type: unknown, payload?: unknown) => {
+    if (typeof payload === 'function') (payload as () => unknown)();
+  }) as Mock & UploadEventsControllerDeps['emit'];
+  const uploadTriggerSet = new Set<Uid>();
+  let collectionState = opts.collectionState ?? makeState();
+  let commonProgress = 0;
+  const collectionErrors: never[] = [];
+
+  // Capture the observer callbacks so tests invoke the handlers directly with
+  // controlled (entries, added, removed) / changeMap — no collection debounce.
+  let collectionObserver: CollectionObserver = () => {};
+  let propertyObserver: PropertyObserver = () => {};
+  vi.spyOn(collection, 'observeCollection').mockImplementation((cb) => {
+    collectionObserver = cb;
+    return () => {};
+  });
+  vi.spyOn(collection, 'observeProperties').mockImplementation((cb) => {
+    propertyObserver = cb;
+    return () => {};
+  });
+
+  const config = new ConfigController();
+
+  const deps: UploadEventsControllerDeps = {
+    collection,
+    config,
+    validation,
+    emit,
+    getOutputItem: ((uid: Uid) => ({ internalId: uid })) as unknown as UploadEventsControllerDeps['getOutputItem'],
+    getOutputCollectionState: () => collectionState,
+    getOutputData: () => new Array(opts.outputDataLength ?? collection.size).fill(0) as OutputFileEntry[],
+    buildUploadOptions: vi.fn(async () => ({}) as FileFromOptions),
+    runOnAddHooks: vi.fn(),
+    applyInitialCrop: vi.fn(),
+    uploadTrigger: () => uploadTriggerSet,
+    setUploadList: vi.fn(),
+    getCollectionState: () => collectionState,
+    setCollectionState: vi.fn((s) => {
+      collectionState = s ?? makeState();
+    }),
+    getCommonProgress: () => commonProgress,
+    setCommonProgress: vi.fn((p) => {
+      commonProgress = p;
+    }),
+    setGroupInfo: vi.fn(),
+    getCollectionErrors: () => collectionErrors,
+  };
+
+  const controller = new UploadEventsController(deps);
+  controller.observe();
+
+  return {
+    controller,
+    collection,
+    config,
+    deps,
+    emit,
+    uploadTriggerSet,
+    fireCollection: (entries: Uid[], added: Set<Entry>, removed: Set<Entry>) =>
+      collectionObserver(entries, added, removed),
+    fireProperties: (changeMap: Parameters<PropertyObserver>[0]) => propertyObserver(changeMap),
+    setCollectionStateValue: (s: OutputCollectionState) => {
+      collectionState = s;
+    },
+  };
+};
+
+const entriesByUid = (collection: UploadCollectionController, uids: Uid[]) =>
+  new Set(uids.map((id) => collection.read(id)).filter((e): e is Entry => !!e));
+
+describe('UploadEventsController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUploadFileGroup.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('collection add/remove', () => {
+    it('emits FILE_ADDED (non-silent), runs add validators + onAdd hooks, clears groupInfo, sets uploadList', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith(null);
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('add', [id]);
+      expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
+      expect(t.deps.validation.runCollectionValidators).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_ADDED, expect.objectContaining({ internalId: id }));
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+    });
+
+    it('suppresses FILE_ADDED for a silent entry (but still runs onAdd hooks)', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', silent: true });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_ADDED, expect.anything());
+      expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
+    });
+
+    it('on remove: aborts, marks removed, revokes thumbUrl, cleans validation, emits FILE_REMOVED', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', thumbUrl: 'blob:xyz' });
+      const entry = t.collection.read(id) as Entry;
+      const ac = new AbortController();
+      const abortSpy = vi.spyOn(ac, 'abort');
+      entry.setValue('abortController', ac);
+      t.uploadTriggerSet.add(id);
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      t.fireCollection([], new Set(), new Set([entry]));
+
+      expect(t.uploadTriggerSet.has(id)).toBe(false);
+      expect(t.deps.validation.cleanupValidationForEntry).toHaveBeenCalledWith(entry);
+      expect(abortSpy).toHaveBeenCalled();
+      expect(entry.getValue('isRemoved')).toBe(true);
+      expect(revokeSpy).toHaveBeenCalledWith('blob:xyz');
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.objectContaining({ internalId: id }));
+    });
+
+    it('does nothing once unobserved (inactive guard)', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.controller.unobserve();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not reset groupInfo when the update has no adds or removes', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], new Set(), new Set());
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalled();
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+    });
+
+    it('destroy() stops the controller', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.controller.destroy();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+
+    it('handles a removed entry without a thumbUrl', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' }); // no thumbUrl
+      const entry = t.collection.read(id) as Entry;
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      t.fireCollection([], new Set(), new Set([entry]));
+
+      expect(revokeSpy).not.toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.anything());
+    });
+  });
+
+  describe('property updates → events', () => {
+    const addUploadingEntry = (t: ReturnType<typeof setup>, init: Partial<UploadEntryData> = {}) => {
+      const id = t.collection.add({ fileName: 'a.txt', isUploading: true, ...init });
+      return id;
+    };
+
+    it('emits FILE_UPLOAD_PROGRESS for uploading non-silent entries + flushes common progress', () => {
+      const t = setup();
+      const id = addUploadingEntry(t);
+      t.uploadTriggerSet.add(id);
+      t.collection.publishProp(id, 'uploadProgress', 50);
+
+      t.fireProperties({ uploadProgress: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_PROGRESS,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.setCommonProgress).toHaveBeenCalled();
+    });
+
+    it('emits FILE_UPLOAD_START only for uploading + non-silent', () => {
+      const t = setup();
+      const uploading = addUploadingEntry(t);
+      const silent = t.collection.add({ isUploading: true, silent: true });
+
+      t.fireProperties({ isUploading: new Set([uploading, silent]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_START,
+        expect.objectContaining({ internalId: uploading }),
+      );
+      expect(t.emit).not.toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_START,
+        expect.objectContaining({ internalId: silent }),
+      );
+    });
+
+    it('emits FILE_UPLOAD_SUCCESS for entries with fileInfo and applies crop when cropPreset set', () => {
+      const t = setup();
+      t.config.set('cropPreset', '1:1');
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_SUCCESS,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.applyInitialCrop).toHaveBeenCalled();
+    });
+
+    it('emits FILE_UPLOAD_FAILED + debounced COMMON_UPLOAD_FAILED for errored entries', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'errors', [{ type: 'X', message: 'm' }] as never);
+
+      t.fireProperties({ errors: new Set([id]) });
+
+      expect(t.deps.validation.runCollectionValidators).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_FAILED,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_FAILED, expect.any(Function), {
+        debounce: true,
+      });
+    });
+
+    it('emits COMMON_UPLOAD_SUCCESS when all entries are loaded with no errors', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+      // errors changeMap with an entry that has no errors → triggers the success check
+      t.fireProperties({ errors: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_SUCCESS, expect.anything());
+    });
+
+    it('emits FILE_URL_CHANGED for entries that now have a cdnUrl and clears groupInfo', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'cdnUrl', 'https://cdn/u1/');
+
+      t.fireProperties({ cdnUrl: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_URL_CHANGED,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith(null);
+    });
+
+    it('schedules deferred validation for watched-key changes', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('upload', [id]);
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('change', [id]);
+    });
+
+    it('does not emit FILE_UPLOAD_PROGRESS for a non-uploading entry', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: false });
+      t.uploadTriggerSet.add(id);
+      t.collection.publishProp(id, 'uploadProgress', 50);
+
+      t.fireProperties({ uploadProgress: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_PROGRESS, expect.anything());
+    });
+
+    it('does not apply crop when no cropPreset is configured', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.deps.applyInitialCrop).not.toHaveBeenCalled();
+    });
+
+    it('skips FILE_URL_CHANGED for entries that still lack a cdnUrl', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' }); // no cdnUrl set
+
+      t.fireProperties({ cdnUrl: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_URL_CHANGED, expect.anything());
+    });
+
+    it('suppresses FILE_UPLOAD_SUCCESS for a silent entry with fileInfo', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', silent: true });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_SUCCESS, expect.anything());
+    });
+
+    it('skips changeMap ids that have no backing entry (stale uids)', () => {
+      const t = setup();
+      const ghost = 'ghost' as Uid;
+
+      expect(() =>
+        t.fireProperties({
+          uploadProgress: new Set([ghost]),
+          isUploading: new Set([ghost]),
+          fileInfo: new Set([ghost]),
+          errors: new Set([ghost]),
+        }),
+      ).not.toThrow();
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_START, expect.anything());
+    });
+
+    it('defers only "change" validators for a non-fileInfo watched-key change', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireProperties({ cdnUrl: new Set([id]) }); // watched key, but not fileInfo
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('change', [id]);
+      expect(t.deps.validation.runFileValidators).not.toHaveBeenCalledWith('upload', expect.anything());
+    });
+
+    it('skips deferred validation if unobserved before the microtask fires', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+      t.controller.unobserve();
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).not.toHaveBeenCalledWith('change', expect.anything());
+    });
+
+    it('ignores a non-numeric uploadProgress when averaging', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: true });
+      t.collection.read(id)?.setValue('uploadProgress', 'oops' as never);
+      t.uploadTriggerSet.add(id);
+
+      expect(() => t.fireProperties({ uploadProgress: new Set([id]) })).not.toThrow();
+    });
+
+    it('tolerates an undefined changeMap value for a watched key', () => {
+      const t = setup();
+      expect(() => t.fireProperties({ file: undefined } as never)).not.toThrow();
+    });
+
+    it('does nothing once unobserved (inactive guard)', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: true });
+      t.controller.unobserve();
+
+      t.fireProperties({ isUploading: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('output flush + group', () => {
+    it('flushes collection state + emits CHANGE when output data matches collection size', () => {
+      const t = setup({ collectionState: makeState({ totalCount: 1, status: 'idle' }), outputDataLength: 1 });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      vi.advanceTimersByTime(300);
+
+      expect(t.deps.setCollectionState).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.CHANGE, expect.any(Function), { debounce: true });
+    });
+
+    it('skips flush when output data length does not match the collection size', () => {
+      const t = setup({ outputDataLength: 0 });
+      const id = t.collection.add({ fileName: 'a.txt' }); // size 1, output 0
+      (t.deps.setCollectionState as Mock).mockClear();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      vi.advanceTimersByTime(300);
+
+      expect(t.deps.setCollectionState).not.toHaveBeenCalled();
+    });
+
+    it('creates a group when groupOutput is on and the collection is fully successful', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '-/preview/' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockResolvedValue({ uuid: 'group~1' } as UploadcareGroup);
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(mockUploadFileGroup).toHaveBeenCalled();
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
+    it('aborts group creation if the collection state changed mid-flight', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockImplementation(async () => {
+        t.setCollectionStateValue(makeState({ totalCount: 2, status: 'success' })); // race: state replaced
+        return { uuid: 'group~1' } as UploadcareGroup;
+      });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+  });
+
+  describe('common upload progress', () => {
+    it('averages trigger-entry progress and emits COMMON_UPLOAD_PROGRESS on change', () => {
+      const t = setup();
+      const a = t.collection.add({ isUploading: true });
+      const b = t.collection.add({ isUploading: true });
+      t.collection.publishProp(a, 'uploadProgress', 40);
+      t.collection.publishProp(b, 'uploadProgress', 60);
+      t.uploadTriggerSet.add(a);
+      t.uploadTriggerSet.add(b);
+
+      t.fireProperties({ uploadProgress: new Set([a, b]) });
+
+      expect(t.deps.setCommonProgress).toHaveBeenCalledWith(50);
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_PROGRESS, expect.anything());
+    });
+
+    it('does not re-emit when the rounded progress is unchanged', () => {
+      const t = setup();
+      const a = t.collection.add({ isUploading: true });
+      t.collection.publishProp(a, 'uploadProgress', 0);
+      t.uploadTriggerSet.add(a);
+
+      // common progress starts at 0; an all-zero average stays 0 → no emit
+      t.fireProperties({ uploadProgress: new Set([a]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_PROGRESS, expect.anything());
+    });
+  });
+});

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -1,0 +1,309 @@
+import { type FileFromOptions, type UploadcareGroup, uploadFileGroup } from '@uploadcare/upload-client';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState, OutputErrorCollection, OutputFileEntry, OutputFileStatus } from '../../types';
+import { debounce } from '../../utils/debounce';
+import { type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../EventBus';
+import { TypedData } from '../TypedData';
+import type { UploadEntryData } from '../uploadEntrySchema';
+import type { ConfigController } from './ConfigController';
+import type {
+  CollectionObserver,
+  UploadCollectionChangeMap,
+  UploadCollectionController,
+} from './UploadCollectionController';
+import type { ValidationController } from './ValidationController';
+
+type Unsubscribe = () => void;
+
+/** Emit on the event backbone (telemetry-augmented `LitBlock.emit`). */
+type EmitFn = <T extends UploaderEventKey>(
+  type: T,
+  payload?: UploaderEventPayload[T] | (() => UploaderEventPayload[T]),
+  options?: { debounce?: boolean | number },
+) => void;
+
+export type UploadEventsControllerDeps = {
+  collection: UploadCollectionController;
+  config: ConfigController;
+  validation: ValidationController;
+  emit: EmitFn;
+  getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => OutputFileEntry<TStatus>;
+  getOutputCollectionState: () => OutputCollectionState;
+  getOutputData: () => OutputFileEntry[];
+  /** Base upload-client options for the grouped upload (from `UploadController`). */
+  buildUploadOptions: () => Promise<FileFromOptions>;
+  /** Run plugin `onAdd` hooks for a freshly-added entry. */
+  runOnAddHooks: (entry: TypedData<UploadEntryData>) => void;
+  /** Apply the `cropPreset` to freshly-uploaded images (lives in the UI layer). */
+  applyInitialCrop: () => void;
+
+  // ─── v1 shared-state bridge (`*`-keys via the `$` proxy) ───
+  /** The live `*uploadTrigger` set (mutated in place on remove). */
+  uploadTrigger: () => Set<Uid>;
+  setUploadList: (list: { uid: Uid }[]) => void;
+  getCollectionState: () => OutputCollectionState | null;
+  setCollectionState: (state: OutputCollectionState | null) => void;
+  getCommonProgress: () => number;
+  setCommonProgress: (progress: number) => void;
+  setGroupInfo: (group: UploadcareGroup | null) => void;
+  getCollectionErrors: () => OutputErrorCollection[];
+};
+
+const VALIDATION_TRIGGER_KEYS: (keyof UploadEntryData)[] = [
+  'file',
+  'uploadError',
+  'fileInfo',
+  'cdnUrl',
+  'cdnUrlModifiers',
+];
+
+/**
+ * DOM-free upload-events engine — the collection→events derivation that v1 ran
+ * inline in `LitUploaderBlock` (`_handleCollectionUpdate` /
+ * `_handleCollectionPropertiesUpdate` / `_flushOutputItems` /
+ * `_flushCommonUploadProgress` / `_createGroup`).
+ *
+ * It observes the upload collection and, as entries are added/removed and their
+ * properties change, drives validation, emits the documented events (via the
+ * injected telemetry-augmented `emit`, which reaches the EventBus), maintains
+ * the derived `*uploadList`/`*collectionState`/`*commonProgress`/`*groupInfo`
+ * shared state through injected sinks, and creates the output group. All
+ * collaborators are injected, so it runs without a DOM and is unit-testable.
+ */
+export class UploadEventsController {
+  private _deps: UploadEventsControllerDeps;
+  // Active while observing (the v1 `isConnected` guard) — survives disconnect/
+  // reconnect cycles; gates the debounced flush + deferred validation that may
+  // fire after the host disconnects.
+  private _active = false;
+  private _unobserveCollection?: Unsubscribe;
+  private _unobserveProperties?: Unsubscribe;
+
+  public constructor(deps: UploadEventsControllerDeps) {
+    this._deps = deps;
+  }
+
+  /** Start observing the collection. Idempotent. */
+  public observe(): void {
+    this.unobserve();
+    this._active = true;
+    this._unobserveCollection = this._deps.collection.observeCollection(this._handleCollectionUpdate);
+    this._unobserveProperties = this._deps.collection.observeProperties(this._handleCollectionPropertiesUpdate);
+  }
+
+  public unobserve(): void {
+    this._active = false;
+    this._unobserveProperties?.();
+    this._unobserveCollection?.();
+    this._unobserveProperties = undefined;
+    this._unobserveCollection = undefined;
+    this._flushOutputItems.cancel();
+  }
+
+  /** Final teardown — alias for {@link unobserve}. */
+  public destroy(): void {
+    this.unobserve();
+  }
+
+  private _handleCollectionUpdate: CollectionObserver = (entries, added, removed) => {
+    if (!this._active) return;
+    const { validation, emit, getOutputItem } = this._deps;
+
+    if (added.size || removed.size) {
+      this._deps.setGroupInfo(null);
+    }
+
+    validation.runFileValidators(
+      'add',
+      [...added].map((e) => e.uid),
+    );
+
+    for (const entry of added) {
+      if (!entry.getValue('silent')) {
+        emit(UploaderEventType.FILE_ADDED, getOutputItem(entry.uid));
+      }
+      this._deps.runOnAddHooks(entry);
+    }
+
+    validation.runCollectionValidators();
+
+    for (const entry of removed) {
+      this._deps.uploadTrigger().delete(entry.uid);
+
+      validation.cleanupValidationForEntry(entry);
+      entry.getValue('abortController')?.abort();
+      entry.setMultipleValues({
+        isRemoved: true,
+        abortController: null,
+        isUploading: false,
+        uploadProgress: 0,
+      });
+      const thumbUrl = entry?.getValue('thumbUrl');
+      thumbUrl && URL.revokeObjectURL(thumbUrl);
+      emit(UploaderEventType.FILE_REMOVED, getOutputItem(entry.uid));
+    }
+
+    this._deps.setUploadList(entries.map((uid) => ({ uid })));
+
+    this._flushCommonUploadProgress();
+    this._flushOutputItems();
+  };
+
+  private _handleCollectionPropertiesUpdate = (changeMap: UploadCollectionChangeMap): void => {
+    if (!this._active) return;
+    const { collection, config, validation, emit, getOutputItem, getOutputCollectionState } = this._deps;
+
+    this._flushOutputItems();
+
+    const entriesToRunValidation = [
+      ...new Set(
+        Object.entries(changeMap)
+          .filter(([key]) => VALIDATION_TRIGGER_KEYS.includes(key as keyof UploadEntryData))
+          .flatMap(([, ids]) => [...(ids ?? [])]),
+      ),
+    ];
+
+    entriesToRunValidation.length > 0 &&
+      setTimeout(() => {
+        if (!this._active) return;
+        // We can't modify entry properties in the same tick, so we need to wait a bit
+        const entriesToRunOnUpload = entriesToRunValidation.filter(
+          (entryId) =>
+            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
+        );
+        if (entriesToRunOnUpload.length > 0) {
+          validation.runFileValidators('upload', entriesToRunOnUpload);
+        }
+        validation.runFileValidators('change', entriesToRunValidation);
+      });
+
+    if (changeMap.uploadProgress) {
+      for (const entryId of changeMap.uploadProgress) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
+        if (isUploading && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_PROGRESS, getOutputItem(entryId));
+        }
+      }
+
+      this._flushCommonUploadProgress();
+    }
+    if (changeMap.isUploading) {
+      for (const entryId of changeMap.isUploading) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
+        if (isUploading && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_START, getOutputItem(entryId));
+        }
+      }
+    }
+    if (changeMap.fileInfo) {
+      for (const entryId of changeMap.fileInfo) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { fileInfo, silent } = entry.snapshot();
+        if (fileInfo && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_SUCCESS, getOutputItem(entryId));
+        }
+      }
+      if (config.get('cropPreset')) {
+        this._deps.applyInitialCrop();
+      }
+    }
+    if (changeMap.errors) {
+      validation.runCollectionValidators();
+
+      for (const entryId of changeMap.errors) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { errors } = entry.snapshot();
+        if (errors.length > 0) {
+          emit(UploaderEventType.FILE_UPLOAD_FAILED, getOutputItem(entryId));
+          emit(
+            UploaderEventType.COMMON_UPLOAD_FAILED,
+            () => getOutputCollectionState() as OutputCollectionState<'failed'>,
+            { debounce: true },
+          );
+        }
+      }
+      const loadedItems = collection.findItems((entry) => !!entry.getValue('fileInfo'));
+      const errorItems = collection.findItems((entry) => entry.getValue('errors').length > 0);
+      if (
+        collection.size > 0 &&
+        errorItems.length === 0 &&
+        collection.size === loadedItems.length &&
+        this._deps.getCollectionErrors().length === 0
+      ) {
+        emit(UploaderEventType.COMMON_UPLOAD_SUCCESS, getOutputCollectionState() as OutputCollectionState<'success'>);
+      }
+    }
+    if (changeMap.cdnUrl) {
+      const uids = [...changeMap.cdnUrl].filter((uid) => !!collection.read(uid)?.getValue('cdnUrl'));
+      uids.forEach((uid) => {
+        emit(UploaderEventType.FILE_URL_CHANGED, getOutputItem(uid));
+      });
+
+      this._deps.setGroupInfo(null);
+    }
+  };
+
+  private _flushOutputItems = debounce(async () => {
+    const { collection, config, emit, getOutputCollectionState, getOutputData, setCollectionState } = this._deps;
+    const data = getOutputData();
+    if (data.length !== collection.size) {
+      return;
+    }
+    const collectionState = getOutputCollectionState();
+    setCollectionState(collectionState);
+    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+
+    if (config.get('groupOutput') && collectionState.totalCount > 0 && collectionState.status === 'success') {
+      this._createGroup(collectionState);
+    }
+  }, 300);
+
+  private async _createGroup(collectionState: OutputCollectionState): Promise<void> {
+    const { emit, getOutputCollectionState, getCollectionState, setCollectionState, setGroupInfo, buildUploadOptions } =
+      this._deps;
+    const uploadClientOptions = await buildUploadOptions();
+    const uuidList = collectionState.allEntries.map((entry) => {
+      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
+    });
+    const abortController = new AbortController();
+    const resp = await uploadFileGroup(uuidList, {
+      ...uploadClientOptions,
+      signal: abortController.signal,
+    });
+    if (getCollectionState() !== collectionState) {
+      abortController.abort();
+      return;
+    }
+    setGroupInfo(resp);
+    const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
+    emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
+    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+    setCollectionState(collectionStateWithGroup);
+  }
+
+  private _flushCommonUploadProgress = (): void => {
+    const { collection, emit, getOutputCollectionState, getCommonProgress, setCommonProgress } = this._deps;
+    let commonProgress = 0;
+    const items = [...this._deps.uploadTrigger()].filter((id) => !!collection.read(id));
+    items.forEach((id) => {
+      const uploadProgress = collection.readProp(id, 'uploadProgress');
+      if (typeof uploadProgress === 'number') {
+        commonProgress += uploadProgress;
+      }
+    });
+    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
+
+    if (getCommonProgress() === progress) {
+      return;
+    }
+
+    setCommonProgress(progress);
+    emit(UploaderEventType.COMMON_UPLOAD_PROGRESS, getOutputCollectionState() as OutputCollectionState<'uploading'>);
+  };
+}

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -276,7 +276,10 @@ export class UploadEventsController {
       ...uploadClientOptions,
       signal: abortController.signal,
     });
-    if (getCollectionState() !== collectionState) {
+    // Bail if the controller was unobserved mid-flight (the `_active` check is
+    // new with the controller lifecycle) or the collection state moved on
+    // (mirrors v1).
+    if (!this._active || getCollectionState() !== collectionState) {
       abortController.abort();
       return;
     }

--- a/src/blocks/UploadCtxProvider/EventEmitter.test.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.test.ts
@@ -1,0 +1,89 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventBus } from '../../abstract/EventBus';
+import type { SharedInstancesBag } from '../../lit/shared-instances';
+import type { OutputFileEntry } from '../../types';
+import { EventEmitter, EventType } from './EventEmitter';
+
+// The facade reads `ctx.uploaderController().events`; stub that chain to a real
+// EventBus so we exercise the actual delegation (not a mock of it).
+const setup = () => {
+  const bus = new EventBus();
+  const ctx = { uploaderController: () => ({ events: bus }) };
+  const bag = { ctx } as unknown as SharedInstancesBag;
+  const emitter = new EventEmitter(bag);
+  return { emitter, bus };
+};
+
+const fileEntry = (internalId: string) => ({ internalId }) as unknown as OutputFileEntry<'idle'>;
+
+describe('EventEmitter (EventBus facade)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('delegates on/emit to the bus (immediate, value payload)', () => {
+    const { emitter } = setup();
+    const handler = vi.fn();
+    emitter.on(EventType.FILE_ADDED, handler);
+
+    const payload = fileEntry('a');
+    emitter.emit(EventType.FILE_ADDED, payload);
+
+    expect(handler).toHaveBeenCalledWith(payload);
+  });
+
+  it('resolves a function payload before dispatching (immediate)', () => {
+    const { emitter } = setup();
+    const handler = vi.fn();
+    emitter.on(EventType.FILE_ADDED, handler);
+
+    const payload = fileEntry('b');
+    // A thunk payload is allowed even without debounce; it must be resolved.
+    emitter.emit(EventType.FILE_ADDED, (() => payload) as never);
+
+    expect(handler).toHaveBeenCalledWith(payload);
+  });
+
+  it('debounces with the default 20ms window and coalesces to one dispatch', () => {
+    const { emitter } = setup();
+    const handler = vi.fn();
+    emitter.on(EventType.CHANGE, handler);
+
+    emitter.emit(EventType.CHANGE, () => fileEntry('1') as never, { debounce: true });
+    emitter.emit(EventType.CHANGE, () => fileEntry('2') as never, { debounce: true });
+    expect(handler).not.toHaveBeenCalled();
+
+    vi.advanceTimersByTime(20);
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(expect.objectContaining({ internalId: '2' }));
+  });
+
+  it('honors a numeric debounce window', () => {
+    const { emitter } = setup();
+    const handler = vi.fn();
+    emitter.on(EventType.COMMON_UPLOAD_PROGRESS, handler);
+
+    emitter.emit(EventType.COMMON_UPLOAD_PROGRESS, () => fileEntry('p') as never, { debounce: 100 });
+
+    vi.advanceTimersByTime(50);
+    expect(handler).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(50);
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops notifying after the returned unsubscribe is called', () => {
+    const { emitter } = setup();
+    const handler = vi.fn();
+    const unsubscribe = emitter.on(EventType.FILE_ADDED, handler);
+
+    unsubscribe();
+    emitter.emit(EventType.FILE_ADDED, fileEntry('c'));
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/src/blocks/UploadCtxProvider/EventEmitter.test.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.test.ts
@@ -43,7 +43,7 @@ describe('EventEmitter (EventBus facade)', () => {
 
     const payload = fileEntry('b');
     // A thunk payload is allowed even without debounce; it must be resolved.
-    emitter.emit(EventType.FILE_ADDED, (() => payload) as never);
+    emitter.emit(EventType.FILE_ADDED, () => payload);
 
     expect(handler).toHaveBeenCalledWith(payload);
   });
@@ -51,10 +51,10 @@ describe('EventEmitter (EventBus facade)', () => {
   it('debounces with the default 20ms window and coalesces to one dispatch', () => {
     const { emitter } = setup();
     const handler = vi.fn();
-    emitter.on(EventType.CHANGE, handler);
+    emitter.on(EventType.FILE_ADDED, handler);
 
-    emitter.emit(EventType.CHANGE, () => fileEntry('1') as never, { debounce: true });
-    emitter.emit(EventType.CHANGE, () => fileEntry('2') as never, { debounce: true });
+    emitter.emit(EventType.FILE_ADDED, () => fileEntry('1'), { debounce: true });
+    emitter.emit(EventType.FILE_ADDED, () => fileEntry('2'), { debounce: true });
     expect(handler).not.toHaveBeenCalled();
 
     vi.advanceTimersByTime(20);
@@ -66,9 +66,9 @@ describe('EventEmitter (EventBus facade)', () => {
   it('honors a numeric debounce window', () => {
     const { emitter } = setup();
     const handler = vi.fn();
-    emitter.on(EventType.COMMON_UPLOAD_PROGRESS, handler);
+    emitter.on(EventType.FILE_ADDED, handler);
 
-    emitter.emit(EventType.COMMON_UPLOAD_PROGRESS, () => fileEntry('p') as never, { debounce: 100 });
+    emitter.emit(EventType.FILE_ADDED, () => fileEntry('p'), { debounce: 100 });
 
     vi.advanceTimersByTime(50);
     expect(handler).not.toHaveBeenCalled();

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -1,10 +1,21 @@
 import type { ModalId } from '../../abstract/managers/ModalManager';
 import type { ActivityType } from '../../lit/LitActivityBlock';
-import type { LitBlock } from '../../lit/LitBlock';
 import { SharedInstance } from '../../lit/shared-instances';
 import type { OutputCollectionState, OutputFileEntry } from '../../types';
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 20;
+
+/**
+ * Transport view of the per-ctx `EventBus`. The facade carries the documented
+ * (v1) `EventPayload` shapes through the bus, which types its own richer v2
+ * payloads (`UploaderEventPayload`); the two type views of the same runtime
+ * events are bridged once, here.
+ */
+type EventBusTransport = {
+  on(type: string, handler: (payload: unknown) => void): () => void;
+  emit(type: string, payload: unknown): void;
+  emitDebounced(type: string, payload: () => unknown, ms?: number): void;
+};
 
 export const InternalEventType = Object.freeze({
   INIT_SOLUTION: 'init-solution',
@@ -67,48 +78,21 @@ export type EventPayload = {
   [EventType.GROUP_CREATED]: OutputCollectionState<'success', 'has-group'>;
 };
 
+/**
+ * Facade over the per-ctx DOM-free `EventBus` (`UploaderController.events`).
+ *
+ * `on`/`emit` delegate to the bus; the DOM `CustomEvent` dispatch now lives in
+ * the reactive `EventBridgeController` attached to `<uc-upload-ctx-provider>`.
+ * The public surface (`EventType`/`EventPayload`, debounce, payload thunks,
+ * `api.on`) is unchanged — only the storage/dispatch moved behind the bus.
+ */
 export class EventEmitter extends SharedInstance {
-  private _timeoutStore: Map<string, number> = new Map();
-  private _targets: Set<LitBlock> = new Set();
-  private _listeners: Map<string, Set<(payload: unknown) => void>> = new Map();
-
-  public bindTarget(target: LitBlock) {
-    this._targets.add(target);
-    return () => {
-      this._targets.delete(target);
-    };
+  private get _bus(): EventBusTransport {
+    return this._ctx.uploaderController().events as EventBusTransport;
   }
 
   public on<T extends EventKey>(type: T, handler: (payload: EventPayload[T]) => void): () => void {
-    let listeners = this._listeners.get(type);
-    if (!listeners) {
-      listeners = new Set();
-      this._listeners.set(type, listeners);
-    }
-    listeners.add(handler as (payload: unknown) => void);
-    return () => this._listeners.get(type)?.delete(handler as (payload: unknown) => void);
-  }
-
-  private _dispatch<T extends EventKey>(type: T, payload?: EventPayload[T]): void {
-    for (const target of this._targets) {
-      target.dispatchEvent(
-        new CustomEvent(type, {
-          detail: payload,
-        }),
-      );
-    }
-
-    const listeners = this._listeners.get(type);
-    if (listeners) {
-      for (const handler of listeners) {
-        handler(payload);
-      }
-    }
-
-    this._debugPrint?.(() => {
-      const copyPayload = !!payload && typeof payload === 'object' ? { ...payload } : payload;
-      return [`event "${type}"`, copyPayload];
-    });
+    return this._bus.on(type, handler as (payload: unknown) => void);
   }
 
   public emit<T extends EventKey, TDebounce extends boolean | number | undefined = undefined>(
@@ -117,33 +101,12 @@ export class EventEmitter extends SharedInstance {
     options: { debounce?: TDebounce } = {},
   ): void {
     const { debounce } = options;
+    const resolve = () => (typeof payload === 'function' ? payload() : payload);
     if (typeof debounce !== 'number' && !debounce) {
-      this._dispatch(type, typeof payload === 'function' ? payload() : (payload as EventPayload[T]));
+      this._bus.emit(type, resolve());
       return;
     }
-
-    if (this._timeoutStore.has(type)) {
-      window.clearTimeout(this._timeoutStore.get(type));
-    }
     const timeout = typeof debounce === 'number' ? debounce : DEFAULT_DEBOUNCE_TIMEOUT;
-    const timeoutId = window.setTimeout(() => {
-      try {
-        const data = typeof payload === 'function' ? payload() : (payload as EventPayload[T]);
-        this._dispatch(type, data);
-        this._timeoutStore.delete(type);
-      } catch (error) {
-        this._debugPrint?.(() => `Error while getting payload for event "${type}"`, error);
-      }
-    }, timeout);
-    this._timeoutStore.set(type, timeoutId);
-  }
-
-  public override destroy(): void {
-    for (const timeoutId of this._timeoutStore.values()) {
-      window.clearTimeout(timeoutId);
-    }
-
-    this._targets.clear();
-    this._listeners.clear();
+    this._bus.emitDebounced(type, resolve, timeout);
   }
 }

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -1,21 +1,12 @@
-import type { ModalId } from '../../abstract/managers/ModalManager';
-import type { ActivityType } from '../../lit/LitActivityBlock';
+import {
+  type EventBus,
+  type UploaderEventKey,
+  type UploaderEventPayload,
+  UploaderEventType,
+} from '../../abstract/EventBus';
 import { SharedInstance } from '../../lit/shared-instances';
-import type { OutputCollectionState, OutputFileEntry } from '../../types';
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 20;
-
-/**
- * Transport view of the per-ctx `EventBus`. The facade carries the documented
- * (v1) `EventPayload` shapes through the bus, which types its own richer v2
- * payloads (`UploaderEventPayload`); the two type views of the same runtime
- * events are bridged once, here.
- */
-type EventBusTransport = {
-  on(type: string, handler: (payload: unknown) => void): () => void;
-  emit(type: string, payload: unknown): void;
-  emitDebounced(type: string, payload: () => unknown, ms?: number): void;
-};
 
 export const InternalEventType = Object.freeze({
   INIT_SOLUTION: 'init-solution',
@@ -24,84 +15,45 @@ export const InternalEventType = Object.freeze({
   ERROR_EVENT: 'error-event',
 } as const);
 
-export const EventType = Object.freeze({
-  FILE_ADDED: 'file-added',
-  FILE_REMOVED: 'file-removed',
-  FILE_UPLOAD_START: 'file-upload-start',
-  FILE_UPLOAD_PROGRESS: 'file-upload-progress',
-  FILE_UPLOAD_SUCCESS: 'file-upload-success',
-  FILE_UPLOAD_FAILED: 'file-upload-failed',
-  FILE_URL_CHANGED: 'file-url-changed',
-
-  MODAL_OPEN: 'modal-open',
-  MODAL_CLOSE: 'modal-close',
-  DONE_CLICK: 'done-click',
-  UPLOAD_CLICK: 'upload-click',
-  ACTIVITY_CHANGE: 'activity-change',
-
-  COMMON_UPLOAD_START: 'common-upload-start',
-  COMMON_UPLOAD_PROGRESS: 'common-upload-progress',
-  COMMON_UPLOAD_SUCCESS: 'common-upload-success',
-  COMMON_UPLOAD_FAILED: 'common-upload-failed',
-
-  CHANGE: 'change',
-  GROUP_CREATED: 'group-created',
-} as const);
-
-export type EventKey = (typeof EventType)[keyof typeof EventType];
-
 export type InternalEventKey = (typeof InternalEventType)[keyof typeof InternalEventType];
 
-export type EventPayload = {
-  [EventType.FILE_ADDED]: OutputFileEntry<'idle'>;
-  [EventType.FILE_REMOVED]: OutputFileEntry<'removed'>;
-  [EventType.FILE_UPLOAD_START]: OutputFileEntry<'uploading'>;
-  [EventType.FILE_UPLOAD_PROGRESS]: OutputFileEntry<'uploading'>;
-  [EventType.FILE_UPLOAD_SUCCESS]: OutputFileEntry<'success'>;
-  [EventType.FILE_UPLOAD_FAILED]: OutputFileEntry<'failed'>;
-  [EventType.FILE_URL_CHANGED]: OutputFileEntry<'success'>;
-  [EventType.MODAL_OPEN]: { modalId: ModalId };
-  [EventType.MODAL_CLOSE]: {
-    modalId: ModalId;
-    hasActiveModals: boolean;
-  };
-  [EventType.ACTIVITY_CHANGE]: {
-    activity: ActivityType;
-  };
-  [EventType.UPLOAD_CLICK]: undefined;
-  [EventType.DONE_CLICK]: OutputCollectionState;
-  [EventType.COMMON_UPLOAD_START]: OutputCollectionState<'uploading'>;
-  [EventType.COMMON_UPLOAD_PROGRESS]: OutputCollectionState<'uploading'>;
-  [EventType.COMMON_UPLOAD_SUCCESS]: OutputCollectionState<'success'>;
-  [EventType.COMMON_UPLOAD_FAILED]: OutputCollectionState<'failed'>;
-  [EventType.CHANGE]: OutputCollectionState;
-  [EventType.GROUP_CREATED]: OutputCollectionState<'success', 'has-group'>;
-};
+/**
+ * The documented event surface lives in `EventBus`
+ * (`UploaderEventType`/`UploaderEventPayload`) — the single source of truth. It
+ * is re-exported here under the public `EventType`/`EventPayload`/`EventKey`
+ * names so the documented contract and the bus the facade delegates to cannot
+ * drift apart.
+ */
+export { UploaderEventType as EventType };
+export type { UploaderEventKey as EventKey, UploaderEventPayload as EventPayload };
 
 /**
  * Facade over the per-ctx DOM-free `EventBus` (`UploaderController.events`).
  *
- * `on`/`emit` delegate to the bus; the DOM `CustomEvent` dispatch now lives in
- * the reactive `EventBridgeController` attached to `<uc-upload-ctx-provider>`.
- * The public surface (`EventType`/`EventPayload`, debounce, payload thunks,
- * `api.on`) is unchanged — only the storage/dispatch moved behind the bus.
+ * `on`/`emit` delegate to the bus; the DOM `CustomEvent` dispatch lives in the
+ * reactive `EventBridgeController` attached to `<uc-upload-ctx-provider>`. The
+ * public surface (event types, debounce, payload thunks, `api.on`) is
+ * unchanged — only the storage/dispatch moved behind the bus.
  */
 export class EventEmitter extends SharedInstance {
-  private get _bus(): EventBusTransport {
-    return this._ctx.uploaderController().events as EventBusTransport;
+  private get _bus(): EventBus {
+    return this._ctx.uploaderController().events;
   }
 
-  public on<T extends EventKey>(type: T, handler: (payload: EventPayload[T]) => void): () => void {
-    return this._bus.on(type, handler as (payload: unknown) => void);
+  public on<T extends UploaderEventKey>(type: T, handler: (payload: UploaderEventPayload[T]) => void): () => void {
+    return this._bus.on(type, handler);
   }
 
-  public emit<T extends EventKey, TDebounce extends boolean | number | undefined = undefined>(
+  public emit<T extends UploaderEventKey, TDebounce extends boolean | number | undefined = undefined>(
     type: T,
-    payload?: TDebounce extends false | undefined ? EventPayload[T] : () => EventPayload[T],
+    payload?: TDebounce extends false | undefined ? UploaderEventPayload[T] : () => UploaderEventPayload[T],
     options: { debounce?: TDebounce } = {},
   ): void {
     const { debounce } = options;
-    const resolve = () => (typeof payload === 'function' ? payload() : payload);
+    // The public API permits omitting `payload`, but callers always provide one
+    // for events whose payload isn't `undefined`; assert presence at this single
+    // boundary (mirrors v1's `payload as EventPayload[T]`).
+    const resolve = () => (typeof payload === 'function' ? payload() : payload) as UploaderEventPayload[T];
     if (typeof debounce !== 'number' && !debounce) {
       this._bus.emit(type, resolve());
       return;

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -44,15 +44,15 @@ export class EventEmitter extends SharedInstance {
     return this._bus.on(type, handler);
   }
 
-  public emit<T extends UploaderEventKey, TDebounce extends boolean | number | undefined = undefined>(
+  public emit<T extends UploaderEventKey>(
     type: T,
-    payload?: TDebounce extends false | undefined ? UploaderEventPayload[T] : () => UploaderEventPayload[T],
-    options: { debounce?: TDebounce } = {},
+    payload?: UploaderEventPayload[T] | (() => UploaderEventPayload[T]),
+    options: { debounce?: boolean | number } = {},
   ): void {
     const { debounce } = options;
-    // The public API permits omitting `payload`, but callers always provide one
-    // for events whose payload isn't `undefined`; assert presence at this single
-    // boundary (mirrors v1's `payload as EventPayload[T]`).
+    // A value or a thunk is accepted on either path (the runtime resolves
+    // both); the single `as` bridges the optional `payload?` to the required
+    // payload for events whose payload isn't `undefined`.
     const resolve = () => (typeof payload === 'function' ? payload() : payload) as UploaderEventPayload[T];
     if (typeof debounce !== 'number' && !debounce) {
       this._bus.emit(type, resolve());

--- a/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
+++ b/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
@@ -19,7 +19,11 @@ export class UploadCtxProvider extends LitUploaderBlock {
 
     // Bridge the per-ctx EventBus to documented DOM CustomEvents on this
     // element. The reactive controller manages its own connect/disconnect.
-    this._eventBridge ??= new EventBridgeController(this, () => this.sharedCtx.uploaderController().events);
+    this._eventBridge ??= new EventBridgeController(
+      this,
+      () => this.sharedCtx.uploaderController().events,
+      (...args) => this.debugPrint(...args),
+    );
   }
 }
 

--- a/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
+++ b/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { EventBridgeController } from '../../lit/EventBridgeController';
 import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
 import { type EventPayload, EventType } from './EventEmitter';
 
@@ -11,18 +12,14 @@ export class UploadCtxProvider extends LitUploaderBlock {
   public static override styleAttrs = ['uc-wgt-common'];
   public static EventType = EventType;
 
-  private _unbindEventEmitter: (() => void) | null = null;
+  private _eventBridge: EventBridgeController | null = null;
 
   public override initCallback() {
     super.initCallback();
 
-    this._unbindEventEmitter = this.eventEmitter.bindTarget(this);
-  }
-
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-
-    this._unbindEventEmitter?.();
+    // Bridge the per-ctx EventBus to documented DOM CustomEvents on this
+    // element. The reactive controller manages its own connect/disconnect.
+    this._eventBridge ??= new EventBridgeController(this, () => this.sharedCtx.uploaderController().events);
   }
 }
 

--- a/src/blocks/UploadCtxProvider/event-types.test.ts
+++ b/src/blocks/UploadCtxProvider/event-types.test.ts
@@ -1,0 +1,36 @@
+import { describe, expectTypeOf, it } from 'vitest';
+import type { UploaderEventKey, UploaderEventPayload, UploaderEventType } from '../../abstract/EventBus';
+import type { ActivityType } from '../../lit/activity-constants';
+import type { OutputCollectionState, OutputFileEntry } from '../../types';
+import type { EventKey, EventPayload, EventType } from './EventEmitter';
+
+// Type-level ("tsd"-style) tests via vitest `expectTypeOf` — checked by
+// `tsc:test`. They are the migration guards for the event surface: a payload
+// change or a divergence between the documented (v1) names and the canonical
+// `EventBus` map fails the build, not just a runtime assertion.
+describe('event type contract', () => {
+  it('re-exports the canonical EventBus surface (single source of truth)', () => {
+    expectTypeOf<typeof EventType>().toEqualTypeOf<typeof UploaderEventType>();
+    expectTypeOf<EventKey>().toEqualTypeOf<UploaderEventKey>();
+    expectTypeOf<EventPayload>().toEqualTypeOf<UploaderEventPayload>();
+  });
+
+  it('every documented event key is present on the bus payload map', () => {
+    expectTypeOf<EventKey>().toEqualTypeOf<keyof UploaderEventPayload>();
+  });
+
+  it('locks the documented payload shapes', () => {
+    expectTypeOf<EventPayload['file-added']>().toEqualTypeOf<OutputFileEntry<'idle'>>();
+    expectTypeOf<EventPayload['file-upload-start']>().toEqualTypeOf<OutputFileEntry<'uploading'>>();
+    expectTypeOf<EventPayload['file-upload-success']>().toEqualTypeOf<OutputFileEntry<'success'>>();
+    expectTypeOf<EventPayload['file-upload-failed']>().toEqualTypeOf<OutputFileEntry<'failed'>>();
+    expectTypeOf<EventPayload['modal-open']>().toEqualTypeOf<{ modalId: ActivityType }>();
+    expectTypeOf<EventPayload['modal-close']>().toEqualTypeOf<{ modalId: ActivityType; hasActiveModals: boolean }>();
+    expectTypeOf<EventPayload['activity-change']>().toEqualTypeOf<{ activity: ActivityType }>();
+    expectTypeOf<EventPayload['upload-click']>().toEqualTypeOf<undefined>();
+    expectTypeOf<EventPayload['done-click']>().toEqualTypeOf<OutputCollectionState>();
+    expectTypeOf<EventPayload['common-upload-start']>().toEqualTypeOf<OutputCollectionState<'uploading'>>();
+    expectTypeOf<EventPayload['change']>().toEqualTypeOf<OutputCollectionState>();
+    expectTypeOf<EventPayload['group-created']>().toEqualTypeOf<OutputCollectionState<'success', 'has-group'>>();
+  });
+});

--- a/src/lit/EventBridgeController.test.ts
+++ b/src/lit/EventBridgeController.test.ts
@@ -84,4 +84,28 @@ describe('EventBridgeController', () => {
 
     expect(host.events).toHaveLength(1);
   });
+
+  it('logs each event via the debug hook (shallow-copying object payloads)', () => {
+    // Invoke the thunk like the real `debugPrint` does, to capture the logged args.
+    const logged: unknown[][] = [];
+    const debug = vi.fn((...args: unknown[]) => {
+      logged.push((args[0] as () => unknown[])());
+    });
+    new EventBridgeController(asHostArg(host), () => bus, debug);
+
+    const payload = { internalId: 'a' };
+    bus.emit('file-added', payload as never);
+    bus.emit('upload-click', undefined); // non-object payload → passed through as-is
+
+    expect(debug).toHaveBeenCalledTimes(2);
+    expect(logged[0]?.[0]).toBe('event "file-added"');
+    expect(logged[0]?.[1]).toEqual(payload);
+    expect(logged[0]?.[1]).not.toBe(payload); // shallow copy, not the same ref
+    expect(logged[1]?.[1]).toBeUndefined(); // undefined payload, not copied
+  });
+
+  it('does not throw when no debug hook is provided', () => {
+    new EventBridgeController(asHostArg(host), () => bus);
+    expect(() => bus.emit('upload-click', undefined)).not.toThrow();
+  });
 });

--- a/src/lit/EventBridgeController.test.ts
+++ b/src/lit/EventBridgeController.test.ts
@@ -1,0 +1,87 @@
+import type { ReactiveController } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { EventBus } from '../abstract/EventBus';
+import { EventBridgeController } from './EventBridgeController';
+
+// A minimal host that just records dispatchEvent calls. It intentionally does
+// NOT extend EventTarget / call a real dispatch — doing so re-enters this method
+// once per event phase (capture/target/bubble) and inflates the count.
+class FakeHost {
+  public controllers: ReactiveController[] = [];
+  public events: CustomEvent[] = [];
+
+  public addController(controller: ReactiveController): void {
+    this.controllers.push(controller);
+  }
+  public removeController(): void {}
+  public requestUpdate(): void {}
+  public updateComplete = Promise.resolve(true);
+
+  public dispatchEvent(event: Event): boolean {
+    this.events.push(event as CustomEvent);
+    return true;
+  }
+}
+
+const makeHost = () => new FakeHost();
+// The controller only needs `addController` + `dispatchEvent`; FakeHost provides both.
+const asHostArg = (host: FakeHost) => host as unknown as ConstructorParameters<typeof EventBridgeController>[0];
+
+describe('EventBridgeController', () => {
+  let host: FakeHost;
+  let bus: EventBus;
+
+  beforeEach(() => {
+    host = makeHost();
+    bus = new EventBus();
+  });
+
+  afterEach(() => {
+    bus.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('registers itself as a controller on the host', () => {
+    const controller = new EventBridgeController(asHostArg(host), () => bus);
+    expect(host.controllers).toContain(controller);
+  });
+
+  it('subscribes on construction and dispatches bus events as CustomEvents on the host', () => {
+    new EventBridgeController(asHostArg(host), () => bus);
+
+    const payload = { internalId: 'a' } as never;
+    bus.emit('file-added', payload);
+
+    expect(host.events).toHaveLength(1);
+    expect(host.events[0]?.type).toBe('file-added');
+    expect(host.events[0]?.detail).toBe(payload);
+  });
+
+  it('does not double-subscribe when hostConnected fires while already subscribed', () => {
+    const controller = new EventBridgeController(asHostArg(host), () => bus);
+    controller.hostConnected(); // already subscribed in constructor → no-op
+
+    bus.emit('file-removed', {} as never);
+
+    expect(host.events).toHaveLength(1);
+  });
+
+  it('stops dispatching after hostDisconnected', () => {
+    const controller = new EventBridgeController(asHostArg(host), () => bus);
+    controller.hostDisconnected();
+
+    bus.emit('file-added', {} as never);
+
+    expect(host.events).toHaveLength(0);
+  });
+
+  it('re-subscribes on hostConnected after a disconnect', () => {
+    const controller = new EventBridgeController(asHostArg(host), () => bus);
+    controller.hostDisconnected();
+    controller.hostConnected();
+
+    bus.emit('file-added', {} as never);
+
+    expect(host.events).toHaveLength(1);
+  });
+});

--- a/src/lit/EventBridgeController.ts
+++ b/src/lit/EventBridgeController.ts
@@ -18,11 +18,13 @@ type EventBridgeHost = ReactiveControllerHost & EventTarget;
 export class EventBridgeController implements ReactiveController {
   private _host: EventBridgeHost;
   private _getBus: () => EventBus;
+  private _debug?: (...args: unknown[]) => void;
   private _unsubscribe?: () => void;
 
-  public constructor(host: EventBridgeHost, getBus: () => EventBus) {
+  public constructor(host: EventBridgeHost, getBus: () => EventBus, debug?: (...args: unknown[]) => void) {
     this._host = host;
     this._getBus = getBus;
+    this._debug = debug;
     host.addController(this);
     this._subscribe();
   }
@@ -41,6 +43,12 @@ export class EventBridgeController implements ReactiveController {
       return;
     }
     this._unsubscribe = this._getBus().onAny((type, payload) => {
+      // Debug-mode event logging, gated by the host's `debugPrint` (preserves
+      // v1 `EventEmitter._dispatch` behavior). Thunked so it's free when off.
+      this._debug?.(() => {
+        const copy = payload && typeof payload === 'object' ? { ...payload } : payload;
+        return [`event "${type}"`, copy];
+      });
       this._host.dispatchEvent(new CustomEvent(type, { detail: payload }));
     });
   }

--- a/src/lit/EventBridgeController.ts
+++ b/src/lit/EventBridgeController.ts
@@ -1,0 +1,47 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { EventBus } from '../abstract/EventBus';
+
+type EventBridgeHost = ReactiveControllerHost & EventTarget;
+
+/**
+ * Bridges the DOM-free {@link EventBus} to documented DOM `CustomEvent`s on the
+ * host element (`<uc-upload-ctx-provider>`).
+ *
+ * A reactive Lit controller — the UI-coupled half of the event system. The
+ * DOM-free controllers emit on the per-ctx `UploaderController.events` bus; this
+ * controller subscribes (`onAny`) while the host is connected and re-dispatches
+ * each event as `new CustomEvent(type, { detail })`, exactly as v1's
+ * `EventEmitter._dispatch` did. It subscribes immediately (so events flow
+ * regardless of when it's attached relative to the connect lifecycle) and
+ * re-subscribes/tears down across reconnects.
+ */
+export class EventBridgeController implements ReactiveController {
+  private _host: EventBridgeHost;
+  private _getBus: () => EventBus;
+  private _unsubscribe?: () => void;
+
+  public constructor(host: EventBridgeHost, getBus: () => EventBus) {
+    this._host = host;
+    this._getBus = getBus;
+    host.addController(this);
+    this._subscribe();
+  }
+
+  public hostConnected(): void {
+    this._subscribe();
+  }
+
+  public hostDisconnected(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = undefined;
+  }
+
+  private _subscribe(): void {
+    if (this._unsubscribe) {
+      return;
+    }
+    this._unsubscribe = this._getBus().onAny((type, payload) => {
+      this._host.dispatchEvent(new CustomEvent(type, { detail: payload }));
+    });
+  }
+}

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,27 +1,21 @@
 // @ts-check
 
-import { uploadFileGroup } from '@uploadcare/upload-client';
 import { uploaderBlockCtx } from '../abstract/CTX';
 import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
-import type {
-  CollectionObserver,
-  UploadCollectionChangeMap,
-  UploadCollectionController,
-} from '../abstract/controllers/UploadCollectionController';
+import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
 import { UploadController } from '../abstract/controllers/UploadController';
+import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
 import { ValidationController } from '../abstract/controllers/ValidationController';
-import { TypedData } from '../abstract/TypedData';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
-import type { UploadEntryData } from '../abstract/uploadEntrySchema';
 import { calculateMaxCenteredCropFrame } from '../blocks/CloudImageEditor/src/crop-utils';
 import { parseCropPreset } from '../blocks/CloudImageEditor/src/lib/parseCropPreset';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
-import type { OutputCollectionState, OutputFileEntry } from '../types/index';
+import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
 import { createCdnUrl, createCdnUrlModifiers } from '../utils/cdn-utils';
-import { debounce } from '../utils/debounce';
 import { ExternalUploadSource, UploadSource } from '../utils/UploadSource';
 import { getOutputData } from './getOutputData';
 import { LitActivityBlock } from './LitActivityBlock';
+import type { Uid } from './Uid';
 
 export class LitUploaderBlock extends LitActivityBlock {
   public static extSrcList: Readonly<typeof ExternalUploadSource>;
@@ -30,8 +24,7 @@ export class LitUploaderBlock extends LitActivityBlock {
 
   private _isCtxOwner = false;
 
-  private _unobserveCollection?: () => void;
-  private _unobserveCollectionProperties?: () => void;
+  private _uploadEvents?: UploadEventsController;
 
   public override init$ = uploaderBlockCtx(this);
 
@@ -133,263 +126,58 @@ export class LitUploaderBlock extends LitActivityBlock {
     super.disconnectedCallback();
 
     if (this._isCtxOwner) {
-      this._unobserveUploadCollection();
+      this._uploadEvents?.unobserve();
     }
-
-    this._flushOutputItems.cancel();
   }
 
   public override connectedCallback(): void {
     super.connectedCallback();
 
     if (this._isCtxOwner) {
-      this._observeUploadCollection();
+      this._uploadEvents?.observe();
     }
   }
 
   private _initCtxOwner(): void {
     this._isCtxOwner = true;
 
-    this._observeUploadCollection();
+    // The collection→events derivation lives in the DOM-free UploadEventsController;
+    // this block just wires its collaborators (api, validation, plugin hooks) and
+    // the v1 `*`-shared-state sinks.
+    this._uploadEvents = new UploadEventsController({
+      collection: this.uploadCollection,
+      config: this.sharedCtx.uploaderController().config,
+      validation: this.validationManager,
+      emit: (type, payload, options) => this.emit(type, payload, options),
+      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => this.api.getOutputItem<TStatus>(uid),
+      getOutputCollectionState: () => this.api.getOutputCollectionState(),
+      getOutputData: () => this.getOutputData(),
+      buildUploadOptions: () => this.uploadController.buildUploadOptions(),
+      runOnAddHooks: (entry) =>
+        void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+      applyInitialCrop: () => this._setInitialCrop(),
+      uploadTrigger: () => this.$['*uploadTrigger'],
+      setUploadList: (list) => {
+        this.$['*uploadList'] = list;
+      },
+      getCollectionState: () => this.$['*collectionState'],
+      setCollectionState: (state) => {
+        this.$['*collectionState'] = state;
+      },
+      getCommonProgress: () => this.$['*commonProgress'],
+      setCommonProgress: (progress) => {
+        this.$['*commonProgress'] = progress;
+      },
+      setGroupInfo: (group) => {
+        this.$['*groupInfo'] = group;
+      },
+      getCollectionErrors: () => this.$['*collectionErrors'],
+    });
+    this._uploadEvents.observe();
 
     // Upload-queue concurrency is owned by the UploadController, which syncs it
     // from `maxConcurrentRequests` itself.
   }
-
-  private _observeUploadCollection(): void {
-    this._unobserveUploadCollection();
-
-    this._unobserveCollection = this.uploadCollection.observeCollection(this._handleCollectionUpdate);
-
-    this._unobserveCollectionProperties = this.uploadCollection.observeProperties(
-      this._handleCollectionPropertiesUpdate,
-    );
-  }
-
-  private _unobserveUploadCollection(): void {
-    this._unobserveCollectionProperties?.();
-    this._unobserveCollection?.();
-
-    this._unobserveCollectionProperties = undefined;
-    this._unobserveCollection = undefined;
-  }
-
-  private async _createGroup(collectionState: OutputCollectionState): Promise<void> {
-    const uploadClientOptions = await this.uploadController.buildUploadOptions();
-    const uuidList = collectionState.allEntries.map((entry) => {
-      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
-    });
-    const abortController = new AbortController();
-    const resp = await uploadFileGroup(uuidList, {
-      ...uploadClientOptions,
-      signal: abortController.signal,
-    });
-    if (this.$['*collectionState'] !== collectionState) {
-      abortController.abort();
-      return;
-    }
-    this.$['*groupInfo'] = resp;
-    const collectionStateWithGroup = this.api.getOutputCollectionState() as OutputCollectionState<
-      'success',
-      'has-group'
-    >;
-    this.emit(EventType.GROUP_CREATED, collectionStateWithGroup);
-    this.emit(EventType.CHANGE, () => this.api.getOutputCollectionState(), {
-      debounce: true,
-    });
-    this.$['*collectionState'] = collectionStateWithGroup;
-  }
-
-  private _flushOutputItems = debounce(async () => {
-    const data = this.getOutputData();
-    if (data.length !== this.uploadCollection.size) {
-      return;
-    }
-    const collectionState = this.api.getOutputCollectionState();
-    this.$['*collectionState'] = collectionState;
-    this.emit(EventType.CHANGE, () => this.api.getOutputCollectionState(), {
-      debounce: true,
-    });
-
-    if (this.cfg.groupOutput && collectionState.totalCount > 0 && collectionState.status === 'success') {
-      this._createGroup(collectionState);
-    }
-  }, 300);
-
-  private _handleCollectionUpdate: CollectionObserver = (entries, added, removed) => {
-    if (!this.isConnected) return;
-    if (added.size || removed.size) {
-      this.$['*groupInfo'] = null;
-    }
-
-    this.validationManager.runFileValidators(
-      'add',
-      [...added].map((e) => e.uid),
-    );
-
-    for (const entry of added) {
-      if (!entry.getValue('silent')) {
-        this.emit(EventType.FILE_ADDED, this.api.getOutputItem(entry.uid));
-      }
-      void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry));
-    }
-
-    this.validationManager.runCollectionValidators();
-
-    for (const entry of removed) {
-      this.$['*uploadTrigger'].delete(entry.uid);
-
-      this.validationManager.cleanupValidationForEntry(entry);
-      entry.getValue('abortController')?.abort();
-      entry.setMultipleValues({
-        isRemoved: true,
-        abortController: null,
-        isUploading: false,
-        uploadProgress: 0,
-      });
-      const thumbUrl = entry?.getValue('thumbUrl');
-      thumbUrl && URL.revokeObjectURL(thumbUrl);
-      this.emit(EventType.FILE_REMOVED, this.api.getOutputItem(entry.uid));
-    }
-
-    this.$['*uploadList'] = entries.map((uid) => {
-      return { uid };
-    });
-
-    this._flushCommonUploadProgress();
-    this._flushOutputItems();
-  };
-
-  private _handleCollectionPropertiesUpdate = (changeMap: UploadCollectionChangeMap): void => {
-    if (!this.isConnected) return;
-    this._flushOutputItems();
-
-    const uploadCollection = this.uploadCollection;
-    const entriesToRunValidation = [
-      ...new Set(
-        Object.entries(changeMap)
-          .filter(([key]) => ['file', 'uploadError', 'fileInfo', 'cdnUrl', 'cdnUrlModifiers'].includes(key))
-          .flatMap(([, ids]) => [...(ids ?? [])]),
-      ),
-    ];
-
-    entriesToRunValidation.length > 0 &&
-      setTimeout(() => {
-        if (!this.isConnected) return;
-        // We can't modify entry properties in the same tick, so we need to wait a bit
-        const entriesToRunOnUpload = entriesToRunValidation.filter(
-          (entryId) =>
-            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
-        );
-        if (entriesToRunOnUpload.length > 0) {
-          this.validationManager.runFileValidators('upload', entriesToRunOnUpload);
-        }
-        this.validationManager.runFileValidators('change', entriesToRunValidation);
-      });
-
-    if (changeMap.uploadProgress) {
-      for (const entryId of changeMap.uploadProgress) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
-        if (isUploading && !silent) {
-          this.emit(EventType.FILE_UPLOAD_PROGRESS, this.api.getOutputItem(entryId));
-        }
-      }
-
-      this._flushCommonUploadProgress();
-    }
-    if (changeMap.isUploading) {
-      for (const entryId of changeMap.isUploading) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
-        if (isUploading && !silent) {
-          this.emit(EventType.FILE_UPLOAD_START, this.api.getOutputItem(entryId));
-        }
-      }
-    }
-    if (changeMap.fileInfo) {
-      for (const entryId of changeMap.fileInfo) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { fileInfo, silent } = entry.snapshot();
-        if (fileInfo && !silent) {
-          this.emit(EventType.FILE_UPLOAD_SUCCESS, this.api.getOutputItem(entryId));
-        }
-      }
-      if (this.cfg.cropPreset) {
-        this._setInitialCrop();
-      }
-    }
-    if (changeMap.errors) {
-      this.validationManager.runCollectionValidators();
-
-      for (const entryId of changeMap.errors) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { errors } = entry.snapshot();
-        if (errors.length > 0) {
-          this.emit(EventType.FILE_UPLOAD_FAILED, this.api.getOutputItem(entryId));
-          this.emit(
-            EventType.COMMON_UPLOAD_FAILED,
-            () => this.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-            { debounce: true },
-          );
-        }
-      }
-      const loadedItems = uploadCollection.findItems((entry) => {
-        return !!entry.getValue('fileInfo');
-      });
-      const errorItems = uploadCollection.findItems((entry) => {
-        return entry.getValue('errors').length > 0;
-      });
-      if (
-        uploadCollection.size > 0 &&
-        errorItems.length === 0 &&
-        uploadCollection.size === loadedItems.length &&
-        this.$['*collectionErrors'].length === 0
-      ) {
-        this.emit(
-          EventType.COMMON_UPLOAD_SUCCESS,
-          this.api.getOutputCollectionState() as OutputCollectionState<'success'>,
-        );
-      }
-    }
-    if (changeMap.cdnUrl) {
-      const uids = [...changeMap.cdnUrl].filter((uid) => {
-        return !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
-      });
-      uids.forEach((uid) => {
-        this.emit(EventType.FILE_URL_CHANGED, this.api.getOutputItem(uid));
-      });
-
-      this.$['*groupInfo'] = null;
-    }
-  };
-
-  private _flushCommonUploadProgress = (): void => {
-    let commonProgress = 0;
-    const uploadTrigger = this.$['*uploadTrigger'];
-    const items = [...uploadTrigger].filter((id) => !!this.uploadCollection.read(id));
-    items.forEach((id) => {
-      const uploadProgress = this.uploadCollection.readProp(id, 'uploadProgress');
-      if (typeof uploadProgress === 'number') {
-        commonProgress += uploadProgress;
-      }
-    });
-    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
-
-    if (this.$['*commonProgress'] === progress) {
-      return;
-    }
-
-    this.$['*commonProgress'] = progress;
-    this.emit(
-      EventType.COMMON_UPLOAD_PROGRESS,
-      this.api.getOutputCollectionState() as OutputCollectionState<'uploading'>,
-    );
-  };
 
   private _setInitialCrop(): void {
     const cropPreset = parseCropPreset(this.cfg.cropPreset);


### PR DESCRIPTION
## M5b — `UploadEventsController`

Part of the v2 strangler migration (see `MIGRATION-PLAN.md`). Stacked on **#993** (M5a). This is the step that **empties most of the event logic out of `LitUploaderBlock`**.

Moves the four big collection-observation handlers into a new DOM-free controller:
`_handleCollectionUpdate`, `_handleCollectionPropertiesUpdate`, `_flushOutputItems`, `_flushCommonUploadProgress`, and `_createGroup` (~220 lines).

### What changed
- **New `UploadEventsController`** (`src/abstract/controllers/`): observes the upload collection and, as entries are added/removed and properties change, drives validation, emits the documented events, maintains the derived `*uploadList`/`*collectionState`/`*commonProgress`/`*groupInfo` shared state via injected sinks, and creates the output group. An `_active` flag (observe/unobserve) reproduces v1's `isConnected` guard for the debounced flush + deferred validation.
- **Telemetry preserved**: events flow through the injected telemetry-augmented `emit` (= `LitBlock.emit` → EventBus + `sendEvent`), not the raw bus.
- **`LitUploaderBlock`** now just wires the controller's collaborators (api, validation, plugin hooks, `buildUploadOptions`) + the v1 `*`-state sinks, and drives `observe()`/`unobserve()` from connect/disconnect.
- **`_setInitialCrop` stays in the block** (it imports CloudImageEditor crop utils, which a DOM-free controller must not pull in) — injected as `applyInitialCrop`.
- **Full typing**: `getOutputItem` is wired generically so the per-event payload status (`OutputFileEntry<'idle'>` etc.) is inferred — no casts.

### Tests
New suite at **100% coverage** (30 specs); these handlers had **no** unit coverage before (only e2e). The observer callbacks are captured and invoked directly with real `TypedData` entries, so each derivation branch is exercised in isolation.

### Contract (unchanged)
All documented events + payloads, validation triggering, plugin `onAdd` hooks, group creation, and the `*`-shared-state consumed by UI blocks.

### Green gate
`tsc:app` + `tsc:test`, `build`, `test:specs` 481/481, `test:locales`, `test:e2e` 187/187, `lint` (0 errors).

> Note: M5c (group creation) is folded in here — `_createGroup` moved along with the flush that triggers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized upload event handling and lifecycle management for more consistent start/progress/success/failure events, debounced change emissions, reliable aggregated upload progress, and safer grouped upload creation/cancellation.

* **Tests**
  * Added comprehensive tests covering collection add/remove, property-driven events, progress aggregation, grouped uploads, deferred validation, and lifecycle unobserve/destroy behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->