### PR TITLE
feat(plugins): DOM-free PluginController (M6)

### DIFF
--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -453,6 +453,27 @@ describe('UploadEventsController', () => {
       expect(t.emit).toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
     });
 
+    it('does not finalize the group if the controller is unobserved mid-flight', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockImplementation(async () => {
+        t.controller.unobserve(); // host disconnects while the group upload is in-flight
+        return { uuid: 'group~1' } as UploadcareGroup;
+      });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
     it('aborts group creation if the collection state changed mid-flight', async () => {
       const state = makeState({
         totalCount: 1,

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -1,0 +1,506 @@
+import type { FileFromOptions, UploadcareGroup } from '@uploadcare/upload-client';
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState, OutputFileEntry } from '../../types';
+import { UploaderEventType } from '../EventBus';
+import type { TypedData } from '../TypedData';
+import type { UploadEntryData } from '../uploadEntrySchema';
+import { ConfigController } from './ConfigController';
+import type { CollectionObserver, PropertyObserver } from './UploadCollectionController';
+import { UploadCollectionController } from './UploadCollectionController';
+import { UploadEventsController, type UploadEventsControllerDeps } from './UploadEventsController';
+import type { ValidationController } from './ValidationController';
+
+vi.mock('@uploadcare/upload-client', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@uploadcare/upload-client')>();
+  return { ...actual, uploadFileGroup: vi.fn() };
+});
+
+import { uploadFileGroup } from '@uploadcare/upload-client';
+
+const mockUploadFileGroup = vi.mocked(uploadFileGroup);
+
+type Entry = TypedData<UploadEntryData>;
+
+const makeState = (overrides: Partial<OutputCollectionState> = {}): OutputCollectionState =>
+  ({ totalCount: 0, status: 'idle', allEntries: [], ...overrides }) as OutputCollectionState;
+
+const setup = (opts: { collectionState?: OutputCollectionState; outputDataLength?: number } = {}) => {
+  const collection = new UploadCollectionController();
+  const validation = {
+    runFileValidators: vi.fn(),
+    runCollectionValidators: vi.fn(),
+    cleanupValidationForEntry: vi.fn(),
+  } as unknown as ValidationController;
+
+  // Invoke thunk payloads like the real emit does, so deferred-payload bodies run.
+  const emit = vi.fn((_type: unknown, payload?: unknown) => {
+    if (typeof payload === 'function') (payload as () => unknown)();
+  }) as Mock & UploadEventsControllerDeps['emit'];
+  const uploadTriggerSet = new Set<Uid>();
+  let collectionState = opts.collectionState ?? makeState();
+  let commonProgress = 0;
+  const collectionErrors: never[] = [];
+
+  // Capture the observer callbacks so tests invoke the handlers directly with
+  // controlled (entries, added, removed) / changeMap — no collection debounce.
+  let collectionObserver: CollectionObserver = () => {};
+  let propertyObserver: PropertyObserver = () => {};
+  vi.spyOn(collection, 'observeCollection').mockImplementation((cb) => {
+    collectionObserver = cb;
+    return () => {};
+  });
+  vi.spyOn(collection, 'observeProperties').mockImplementation((cb) => {
+    propertyObserver = cb;
+    return () => {};
+  });
+
+  const config = new ConfigController();
+
+  const deps: UploadEventsControllerDeps = {
+    collection,
+    config,
+    validation,
+    emit,
+    getOutputItem: ((uid: Uid) => ({ internalId: uid })) as unknown as UploadEventsControllerDeps['getOutputItem'],
+    getOutputCollectionState: () => collectionState,
+    getOutputData: () => new Array(opts.outputDataLength ?? collection.size).fill(0) as OutputFileEntry[],
+    buildUploadOptions: vi.fn(async () => ({}) as FileFromOptions),
+    runOnAddHooks: vi.fn(),
+    applyInitialCrop: vi.fn(),
+    uploadTrigger: () => uploadTriggerSet,
+    setUploadList: vi.fn(),
+    getCollectionState: () => collectionState,
+    setCollectionState: vi.fn((s) => {
+      collectionState = s ?? makeState();
+    }),
+    getCommonProgress: () => commonProgress,
+    setCommonProgress: vi.fn((p) => {
+      commonProgress = p;
+    }),
+    setGroupInfo: vi.fn(),
+    getCollectionErrors: () => collectionErrors,
+  };
+
+  const controller = new UploadEventsController(deps);
+  controller.observe();
+
+  return {
+    controller,
+    collection,
+    config,
+    deps,
+    emit,
+    uploadTriggerSet,
+    fireCollection: (entries: Uid[], added: Set<Entry>, removed: Set<Entry>) =>
+      collectionObserver(entries, added, removed),
+    fireProperties: (changeMap: Parameters<PropertyObserver>[0]) => propertyObserver(changeMap),
+    setCollectionStateValue: (s: OutputCollectionState) => {
+      collectionState = s;
+    },
+  };
+};
+
+const entriesByUid = (collection: UploadCollectionController, uids: Uid[]) =>
+  new Set(uids.map((id) => collection.read(id)).filter((e): e is Entry => !!e));
+
+describe('UploadEventsController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockUploadFileGroup.mockReset();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('collection add/remove', () => {
+    it('emits FILE_ADDED (non-silent), runs add validators + onAdd hooks, clears groupInfo, sets uploadList', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith(null);
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('add', [id]);
+      expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
+      expect(t.deps.validation.runCollectionValidators).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_ADDED, expect.objectContaining({ internalId: id }));
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+    });
+
+    it('suppresses FILE_ADDED for a silent entry (but still runs onAdd hooks)', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', silent: true });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_ADDED, expect.anything());
+      expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
+    });
+
+    it('on remove: aborts, marks removed, revokes thumbUrl, cleans validation, emits FILE_REMOVED', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', thumbUrl: 'blob:xyz' });
+      const entry = t.collection.read(id) as Entry;
+      const ac = new AbortController();
+      const abortSpy = vi.spyOn(ac, 'abort');
+      entry.setValue('abortController', ac);
+      t.uploadTriggerSet.add(id);
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      t.fireCollection([], new Set(), new Set([entry]));
+
+      expect(t.uploadTriggerSet.has(id)).toBe(false);
+      expect(t.deps.validation.cleanupValidationForEntry).toHaveBeenCalledWith(entry);
+      expect(abortSpy).toHaveBeenCalled();
+      expect(entry.getValue('isRemoved')).toBe(true);
+      expect(revokeSpy).toHaveBeenCalledWith('blob:xyz');
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.objectContaining({ internalId: id }));
+    });
+
+    it('does nothing once unobserved (inactive guard)', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.controller.unobserve();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+
+    it('does not reset groupInfo when the update has no adds or removes', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], new Set(), new Set());
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalled();
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+    });
+
+    it('destroy() stops the controller', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.controller.destroy();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+
+    it('handles a removed entry without a thumbUrl', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' }); // no thumbUrl
+      const entry = t.collection.read(id) as Entry;
+      const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+
+      t.fireCollection([], new Set(), new Set([entry]));
+
+      expect(revokeSpy).not.toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.anything());
+    });
+  });
+
+  describe('property updates → events', () => {
+    const addUploadingEntry = (t: ReturnType<typeof setup>, init: Partial<UploadEntryData> = {}) => {
+      const id = t.collection.add({ fileName: 'a.txt', isUploading: true, ...init });
+      return id;
+    };
+
+    it('emits FILE_UPLOAD_PROGRESS for uploading non-silent entries + flushes common progress', () => {
+      const t = setup();
+      const id = addUploadingEntry(t);
+      t.uploadTriggerSet.add(id);
+      t.collection.publishProp(id, 'uploadProgress', 50);
+
+      t.fireProperties({ uploadProgress: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_PROGRESS,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.setCommonProgress).toHaveBeenCalled();
+    });
+
+    it('emits FILE_UPLOAD_START only for uploading + non-silent', () => {
+      const t = setup();
+      const uploading = addUploadingEntry(t);
+      const silent = t.collection.add({ isUploading: true, silent: true });
+
+      t.fireProperties({ isUploading: new Set([uploading, silent]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_START,
+        expect.objectContaining({ internalId: uploading }),
+      );
+      expect(t.emit).not.toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_START,
+        expect.objectContaining({ internalId: silent }),
+      );
+    });
+
+    it('emits FILE_UPLOAD_SUCCESS for entries with fileInfo and applies crop when cropPreset set', () => {
+      const t = setup();
+      t.config.set('cropPreset', '1:1');
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_SUCCESS,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.applyInitialCrop).toHaveBeenCalled();
+    });
+
+    it('emits FILE_UPLOAD_FAILED + debounced COMMON_UPLOAD_FAILED for errored entries', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'errors', [{ type: 'X', message: 'm' }] as never);
+
+      t.fireProperties({ errors: new Set([id]) });
+
+      expect(t.deps.validation.runCollectionValidators).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_UPLOAD_FAILED,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_FAILED, expect.any(Function), {
+        debounce: true,
+      });
+    });
+
+    it('emits COMMON_UPLOAD_SUCCESS when all entries are loaded with no errors', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+      // errors changeMap with an entry that has no errors → triggers the success check
+      t.fireProperties({ errors: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_SUCCESS, expect.anything());
+    });
+
+    it('emits FILE_URL_CHANGED for entries that now have a cdnUrl and clears groupInfo', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'cdnUrl', 'https://cdn/u1/');
+
+      t.fireProperties({ cdnUrl: new Set([id]) });
+
+      expect(t.emit).toHaveBeenCalledWith(
+        UploaderEventType.FILE_URL_CHANGED,
+        expect.objectContaining({ internalId: id }),
+      );
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith(null);
+    });
+
+    it('schedules deferred validation for watched-key changes', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('upload', [id]);
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('change', [id]);
+    });
+
+    it('does not emit FILE_UPLOAD_PROGRESS for a non-uploading entry', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: false });
+      t.uploadTriggerSet.add(id);
+      t.collection.publishProp(id, 'uploadProgress', 50);
+
+      t.fireProperties({ uploadProgress: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_PROGRESS, expect.anything());
+    });
+
+    it('does not apply crop when no cropPreset is configured', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.deps.applyInitialCrop).not.toHaveBeenCalled();
+    });
+
+    it('skips FILE_URL_CHANGED for entries that still lack a cdnUrl', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' }); // no cdnUrl set
+
+      t.fireProperties({ cdnUrl: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_URL_CHANGED, expect.anything());
+    });
+
+    it('suppresses FILE_UPLOAD_SUCCESS for a silent entry with fileInfo', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt', silent: true });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_SUCCESS, expect.anything());
+    });
+
+    it('skips changeMap ids that have no backing entry (stale uids)', () => {
+      const t = setup();
+      const ghost = 'ghost' as Uid;
+
+      expect(() =>
+        t.fireProperties({
+          uploadProgress: new Set([ghost]),
+          isUploading: new Set([ghost]),
+          fileInfo: new Set([ghost]),
+          errors: new Set([ghost]),
+        }),
+      ).not.toThrow();
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.FILE_UPLOAD_START, expect.anything());
+    });
+
+    it('defers only "change" validators for a non-fileInfo watched-key change', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireProperties({ cdnUrl: new Set([id]) }); // watched key, but not fileInfo
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).toHaveBeenCalledWith('change', [id]);
+      expect(t.deps.validation.runFileValidators).not.toHaveBeenCalledWith('upload', expect.anything());
+    });
+
+    it('skips deferred validation if unobserved before the microtask fires', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      t.collection.publishProp(id, 'fileInfo', { uuid: 'u1' } as never);
+
+      t.fireProperties({ fileInfo: new Set([id]) });
+      t.controller.unobserve();
+      vi.advanceTimersByTime(1);
+
+      expect(t.deps.validation.runFileValidators).not.toHaveBeenCalledWith('change', expect.anything());
+    });
+
+    it('ignores a non-numeric uploadProgress when averaging', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: true });
+      t.collection.read(id)?.setValue('uploadProgress', 'oops' as never);
+      t.uploadTriggerSet.add(id);
+
+      expect(() => t.fireProperties({ uploadProgress: new Set([id]) })).not.toThrow();
+    });
+
+    it('tolerates an undefined changeMap value for a watched key', () => {
+      const t = setup();
+      expect(() => t.fireProperties({ file: undefined } as never)).not.toThrow();
+    });
+
+    it('does nothing once unobserved (inactive guard)', () => {
+      const t = setup();
+      const id = t.collection.add({ isUploading: true });
+      t.controller.unobserve();
+
+      t.fireProperties({ isUploading: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('output flush + group', () => {
+    it('flushes collection state + emits CHANGE when output data matches collection size', () => {
+      const t = setup({ collectionState: makeState({ totalCount: 1, status: 'idle' }), outputDataLength: 1 });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      vi.advanceTimersByTime(300);
+
+      expect(t.deps.setCollectionState).toHaveBeenCalled();
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.CHANGE, expect.any(Function), { debounce: true });
+    });
+
+    it('skips flush when output data length does not match the collection size', () => {
+      const t = setup({ outputDataLength: 0 });
+      const id = t.collection.add({ fileName: 'a.txt' }); // size 1, output 0
+      (t.deps.setCollectionState as Mock).mockClear();
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      vi.advanceTimersByTime(300);
+
+      expect(t.deps.setCollectionState).not.toHaveBeenCalled();
+    });
+
+    it('creates a group when groupOutput is on and the collection is fully successful', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '-/preview/' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockResolvedValue({ uuid: 'group~1' } as UploadcareGroup);
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(mockUploadFileGroup).toHaveBeenCalled();
+      expect(t.deps.setGroupInfo).toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
+    it('aborts group creation if the collection state changed mid-flight', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state, outputDataLength: 1 });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockImplementation(async () => {
+        t.setCollectionStateValue(makeState({ totalCount: 2, status: 'success' })); // race: state replaced
+        return { uuid: 'group~1' } as UploadcareGroup;
+      });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith({ uuid: 'group~1' });
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+  });
+
+  describe('common upload progress', () => {
+    it('averages trigger-entry progress and emits COMMON_UPLOAD_PROGRESS on change', () => {
+      const t = setup();
+      const a = t.collection.add({ isUploading: true });
+      const b = t.collection.add({ isUploading: true });
+      t.collection.publishProp(a, 'uploadProgress', 40);
+      t.collection.publishProp(b, 'uploadProgress', 60);
+      t.uploadTriggerSet.add(a);
+      t.uploadTriggerSet.add(b);
+
+      t.fireProperties({ uploadProgress: new Set([a, b]) });
+
+      expect(t.deps.setCommonProgress).toHaveBeenCalledWith(50);
+      expect(t.emit).toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_PROGRESS, expect.anything());
+    });
+
+    it('does not re-emit when the rounded progress is unchanged', () => {
+      const t = setup();
+      const a = t.collection.add({ isUploading: true });
+      t.collection.publishProp(a, 'uploadProgress', 0);
+      t.uploadTriggerSet.add(a);
+
+      // common progress starts at 0; an all-zero average stays 0 → no emit
+      t.fireProperties({ uploadProgress: new Set([a]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_PROGRESS, expect.anything());
+    });
+  });
+});

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -1,0 +1,309 @@
+import { type FileFromOptions, type UploadcareGroup, uploadFileGroup } from '@uploadcare/upload-client';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState, OutputErrorCollection, OutputFileEntry, OutputFileStatus } from '../../types';
+import { debounce } from '../../utils/debounce';
+import { type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../EventBus';
+import { TypedData } from '../TypedData';
+import type { UploadEntryData } from '../uploadEntrySchema';
+import type { ConfigController } from './ConfigController';
+import type {
+  CollectionObserver,
+  UploadCollectionChangeMap,
+  UploadCollectionController,
+} from './UploadCollectionController';
+import type { ValidationController } from './ValidationController';
+
+type Unsubscribe = () => void;
+
+/** Emit on the event backbone (telemetry-augmented `LitBlock.emit`). */
+type EmitFn = <T extends UploaderEventKey>(
+  type: T,
+  payload?: UploaderEventPayload[T] | (() => UploaderEventPayload[T]),
+  options?: { debounce?: boolean | number },
+) => void;
+
+export type UploadEventsControllerDeps = {
+  collection: UploadCollectionController;
+  config: ConfigController;
+  validation: ValidationController;
+  emit: EmitFn;
+  getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => OutputFileEntry<TStatus>;
+  getOutputCollectionState: () => OutputCollectionState;
+  getOutputData: () => OutputFileEntry[];
+  /** Base upload-client options for the grouped upload (from `UploadController`). */
+  buildUploadOptions: () => Promise<FileFromOptions>;
+  /** Run plugin `onAdd` hooks for a freshly-added entry. */
+  runOnAddHooks: (entry: TypedData<UploadEntryData>) => void;
+  /** Apply the `cropPreset` to freshly-uploaded images (lives in the UI layer). */
+  applyInitialCrop: () => void;
+
+  // ─── v1 shared-state bridge (`*`-keys via the `$` proxy) ───
+  /** The live `*uploadTrigger` set (mutated in place on remove). */
+  uploadTrigger: () => Set<Uid>;
+  setUploadList: (list: { uid: Uid }[]) => void;
+  getCollectionState: () => OutputCollectionState | null;
+  setCollectionState: (state: OutputCollectionState | null) => void;
+  getCommonProgress: () => number;
+  setCommonProgress: (progress: number) => void;
+  setGroupInfo: (group: UploadcareGroup | null) => void;
+  getCollectionErrors: () => OutputErrorCollection[];
+};
+
+const VALIDATION_TRIGGER_KEYS: (keyof UploadEntryData)[] = [
+  'file',
+  'uploadError',
+  'fileInfo',
+  'cdnUrl',
+  'cdnUrlModifiers',
+];
+
+/**
+ * DOM-free upload-events engine — the collection→events derivation that v1 ran
+ * inline in `LitUploaderBlock` (`_handleCollectionUpdate` /
+ * `_handleCollectionPropertiesUpdate` / `_flushOutputItems` /
+ * `_flushCommonUploadProgress` / `_createGroup`).
+ *
+ * It observes the upload collection and, as entries are added/removed and their
+ * properties change, drives validation, emits the documented events (via the
+ * injected telemetry-augmented `emit`, which reaches the EventBus), maintains
+ * the derived `*uploadList`/`*collectionState`/`*commonProgress`/`*groupInfo`
+ * shared state through injected sinks, and creates the output group. All
+ * collaborators are injected, so it runs without a DOM and is unit-testable.
+ */
+export class UploadEventsController {
+  private _deps: UploadEventsControllerDeps;
+  // Active while observing (the v1 `isConnected` guard) — survives disconnect/
+  // reconnect cycles; gates the debounced flush + deferred validation that may
+  // fire after the host disconnects.
+  private _active = false;
+  private _unobserveCollection?: Unsubscribe;
+  private _unobserveProperties?: Unsubscribe;
+
+  public constructor(deps: UploadEventsControllerDeps) {
+    this._deps = deps;
+  }
+
+  /** Start observing the collection. Idempotent. */
+  public observe(): void {
+    this.unobserve();
+    this._active = true;
+    this._unobserveCollection = this._deps.collection.observeCollection(this._handleCollectionUpdate);
+    this._unobserveProperties = this._deps.collection.observeProperties(this._handleCollectionPropertiesUpdate);
+  }
+
+  public unobserve(): void {
+    this._active = false;
+    this._unobserveProperties?.();
+    this._unobserveCollection?.();
+    this._unobserveProperties = undefined;
+    this._unobserveCollection = undefined;
+    this._flushOutputItems.cancel();
+  }
+
+  /** Final teardown — alias for {@link unobserve}. */
+  public destroy(): void {
+    this.unobserve();
+  }
+
+  private _handleCollectionUpdate: CollectionObserver = (entries, added, removed) => {
+    if (!this._active) return;
+    const { validation, emit, getOutputItem } = this._deps;
+
+    if (added.size || removed.size) {
+      this._deps.setGroupInfo(null);
+    }
+
+    validation.runFileValidators(
+      'add',
+      [...added].map((e) => e.uid),
+    );
+
+    for (const entry of added) {
+      if (!entry.getValue('silent')) {
+        emit(UploaderEventType.FILE_ADDED, getOutputItem(entry.uid));
+      }
+      this._deps.runOnAddHooks(entry);
+    }
+
+    validation.runCollectionValidators();
+
+    for (const entry of removed) {
+      this._deps.uploadTrigger().delete(entry.uid);
+
+      validation.cleanupValidationForEntry(entry);
+      entry.getValue('abortController')?.abort();
+      entry.setMultipleValues({
+        isRemoved: true,
+        abortController: null,
+        isUploading: false,
+        uploadProgress: 0,
+      });
+      const thumbUrl = entry?.getValue('thumbUrl');
+      thumbUrl && URL.revokeObjectURL(thumbUrl);
+      emit(UploaderEventType.FILE_REMOVED, getOutputItem(entry.uid));
+    }
+
+    this._deps.setUploadList(entries.map((uid) => ({ uid })));
+
+    this._flushCommonUploadProgress();
+    this._flushOutputItems();
+  };
+
+  private _handleCollectionPropertiesUpdate = (changeMap: UploadCollectionChangeMap): void => {
+    if (!this._active) return;
+    const { collection, config, validation, emit, getOutputItem, getOutputCollectionState } = this._deps;
+
+    this._flushOutputItems();
+
+    const entriesToRunValidation = [
+      ...new Set(
+        Object.entries(changeMap)
+          .filter(([key]) => VALIDATION_TRIGGER_KEYS.includes(key as keyof UploadEntryData))
+          .flatMap(([, ids]) => [...(ids ?? [])]),
+      ),
+    ];
+
+    entriesToRunValidation.length > 0 &&
+      setTimeout(() => {
+        if (!this._active) return;
+        // We can't modify entry properties in the same tick, so we need to wait a bit
+        const entriesToRunOnUpload = entriesToRunValidation.filter(
+          (entryId) =>
+            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
+        );
+        if (entriesToRunOnUpload.length > 0) {
+          validation.runFileValidators('upload', entriesToRunOnUpload);
+        }
+        validation.runFileValidators('change', entriesToRunValidation);
+      });
+
+    if (changeMap.uploadProgress) {
+      for (const entryId of changeMap.uploadProgress) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
+        if (isUploading && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_PROGRESS, getOutputItem(entryId));
+        }
+      }
+
+      this._flushCommonUploadProgress();
+    }
+    if (changeMap.isUploading) {
+      for (const entryId of changeMap.isUploading) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { isUploading, silent } = entry.snapshot();
+        if (isUploading && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_START, getOutputItem(entryId));
+        }
+      }
+    }
+    if (changeMap.fileInfo) {
+      for (const entryId of changeMap.fileInfo) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { fileInfo, silent } = entry.snapshot();
+        if (fileInfo && !silent) {
+          emit(UploaderEventType.FILE_UPLOAD_SUCCESS, getOutputItem(entryId));
+        }
+      }
+      if (config.get('cropPreset')) {
+        this._deps.applyInitialCrop();
+      }
+    }
+    if (changeMap.errors) {
+      validation.runCollectionValidators();
+
+      for (const entryId of changeMap.errors) {
+        const entry = TypedData.getByUid<UploadEntryData>(entryId);
+        if (!entry) continue;
+        const { errors } = entry.snapshot();
+        if (errors.length > 0) {
+          emit(UploaderEventType.FILE_UPLOAD_FAILED, getOutputItem(entryId));
+          emit(
+            UploaderEventType.COMMON_UPLOAD_FAILED,
+            () => getOutputCollectionState() as OutputCollectionState<'failed'>,
+            { debounce: true },
+          );
+        }
+      }
+      const loadedItems = collection.findItems((entry) => !!entry.getValue('fileInfo'));
+      const errorItems = collection.findItems((entry) => entry.getValue('errors').length > 0);
+      if (
+        collection.size > 0 &&
+        errorItems.length === 0 &&
+        collection.size === loadedItems.length &&
+        this._deps.getCollectionErrors().length === 0
+      ) {
+        emit(UploaderEventType.COMMON_UPLOAD_SUCCESS, getOutputCollectionState() as OutputCollectionState<'success'>);
+      }
+    }
+    if (changeMap.cdnUrl) {
+      const uids = [...changeMap.cdnUrl].filter((uid) => !!collection.read(uid)?.getValue('cdnUrl'));
+      uids.forEach((uid) => {
+        emit(UploaderEventType.FILE_URL_CHANGED, getOutputItem(uid));
+      });
+
+      this._deps.setGroupInfo(null);
+    }
+  };
+
+  private _flushOutputItems = debounce(async () => {
+    const { collection, config, emit, getOutputCollectionState, getOutputData, setCollectionState } = this._deps;
+    const data = getOutputData();
+    if (data.length !== collection.size) {
+      return;
+    }
+    const collectionState = getOutputCollectionState();
+    setCollectionState(collectionState);
+    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+
+    if (config.get('groupOutput') && collectionState.totalCount > 0 && collectionState.status === 'success') {
+      this._createGroup(collectionState);
+    }
+  }, 300);
+
+  private async _createGroup(collectionState: OutputCollectionState): Promise<void> {
+    const { emit, getOutputCollectionState, getCollectionState, setCollectionState, setGroupInfo, buildUploadOptions } =
+      this._deps;
+    const uploadClientOptions = await buildUploadOptions();
+    const uuidList = collectionState.allEntries.map((entry) => {
+      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
+    });
+    const abortController = new AbortController();
+    const resp = await uploadFileGroup(uuidList, {
+      ...uploadClientOptions,
+      signal: abortController.signal,
+    });
+    if (getCollectionState() !== collectionState) {
+      abortController.abort();
+      return;
+    }
+    setGroupInfo(resp);
+    const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
+    emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
+    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+    setCollectionState(collectionStateWithGroup);
+  }
+
+  private _flushCommonUploadProgress = (): void => {
+    const { collection, emit, getOutputCollectionState, getCommonProgress, setCommonProgress } = this._deps;
+    let commonProgress = 0;
+    const items = [...this._deps.uploadTrigger()].filter((id) => !!collection.read(id));
+    items.forEach((id) => {
+      const uploadProgress = collection.readProp(id, 'uploadProgress');
+      if (typeof uploadProgress === 'number') {
+        commonProgress += uploadProgress;
+      }
+    });
+    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
+
+    if (getCommonProgress() === progress) {
+      return;
+    }
+
+    setCommonProgress(progress);
+    emit(UploaderEventType.COMMON_UPLOAD_PROGRESS, getOutputCollectionState() as OutputCollectionState<'uploading'>);
+  };
+}

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -276,7 +276,10 @@ export class UploadEventsController {
       ...uploadClientOptions,
       signal: abortController.signal,
     });
-    if (getCollectionState() !== collectionState) {
+    // Bail if the controller was unobserved mid-flight (the `_active` check is
+    // new with the controller lifecycle) or the collection state moved on
+    // (mirrors v1).
+    if (!this._active || getCollectionState() !== collectionState) {
       abortController.abort();
       return;
     }

--- a/src/abstract/managers/plugin/PluginController.test.ts
+++ b/src/abstract/managers/plugin/PluginController.test.ts
@@ -50,8 +50,9 @@ const setup = () => {
     onCompute?.(Promise.resolve(plugins));
     await controller.pluginsReady();
   };
+  const push = (pluginsPromise: Promise<UploaderPlugin[] | undefined>) => onCompute?.(pluginsPromise);
 
-  return { controller, sync, getUploaderApi, debug, unwatch, configUnsubs };
+  return { controller, sync, push, getUploaderApi, debug, unwatch, configUnsubs };
 };
 
 const sourcePlugin = (id: string, setup?: UploaderPlugin['setup']): UploaderPlugin => ({
@@ -152,6 +153,47 @@ describe('PluginController', () => {
     it('ignores an undefined plugin list from the loader', async () => {
       const t = setup();
       await expect(t.sync(undefined)).resolves.toBeUndefined();
+      expect(t.controller.snapshot().sources).toHaveLength(0);
+    });
+
+    it('isolates a throwing plugin dispose during unregister and still completes cleanup', async () => {
+      const t = setup();
+      const dispose = vi.fn(() => {
+        throw new Error('dispose boom');
+      });
+      await t.sync([
+        sourcePlugin('a', ({ pluginApi }) => {
+          pluginApi.registry.registerSource({ id: 'a', label: 'a', icon: 'a', onSelect: () => {} });
+          return dispose;
+        }),
+      ]);
+
+      await expect(t.sync([])).resolves.toBeUndefined(); // unregister doesn't throw
+      expect(dispose).toHaveBeenCalled();
+      expect(t.controller.snapshot().sources).toHaveLength(0); // cleanup still ran
+      expect(t.debug).toHaveBeenCalledWith('Failed to dispose plugin', expect.any(Error));
+    });
+
+    it('recovers the sync queue after a rejected emission so later syncs still run', async () => {
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const t = setup();
+
+      t.push(Promise.reject(new Error('load failed')));
+      await t.controller.pluginsReady(); // must not reject
+
+      expect(errorSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to sync plugins'), expect.any(Error));
+
+      await t.sync([sourcePlugin('a')]); // queue recovered → still processes
+      expect(t.controller.snapshot().sources.map((s) => s.id)).toEqual(['a']);
+    });
+
+    it('skips a queued emission that arrives after destroy()', async () => {
+      const t = setup();
+      t.controller.destroy();
+
+      t.push(Promise.resolve([sourcePlugin('late')]));
+      await t.controller.pluginsReady();
+
       expect(t.controller.snapshot().sources).toHaveLength(0);
     });
   });

--- a/src/abstract/managers/plugin/PluginController.test.ts
+++ b/src/abstract/managers/plugin/PluginController.test.ts
@@ -1,0 +1,357 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TypedData } from '../../TypedData';
+import { initialUploadEntryData, type UploadEntryData, type UploadEntryTypedData } from '../../uploadEntrySchema';
+import { PluginController, type PluginControllerDeps } from './PluginController';
+import type { PluginRegistry } from './PluginRegistry';
+import type { PluginApi, PluginUploaderApi, UploaderPlugin } from './PluginTypes';
+
+// A `buildApi` that wires the registry register* methods onto the real registry,
+// so registrations show up in `snapshot()` / get purged on unregister. Pushes a
+// tracked unsub into `configSubscriptions` to exercise the error-cleanup path.
+const setup = () => {
+  let onCompute: ((p: Promise<UploaderPlugin[] | undefined>) => void) | undefined;
+  const unwatch = vi.fn();
+  const getUploaderApi = vi.fn(() => ({}) as PluginUploaderApi);
+  const debug = vi.fn();
+  const configUnsubs: Array<ReturnType<typeof vi.fn>> = [];
+
+  const buildApi: PluginControllerDeps['buildApi'] = (registry: PluginRegistry, pluginId, configSubscriptions) => {
+    const sub = vi.fn();
+    configUnsubs.push(sub);
+    configSubscriptions.push(sub);
+    const registryApi: PluginApi['registry'] = {
+      registerSource: (s) => registry.addSource(pluginId, s),
+      registerActivity: (a) => registry.addActivity(pluginId, a),
+      registerFileAction: (a) => registry.addFileAction(pluginId, a),
+      registerFileHook: (h) => registry.addFileHook(pluginId, h),
+      registerIcon: (i) => registry.addIcon(pluginId, i),
+      registerL10n: () => {},
+      registerConfig: () => {},
+    };
+    return {
+      registry: registryApi,
+      config: { get: () => undefined, subscribe: () => () => {} },
+      activity: { getParams: () => ({}), subscribeToParams: () => () => {} },
+      files: { update: () => {} },
+    } as unknown as PluginApi;
+  };
+
+  const controller = new PluginController({
+    buildApi,
+    getUploaderApi,
+    watchPlugins: (cb) => {
+      onCompute = cb;
+      return unwatch;
+    },
+    debug,
+  });
+
+  const sync = async (plugins: UploaderPlugin[] | undefined) => {
+    onCompute?.(Promise.resolve(plugins));
+    await controller.pluginsReady();
+  };
+
+  return { controller, sync, getUploaderApi, debug, unwatch, configUnsubs };
+};
+
+const sourcePlugin = (id: string, setup?: UploaderPlugin['setup']): UploaderPlugin => ({
+  id,
+  setup:
+    setup ??
+    (({ pluginApi }) => {
+      pluginApi.registry.registerSource({ id, label: id, icon: id, onSelect: () => {} });
+    }),
+});
+
+describe('PluginController', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('install / sync', () => {
+    it('registers a plugin: builds api, calls setup with the uploader api, surfaces its registrations', async () => {
+      const t = setup();
+      const onChange = vi.fn();
+      t.controller.onPluginsChange(onChange);
+
+      await t.sync([sourcePlugin('a')]);
+
+      expect(t.getUploaderApi).toHaveBeenCalled();
+      expect(t.controller.snapshot().sources.map((s) => s.id)).toEqual(['a']);
+      expect(onChange).toHaveBeenCalled();
+    });
+
+    it('skips a plugin missing an id', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const t = setup();
+
+      await t.sync([{ id: '', setup: () => {} }]);
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('missing the required "id"'));
+      expect(t.controller.snapshot().sources).toHaveLength(0);
+    });
+
+    it('skips a duplicate id within the same sync', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const t = setup();
+      const setupSpy = vi.fn(({ pluginApi }: Parameters<UploaderPlugin['setup']>[0]) =>
+        pluginApi.registry.registerSource({ id: 'dup', label: 'dup', icon: 'dup', onSelect: () => {} }),
+      );
+
+      await t.sync([sourcePlugin('dup', setupSpy), sourcePlugin('dup', setupSpy)]);
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('already in the list'));
+      expect(setupSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not re-register an already-installed plugin on a later sync', async () => {
+      const t = setup();
+      const setupSpy = vi.fn(sourcePlugin('a').setup);
+      await t.sync([sourcePlugin('a', setupSpy)]);
+      await t.sync([sourcePlugin('a', setupSpy)]); // still present → no re-setup
+
+      expect(setupSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('isolates a plugin whose setup throws: purges, logs, keeps others, cleans config subs', async () => {
+      const error = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const t = setup();
+      const boom = sourcePlugin('boom', ({ pluginApi }) => {
+        pluginApi.registry.registerSource({ id: 'boom', label: 'b', icon: 'b', onSelect: () => {} });
+        throw new Error('setup failed');
+      });
+
+      await t.sync([boom, sourcePlugin('ok')]);
+
+      expect(error).toHaveBeenCalledWith(expect.stringContaining('"boom" setup() threw'), expect.any(Error));
+      expect(t.controller.snapshot().sources.map((s) => s.id)).toEqual(['ok']); // boom purged
+      expect(t.configUnsubs[0]).toHaveBeenCalled(); // its config sub was cleaned up
+    });
+
+    it('unregisters a plugin dropped from a later sync: purges + disposes', async () => {
+      const t = setup();
+      const dispose = vi.fn();
+      await t.sync([
+        sourcePlugin('a', ({ pluginApi }) => {
+          pluginApi.registry.registerSource({ id: 'a', label: 'a', icon: 'a', onSelect: () => {} });
+          return dispose;
+        }),
+      ]);
+      expect(t.controller.snapshot().sources).toHaveLength(1);
+
+      await t.sync([]); // 'a' gone
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(t.controller.snapshot().sources).toHaveLength(0);
+    });
+
+    it('ignores an undefined plugin list from the loader', async () => {
+      const t = setup();
+      await expect(t.sync(undefined)).resolves.toBeUndefined();
+      expect(t.controller.snapshot().sources).toHaveLength(0);
+    });
+  });
+
+  describe('onPluginsChange', () => {
+    it('stops notifying after unsubscribe', async () => {
+      const t = setup();
+      const onChange = vi.fn();
+      const unsub = t.controller.onPluginsChange(onChange);
+      unsub();
+
+      await t.sync([sourcePlugin('a')]);
+
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it('isolates a throwing subscriber so others still run', async () => {
+      const t = setup();
+      const good = vi.fn();
+      t.controller.onPluginsChange(() => {
+        throw new Error('subscriber boom');
+      });
+      t.controller.onPluginsChange(good);
+
+      await expect(t.sync([sourcePlugin('a')])).resolves.toBeUndefined();
+      expect(good).toHaveBeenCalled();
+    });
+  });
+
+  describe('runOnAddHooks', () => {
+    const makeEntry = (file: File | null): UploadEntryTypedData => {
+      const entry = new TypedData<UploadEntryData>(initialUploadEntryData);
+      if (file) entry.setValue('file', file);
+      return entry;
+    };
+
+    const withOnAddHook = (handler: (ctx: { file: File | Blob; signal: AbortSignal }) => unknown, timeout = 30000) =>
+      sourcePlugin('hookplugin', ({ pluginApi }) => {
+        pluginApi.registry.registerFileHook({ type: 'onAdd', handler: handler as never, timeout });
+      });
+
+    it('runs the onAdd hook chain and re-derives file fields on transform', async () => {
+      const t = setup();
+      const newFile = new File(['transformed-bytes'], 'new.png', { type: 'image/png' });
+      await t.sync([withOnAddHook(() => ({ file: newFile }))]);
+      const entry = makeEntry(new File(['x'], 'a.txt'));
+
+      await t.controller.runOnAddHooks(entry);
+
+      expect(entry.getValue('file')).toBe(newFile);
+      expect(entry.getValue('fileName')).toBe('new.png');
+      expect(entry.getValue('mimeType')).toBe('image/png');
+      expect(entry.getValue('isImage')).toBe(true);
+      expect(entry.getValue('fileSize')).toBe(newFile.size);
+    });
+
+    it('no-ops when the entry has no file', async () => {
+      const t = setup();
+      const handler = vi.fn();
+      await t.sync([withOnAddHook(handler)]);
+
+      await t.controller.runOnAddHooks(makeEntry(null));
+
+      expect(handler).not.toHaveBeenCalled();
+    });
+
+    it('no-ops when there are no onAdd hooks', async () => {
+      const t = setup();
+      await t.sync([sourcePlugin('a')]);
+      const entry = makeEntry(new File(['x'], 'a.txt'));
+      const original = entry.getValue('file');
+
+      await t.controller.runOnAddHooks(entry);
+
+      expect(entry.getValue('file')).toBe(original);
+    });
+
+    it('isolates a throwing hook and keeps the original file', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const t = setup();
+      await t.sync([
+        withOnAddHook(() => {
+          throw new Error('hook boom');
+        }),
+      ]);
+      const original = new File(['x'], 'a.txt');
+      const entry = makeEntry(original);
+
+      await t.controller.runOnAddHooks(entry);
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('onAdd'), expect.any(Error));
+      expect(entry.getValue('file')).toBe(original);
+    });
+
+    it('applies a Blob-returning hook without touching fileName', async () => {
+      const t = setup();
+      const newBlob = new Blob(['data'], { type: 'text/plain' });
+      await t.sync([withOnAddHook(() => ({ file: newBlob }))]);
+      const entry = makeEntry(new File(['x'], 'a.txt'));
+      entry.setValue('fileName', 'original.txt');
+
+      await t.controller.runOnAddHooks(entry);
+
+      expect(entry.getValue('file')).toBe(newBlob);
+      expect(entry.getValue('fileName')).toBe('original.txt'); // unchanged — a Blob has no name
+      expect(entry.getValue('mimeType')).toBe('text/plain');
+    });
+
+    it('skips a hook that exceeds its timeout', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const t = setup();
+      await t.sync([withOnAddHook(() => new Promise(() => {}), 50)]);
+      const entry = makeEntry(new File(['x'], 'a.txt'));
+
+      const promise = t.controller.runOnAddHooks(entry);
+      await vi.advanceTimersByTimeAsync(60);
+      await promise;
+
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('onAdd'), expect.any(Error));
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('destroy() unregisters all plugins, destroys the registry, and tears down the watcher', async () => {
+      const t = setup();
+      const dispose = vi.fn();
+      await t.sync([
+        sourcePlugin('a', ({ pluginApi }) => {
+          pluginApi.registry.registerSource({ id: 'a', label: 'a', icon: 'a', onSelect: () => {} });
+          return dispose;
+        }),
+      ]);
+
+      t.controller.destroy();
+
+      expect(dispose).toHaveBeenCalledTimes(1);
+      expect(t.controller.snapshot().sources).toHaveLength(0);
+      expect(t.unwatch).toHaveBeenCalled();
+    });
+
+    it('exposes the config registry', () => {
+      const t = setup();
+      expect(t.controller.configRegistry).toBe(t.controller.registry.config);
+    });
+
+    it('logs (via debug) when a config-subscription throws during error cleanup', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const debug = vi.fn();
+      let onCompute: ((p: Promise<UploaderPlugin[] | undefined>) => void) | undefined;
+      const controller = new PluginController({
+        buildApi: (_registry, _pluginId, subs) => {
+          subs.push(() => {
+            throw new Error('unsub boom');
+          });
+          return {} as PluginApi;
+        },
+        getUploaderApi: () => ({}) as PluginUploaderApi,
+        watchPlugins: (cb) => {
+          onCompute = cb;
+          return () => {};
+        },
+        debug,
+      });
+
+      onCompute?.(
+        Promise.resolve([
+          {
+            id: 'x',
+            setup: () => {
+              throw new Error('setup boom');
+            },
+          },
+        ]),
+      );
+      await controller.pluginsReady();
+
+      expect(debug).toHaveBeenCalledWith('Failed to unsubscribe config listener', expect.any(Error));
+    });
+
+    it('logs when a config-subscription throws during unregister, with debug defaulting to a no-op', async () => {
+      let onCompute: ((p: Promise<UploaderPlugin[] | undefined>) => void) | undefined;
+      const controller = new PluginController({
+        buildApi: (_registry, _pluginId, subs) => {
+          subs.push(() => {
+            throw new Error('unsub boom');
+          });
+          return {} as PluginApi;
+        },
+        getUploaderApi: () => ({}) as PluginUploaderApi,
+        watchPlugins: (cb) => {
+          onCompute = cb;
+          return () => {};
+        },
+        // no debug → exercises the no-op default on the cleanup path
+      });
+
+      onCompute?.(Promise.resolve([{ id: 'x', setup: () => {} }]));
+      await controller.pluginsReady();
+      onCompute?.(Promise.resolve([])); // remove 'x' → unregister → throwing sub caught
+      await expect(controller.pluginsReady()).resolves.toBeUndefined();
+    });
+  });
+});

--- a/src/abstract/managers/plugin/PluginController.ts
+++ b/src/abstract/managers/plugin/PluginController.ts
@@ -1,27 +1,58 @@
-import type { Unsubscriber } from '../../../lit/PubSubCompat';
-import { SharedInstance, type SharedInstancesBag } from '../../../lit/shared-instances';
 import { fileIsImage } from '../../../utils/fileTypes';
 import type { UploadEntryTypedData } from '../../uploadEntrySchema';
-import { buildPluginApi } from './buildPluginApi';
-import { LazyPluginLoader } from './LazyPluginLoader';
 import { PluginRegistry } from './PluginRegistry';
-import type { PluginRegistrySnapshot, UploaderPlugin } from './PluginTypes';
+import type { PluginApi, PluginRegistrySnapshot, PluginUploaderApi, UploaderPlugin } from './PluginTypes';
 
-export class PluginManager extends SharedInstance {
+type Unsubscribe = () => void;
+
+export type PluginControllerDeps = {
+  /** Build the per-plugin public `PluginApi` (config/activity/files bridged to the host). */
+  buildApi: (registry: PluginRegistry, pluginId: string, configSubscriptions: Unsubscribe[]) => PluginApi;
+  /** The public uploader API passed to each plugin's `setup`. */
+  getUploaderApi: () => PluginUploaderApi;
+  /**
+   * Subscribe to the resolved plugin list (user `cfg.plugins` + lazy plugins).
+   * Each emission is a promise of the plugins to sync to. Returns a teardown.
+   */
+  watchPlugins: (onCompute: (pluginsPromise: Promise<UploaderPlugin[] | undefined>) => void) => Unsubscribe;
+  /** Debug logger — defaults to a no-op. */
+  debug?: (...args: unknown[]) => void;
+};
+
+type RegisteredPlugin = {
+  plugin: UploaderPlugin;
+  dispose?: Unsubscribe;
+  configSubscriptions: Unsubscribe[];
+};
+
+/**
+ * DOM-free plugin engine — a faithful port of v1's `PluginManager` (which was a
+ * `SharedInstance`). Owns the {@link PluginRegistry}, runs the install/uninstall
+ * lifecycle (dedup, error isolation, dispose + config-subscription cleanup), and
+ * the `onAdd` hook chain. Its ctx/bag couplings are injected: `buildApi`
+ * (wraps `buildPluginApi`), `getUploaderApi`, and `watchPlugins` (wraps the
+ * ctx-watching `LazyPluginLoader`) — so it constructs without a DOM and is unit
+ * testable. Consumers still reach it through the unchanged `pluginManager`
+ * getter / `*pluginManager` shared instance.
+ */
+export class PluginController {
+  private _deps: PluginControllerDeps;
+  private _debug: (...args: unknown[]) => void;
   private _plugins: Map<string, RegisteredPlugin> = new Map();
-  private _subscribers: Set<Unsubscriber> = new Set();
+  private _subscribers: Set<Unsubscribe> = new Set();
   private _pluginsUpdate: Promise<void> = Promise.resolve();
-  private _lazyPluginLoader: LazyPluginLoader;
+  private _unwatchPlugins: Unsubscribe;
   public readonly registry = new PluginRegistry(() => this._notifySubscribers());
 
   public get configRegistry() {
     return this.registry.config;
   }
 
-  public constructor(sharedInstancesBag: SharedInstancesBag) {
-    super(sharedInstancesBag);
+  public constructor(deps: PluginControllerDeps) {
+    this._deps = deps;
+    this._debug = deps.debug ?? (() => {});
 
-    this._lazyPluginLoader = new LazyPluginLoader(this._ctx, (pluginsPromise) => {
+    this._unwatchPlugins = deps.watchPlugins((pluginsPromise) => {
       this._pluginsUpdate = this._pluginsUpdate
         .then(() => pluginsPromise)
         .then((plugins) => {
@@ -37,7 +68,7 @@ export class PluginManager extends SharedInstance {
     return this._pluginsUpdate;
   }
 
-  public onPluginsChange(callback: Unsubscriber): Unsubscriber {
+  public onPluginsChange(callback: Unsubscribe): Unsubscribe {
     this._subscribers.add(callback);
     return () => {
       this._subscribers.delete(callback);
@@ -82,17 +113,11 @@ export class PluginManager extends SharedInstance {
       this._unregisterPlugin(plugin.id);
     }
 
-    const configSubscriptions: Unsubscriber[] = [];
-    const pluginApi = buildPluginApi(
-      this.registry,
-      this._ctx,
-      this._sharedInstancesBag,
-      plugin.id,
-      configSubscriptions,
-    );
+    const configSubscriptions: Unsubscribe[] = [];
+    const pluginApi = this._deps.buildApi(this.registry, plugin.id, configSubscriptions);
 
-    const uploaderApi = this._sharedInstancesBag.api;
-    let pluginDispose: Unsubscriber | undefined;
+    const uploaderApi = this._deps.getUploaderApi();
+    let pluginDispose: Unsubscribe | undefined;
     try {
       pluginDispose = (await plugin.setup({ pluginApi, uploaderApi })) ?? undefined;
     } catch (error) {
@@ -100,7 +125,7 @@ export class PluginManager extends SharedInstance {
         try {
           unsub();
         } catch (e) {
-          this._debugPrint('Failed to unsubscribe config listener', e);
+          this._debug('Failed to unsubscribe config listener', e);
         }
       }
       throw error;
@@ -120,7 +145,7 @@ export class PluginManager extends SharedInstance {
       try {
         unsub();
       } catch (error) {
-        this._debugPrint('Failed to unsubscribe config listener', error);
+        this._debug('Failed to unsubscribe config listener', error);
       }
     }
 
@@ -166,13 +191,12 @@ export class PluginManager extends SharedInstance {
     }
   }
 
-  public override destroy(): void {
+  public destroy(): void {
     for (const pluginId of Array.from(this._plugins.keys())) {
       this._unregisterPlugin(pluginId);
     }
     this.registry.destroy();
-    this._lazyPluginLoader.destroy();
-    super.destroy();
+    this._unwatchPlugins();
   }
 
   private _notifySubscribers(): void {
@@ -185,9 +209,3 @@ export class PluginManager extends SharedInstance {
     }
   }
 }
-
-type RegisteredPlugin = {
-  plugin: UploaderPlugin;
-  dispose?: Unsubscriber;
-  configSubscriptions: Unsubscriber[];
-};

--- a/src/abstract/managers/plugin/PluginController.ts
+++ b/src/abstract/managers/plugin/PluginController.ts
@@ -38,6 +38,7 @@ type RegisteredPlugin = {
 export class PluginController {
   private _deps: PluginControllerDeps;
   private _debug: (...args: unknown[]) => void;
+  private _isDestroyed = false;
   private _plugins: Map<string, RegisteredPlugin> = new Map();
   private _subscribers: Set<Unsubscribe> = new Set();
   private _pluginsUpdate: Promise<void> = Promise.resolve();
@@ -56,10 +57,14 @@ export class PluginController {
       this._pluginsUpdate = this._pluginsUpdate
         .then(() => pluginsPromise)
         .then((plugins) => {
-          if (plugins) {
-            return this._syncPlugins(plugins);
-          }
-          return;
+          // Skip once destroyed so a queued emission can't re-register on a dead controller.
+          if (this._isDestroyed || !plugins) return;
+          return this._syncPlugins(plugins);
+        })
+        // Recover the queue: a rejected emission must not permanently poison the
+        // chain so later emissions never run. (`_pluginsUpdate` always resolves.)
+        .catch((error) => {
+          console.error('[PluginManager] Failed to sync plugins', error);
         });
     });
   }
@@ -149,7 +154,11 @@ export class PluginController {
       }
     }
 
-    registered.dispose?.();
+    try {
+      registered.dispose?.();
+    } catch (error) {
+      this._debug('Failed to dispose plugin', error);
+    }
     this._plugins.delete(pluginId);
     this._notifySubscribers();
   }
@@ -192,11 +201,13 @@ export class PluginController {
   }
 
   public destroy(): void {
+    this._isDestroyed = true;
+    // Stop new emissions first so a queued sync can't re-register on a dead controller.
+    this._unwatchPlugins();
     for (const pluginId of Array.from(this._plugins.keys())) {
       this._unregisterPlugin(pluginId);
     }
     this.registry.destroy();
-    this._unwatchPlugins();
   }
 
   private _notifySubscribers(): void {

--- a/src/abstract/managers/plugin/index.ts
+++ b/src/abstract/managers/plugin/index.ts
@@ -1,2 +1,2 @@
-export * from './PluginManager';
+export * from './PluginController';
 export * from './PluginTypes';

--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -1,6 +1,6 @@
 // @ts-check
 import type { CustomConfig } from '../../abstract/customConfigOptions';
-import type { PluginManager } from '../../abstract/managers/plugin';
+import type { PluginController } from '../../abstract/managers/plugin';
 import { sharedConfigKey } from '../../abstract/sharedConfigKey';
 import type { ConfigComplexType, ConfigPlainType, ConfigType } from '../../types';
 import { toKebabCase } from '../../utils/toKebabCase';
@@ -211,7 +211,7 @@ export class Config extends LitBlock {
     }
   }
 
-  private _processCustomConfigs(pluginManager: PluginManager): void {
+  private _processCustomConfigs(pluginManager: PluginController): void {
     const customConfigs = pluginManager.configRegistry.getAll();
 
     // Rebuild the custom attribute mapping and names set

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -5,7 +5,9 @@ import { RouterHooksLayer } from '../abstract/features/RouterHooksLayer';
 import { A11y } from '../abstract/managers/a11y';
 import { LocaleManager, localeStateKey } from '../abstract/managers/LocaleManager';
 import { ModalManager } from '../abstract/managers/ModalManager';
-import { PluginManager } from '../abstract/managers/plugin';
+import { PluginController } from '../abstract/managers/plugin';
+import { buildPluginApi } from '../abstract/managers/plugin/buildPluginApi';
+import { LazyPluginLoader } from '../abstract/managers/plugin/LazyPluginLoader';
 import { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import { sharedConfigKey } from '../abstract/sharedConfigKey';
 import { initialConfig } from '../blocks/Config/initialConfig';
@@ -91,7 +93,20 @@ export class LitBlock extends LitBlockBase {
 
   public override initCallback(): void {
     this._addSharedContextInstance('*blocksRegistry', () => new Set());
-    this._addSharedContextInstance('*pluginManager', (sharedInstancesBag) => new PluginManager(sharedInstancesBag));
+    this._addSharedContextInstance(
+      '*pluginManager',
+      (sharedInstancesBag) =>
+        new PluginController({
+          buildApi: (registry, pluginId, configSubscriptions) =>
+            buildPluginApi(registry, sharedInstancesBag.ctx, sharedInstancesBag, pluginId, configSubscriptions),
+          getUploaderApi: () => sharedInstancesBag.api,
+          watchPlugins: (onCompute) => {
+            const loader = new LazyPluginLoader(sharedInstancesBag.ctx, onCompute);
+            return () => loader.destroy();
+          },
+          debug: (...args) => this.debugPrint(...args),
+        }),
+    );
     this._addSharedContextInstance('*eventEmitter', (sharedInstancesBag) => new EventEmitter(sharedInstancesBag));
     this._addSharedContextInstance('*localeManager', (sharedInstancesBag) => new LocaleManager(sharedInstancesBag));
     this._addSharedContextInstance('*modalManager', (sharedInstancesBag) => new ModalManager(sharedInstancesBag));

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -104,7 +104,9 @@ export class LitBlock extends LitBlockBase {
             const loader = new LazyPluginLoader(sharedInstancesBag.ctx, onCompute);
             return () => loader.destroy();
           },
-          debug: (...args) => this.debugPrint(...args),
+          // Scope debug output to the controller (not the hosting block) so its
+          // logs stay consistently prefixed, as v1's SharedInstance did.
+          debug: createDebugPrinter(() => sharedInstancesBag.ctx, 'PluginController'),
         }),
     );
     this._addSharedContextInstance('*eventEmitter', (sharedInstancesBag) => new EventEmitter(sharedInstancesBag));

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,27 +1,21 @@
 // @ts-check
 
-import { uploadFileGroup } from '@uploadcare/upload-client';
 import { uploaderBlockCtx } from '../abstract/CTX';
 import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
-import type {
-  CollectionObserver,
-  UploadCollectionChangeMap,
-  UploadCollectionController,
-} from '../abstract/controllers/UploadCollectionController';
+import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
 import { UploadController } from '../abstract/controllers/UploadController';
+import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
 import { ValidationController } from '../abstract/controllers/ValidationController';
-import { TypedData } from '../abstract/TypedData';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
-import type { UploadEntryData } from '../abstract/uploadEntrySchema';
 import { calculateMaxCenteredCropFrame } from '../blocks/CloudImageEditor/src/crop-utils';
 import { parseCropPreset } from '../blocks/CloudImageEditor/src/lib/parseCropPreset';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
-import type { OutputCollectionState, OutputFileEntry } from '../types/index';
+import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
 import { createCdnUrl, createCdnUrlModifiers } from '../utils/cdn-utils';
-import { debounce } from '../utils/debounce';
 import { ExternalUploadSource, UploadSource } from '../utils/UploadSource';
 import { getOutputData } from './getOutputData';
 import { LitActivityBlock } from './LitActivityBlock';
+import type { Uid } from './Uid';
 
 export class LitUploaderBlock extends LitActivityBlock {
   public static extSrcList: Readonly<typeof ExternalUploadSource>;
@@ -30,8 +24,7 @@ export class LitUploaderBlock extends LitActivityBlock {
 
   private _isCtxOwner = false;
 
-  private _unobserveCollection?: () => void;
-  private _unobserveCollectionProperties?: () => void;
+  private _uploadEvents?: UploadEventsController;
 
   public override init$ = uploaderBlockCtx(this);
 
@@ -133,263 +126,58 @@ export class LitUploaderBlock extends LitActivityBlock {
     super.disconnectedCallback();
 
     if (this._isCtxOwner) {
-      this._unobserveUploadCollection();
+      this._uploadEvents?.unobserve();
     }
-
-    this._flushOutputItems.cancel();
   }
 
   public override connectedCallback(): void {
     super.connectedCallback();
 
     if (this._isCtxOwner) {
-      this._observeUploadCollection();
+      this._uploadEvents?.observe();
     }
   }
 
   private _initCtxOwner(): void {
     this._isCtxOwner = true;
 
-    this._observeUploadCollection();
+    // The collection→events derivation lives in the DOM-free UploadEventsController;
+    // this block just wires its collaborators (api, validation, plugin hooks) and
+    // the v1 `*`-shared-state sinks.
+    this._uploadEvents = new UploadEventsController({
+      collection: this.uploadCollection,
+      config: this.sharedCtx.uploaderController().config,
+      validation: this.validationManager,
+      emit: (type, payload, options) => this.emit(type, payload, options),
+      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => this.api.getOutputItem<TStatus>(uid),
+      getOutputCollectionState: () => this.api.getOutputCollectionState(),
+      getOutputData: () => this.getOutputData(),
+      buildUploadOptions: () => this.uploadController.buildUploadOptions(),
+      runOnAddHooks: (entry) =>
+        void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+      applyInitialCrop: () => this._setInitialCrop(),
+      uploadTrigger: () => this.$['*uploadTrigger'],
+      setUploadList: (list) => {
+        this.$['*uploadList'] = list;
+      },
+      getCollectionState: () => this.$['*collectionState'],
+      setCollectionState: (state) => {
+        this.$['*collectionState'] = state;
+      },
+      getCommonProgress: () => this.$['*commonProgress'],
+      setCommonProgress: (progress) => {
+        this.$['*commonProgress'] = progress;
+      },
+      setGroupInfo: (group) => {
+        this.$['*groupInfo'] = group;
+      },
+      getCollectionErrors: () => this.$['*collectionErrors'],
+    });
+    this._uploadEvents.observe();
 
     // Upload-queue concurrency is owned by the UploadController, which syncs it
     // from `maxConcurrentRequests` itself.
   }
-
-  private _observeUploadCollection(): void {
-    this._unobserveUploadCollection();
-
-    this._unobserveCollection = this.uploadCollection.observeCollection(this._handleCollectionUpdate);
-
-    this._unobserveCollectionProperties = this.uploadCollection.observeProperties(
-      this._handleCollectionPropertiesUpdate,
-    );
-  }
-
-  private _unobserveUploadCollection(): void {
-    this._unobserveCollectionProperties?.();
-    this._unobserveCollection?.();
-
-    this._unobserveCollectionProperties = undefined;
-    this._unobserveCollection = undefined;
-  }
-
-  private async _createGroup(collectionState: OutputCollectionState): Promise<void> {
-    const uploadClientOptions = await this.uploadController.buildUploadOptions();
-    const uuidList = collectionState.allEntries.map((entry) => {
-      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
-    });
-    const abortController = new AbortController();
-    const resp = await uploadFileGroup(uuidList, {
-      ...uploadClientOptions,
-      signal: abortController.signal,
-    });
-    if (this.$['*collectionState'] !== collectionState) {
-      abortController.abort();
-      return;
-    }
-    this.$['*groupInfo'] = resp;
-    const collectionStateWithGroup = this.api.getOutputCollectionState() as OutputCollectionState<
-      'success',
-      'has-group'
-    >;
-    this.emit(EventType.GROUP_CREATED, collectionStateWithGroup);
-    this.emit(EventType.CHANGE, () => this.api.getOutputCollectionState(), {
-      debounce: true,
-    });
-    this.$['*collectionState'] = collectionStateWithGroup;
-  }
-
-  private _flushOutputItems = debounce(async () => {
-    const data = this.getOutputData();
-    if (data.length !== this.uploadCollection.size) {
-      return;
-    }
-    const collectionState = this.api.getOutputCollectionState();
-    this.$['*collectionState'] = collectionState;
-    this.emit(EventType.CHANGE, () => this.api.getOutputCollectionState(), {
-      debounce: true,
-    });
-
-    if (this.cfg.groupOutput && collectionState.totalCount > 0 && collectionState.status === 'success') {
-      this._createGroup(collectionState);
-    }
-  }, 300);
-
-  private _handleCollectionUpdate: CollectionObserver = (entries, added, removed) => {
-    if (!this.isConnected) return;
-    if (added.size || removed.size) {
-      this.$['*groupInfo'] = null;
-    }
-
-    this.validationManager.runFileValidators(
-      'add',
-      [...added].map((e) => e.uid),
-    );
-
-    for (const entry of added) {
-      if (!entry.getValue('silent')) {
-        this.emit(EventType.FILE_ADDED, this.api.getOutputItem(entry.uid));
-      }
-      void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry));
-    }
-
-    this.validationManager.runCollectionValidators();
-
-    for (const entry of removed) {
-      this.$['*uploadTrigger'].delete(entry.uid);
-
-      this.validationManager.cleanupValidationForEntry(entry);
-      entry.getValue('abortController')?.abort();
-      entry.setMultipleValues({
-        isRemoved: true,
-        abortController: null,
-        isUploading: false,
-        uploadProgress: 0,
-      });
-      const thumbUrl = entry?.getValue('thumbUrl');
-      thumbUrl && URL.revokeObjectURL(thumbUrl);
-      this.emit(EventType.FILE_REMOVED, this.api.getOutputItem(entry.uid));
-    }
-
-    this.$['*uploadList'] = entries.map((uid) => {
-      return { uid };
-    });
-
-    this._flushCommonUploadProgress();
-    this._flushOutputItems();
-  };
-
-  private _handleCollectionPropertiesUpdate = (changeMap: UploadCollectionChangeMap): void => {
-    if (!this.isConnected) return;
-    this._flushOutputItems();
-
-    const uploadCollection = this.uploadCollection;
-    const entriesToRunValidation = [
-      ...new Set(
-        Object.entries(changeMap)
-          .filter(([key]) => ['file', 'uploadError', 'fileInfo', 'cdnUrl', 'cdnUrlModifiers'].includes(key))
-          .flatMap(([, ids]) => [...(ids ?? [])]),
-      ),
-    ];
-
-    entriesToRunValidation.length > 0 &&
-      setTimeout(() => {
-        if (!this.isConnected) return;
-        // We can't modify entry properties in the same tick, so we need to wait a bit
-        const entriesToRunOnUpload = entriesToRunValidation.filter(
-          (entryId) =>
-            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
-        );
-        if (entriesToRunOnUpload.length > 0) {
-          this.validationManager.runFileValidators('upload', entriesToRunOnUpload);
-        }
-        this.validationManager.runFileValidators('change', entriesToRunValidation);
-      });
-
-    if (changeMap.uploadProgress) {
-      for (const entryId of changeMap.uploadProgress) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
-        if (isUploading && !silent) {
-          this.emit(EventType.FILE_UPLOAD_PROGRESS, this.api.getOutputItem(entryId));
-        }
-      }
-
-      this._flushCommonUploadProgress();
-    }
-    if (changeMap.isUploading) {
-      for (const entryId of changeMap.isUploading) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
-        if (isUploading && !silent) {
-          this.emit(EventType.FILE_UPLOAD_START, this.api.getOutputItem(entryId));
-        }
-      }
-    }
-    if (changeMap.fileInfo) {
-      for (const entryId of changeMap.fileInfo) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { fileInfo, silent } = entry.snapshot();
-        if (fileInfo && !silent) {
-          this.emit(EventType.FILE_UPLOAD_SUCCESS, this.api.getOutputItem(entryId));
-        }
-      }
-      if (this.cfg.cropPreset) {
-        this._setInitialCrop();
-      }
-    }
-    if (changeMap.errors) {
-      this.validationManager.runCollectionValidators();
-
-      for (const entryId of changeMap.errors) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { errors } = entry.snapshot();
-        if (errors.length > 0) {
-          this.emit(EventType.FILE_UPLOAD_FAILED, this.api.getOutputItem(entryId));
-          this.emit(
-            EventType.COMMON_UPLOAD_FAILED,
-            () => this.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-            { debounce: true },
-          );
-        }
-      }
-      const loadedItems = uploadCollection.findItems((entry) => {
-        return !!entry.getValue('fileInfo');
-      });
-      const errorItems = uploadCollection.findItems((entry) => {
-        return entry.getValue('errors').length > 0;
-      });
-      if (
-        uploadCollection.size > 0 &&
-        errorItems.length === 0 &&
-        uploadCollection.size === loadedItems.length &&
-        this.$['*collectionErrors'].length === 0
-      ) {
-        this.emit(
-          EventType.COMMON_UPLOAD_SUCCESS,
-          this.api.getOutputCollectionState() as OutputCollectionState<'success'>,
-        );
-      }
-    }
-    if (changeMap.cdnUrl) {
-      const uids = [...changeMap.cdnUrl].filter((uid) => {
-        return !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
-      });
-      uids.forEach((uid) => {
-        this.emit(EventType.FILE_URL_CHANGED, this.api.getOutputItem(uid));
-      });
-
-      this.$['*groupInfo'] = null;
-    }
-  };
-
-  private _flushCommonUploadProgress = (): void => {
-    let commonProgress = 0;
-    const uploadTrigger = this.$['*uploadTrigger'];
-    const items = [...uploadTrigger].filter((id) => !!this.uploadCollection.read(id));
-    items.forEach((id) => {
-      const uploadProgress = this.uploadCollection.readProp(id, 'uploadProgress');
-      if (typeof uploadProgress === 'number') {
-        commonProgress += uploadProgress;
-      }
-    });
-    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
-
-    if (this.$['*commonProgress'] === progress) {
-      return;
-    }
-
-    this.$['*commonProgress'] = progress;
-    this.emit(
-      EventType.COMMON_UPLOAD_PROGRESS,
-      this.api.getOutputCollectionState() as OutputCollectionState<'uploading'>,
-    );
-  };
 
   private _setInitialCrop(): void {
     const cropPreset = parseCropPreset(this.cfg.cropPreset);

--- a/src/lit/SharedState.ts
+++ b/src/lit/SharedState.ts
@@ -9,7 +9,7 @@ import type { LocaleDefinition } from '../abstract/localeRegistry';
 import type { A11y } from '../abstract/managers/a11y';
 import type { LocaleManager } from '../abstract/managers/LocaleManager';
 import type { ModalManager } from '../abstract/managers/ModalManager';
-import type { PluginManager } from '../abstract/managers/plugin';
+import type { PluginController } from '../abstract/managers/plugin';
 import type { LazyPluginEntry } from '../abstract/managers/plugin/LazyPluginLoader';
 import type { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import type { UploaderPublicApi } from '../abstract/UploaderPublicApi';
@@ -107,7 +107,7 @@ type DynamicBlockState = {
   '*modalManager': ModalManager | null;
   '*clipboard': ClipboardLayer;
   '*routerLayer': RouterHooksLayer;
-  '*pluginManager': PluginManager;
+  '*pluginManager': PluginController;
 };
 
 type DynamicUploaderBlockState = {

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -7,7 +7,7 @@ import type { RouterHooksLayer } from '../abstract/features/RouterHooksLayer';
 import type { A11y } from '../abstract/managers/a11y';
 import type { LocaleManager } from '../abstract/managers/LocaleManager';
 import type { ModalManager } from '../abstract/managers/ModalManager';
-import type { PluginManager } from '../abstract/managers/plugin';
+import type { PluginController } from '../abstract/managers/plugin';
 import type { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import { sharedConfigKey } from '../abstract/sharedConfigKey';
 import { initialConfig } from '../blocks/Config/initialConfig';
@@ -127,7 +127,7 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
     get modalManager(): ModalManager | null {
       return getSharedInstance(getCtx(), '*modalManager', false);
     },
-    get pluginManager(): PluginManager {
+    get pluginManager(): PluginController {
       return getSharedInstance(getCtx(), '*pluginManager');
     },
     get telemetryManager(): TelemetryManager {


### PR DESCRIPTION
## M6 — Plugins (DOM-free `PluginController`)

Part of the v2 strangler migration (see `MIGRATION-PLAN.md`). Stacked on **#994** (M5b).

**Finding:** the plugin layer was already most of what the plan's M6 describes building — `PluginRegistry` is DOM-free (with the 0ms-debounce batching), `SourceListController` is the reactive sources controller, and `buildPluginApi` is the documented bridge. The one real coupling left was **`PluginManager extends SharedInstance`**. This PR removes it.

### What changed
- **New DOM-free `PluginController`** — a faithful 1:1 port of `PluginManager`: owns the `PluginRegistry`, the install/uninstall lifecycle (dedup, error isolation, dispose + config-subscription cleanup), and the `onAdd` hook chain. Its ctx/bag couplings are **injected**: `buildApi` (wraps `buildPluginApi`), `getUploaderApi`, and `watchPlugins` (wraps the ctx-watching `LazyPluginLoader`) — so it constructs without a DOM and is unit-testable.
- **Wired at the `LitBlock` boundary**; `*pluginManager` now resolves to a `PluginController`. The `pluginManager` getter + every consumer (SourceListController, Icon, FileItem, PluginActivityRenderer, LocaleManager, Config) are **unchanged** — identical `snapshot()` / `onPluginsChange()` / `runOnAddHooks()` / `configRegistry` surface. Console prefixes kept as `[PluginManager]` (no assertion change).
- Retyped `*pluginManager` in SharedState/shared-instances/Config; deleted `PluginManager`.

### Tests
`PluginManager` had **no** unit tests; new suite is **19 specs, 100% funcs/lines**. The only uncovered branches are two faithful-v1 **defensive guards** (the `_registerPlugin` re-register guard — the caller already guards with `!has`; the `aborted` break in `runOnAddHooks` — the local controller never aborts mid-loop). The extensive `tests/plugins/*.e2e` suite is the behavior safety net.

### Scope note
`buildPluginApi`'s config/activity/files sub-APIs + `LazyPluginLoader` stay ctx-bound at the boundary; the plugin **activity** API decouples cleanly once M7 migrates the router/activity state.

### Contract (unchanged)
The documented `pluginApi.*`, plugin `setup`/dispose lifecycle, source/activity/hook/icon/l10n/config registration, lazy loading, and the 0ms-debounce batching.

### Green gate
`tsc:app` + `tsc:test`, `build`, `test:specs` 501/501, `test:locales`, `test:e2e` 187/187 (incl. all `tests/plugins/*`), `lint` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a comprehensive test suite for the plugin system covering installation/sync behavior, hook execution and timeouts, subscription/lifecycle semantics, error isolation/recovery, teardown/cleanup, and config-subscription handling.

* **Refactor**
  * The plugin subsystem was reworked into a dependency-injected controller (DOM-free) with improved API wiring, uploader integration, plugin watching, and explicit teardown; shared context now uses the new controller type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->