### PR TITLE
feat(api): add filesApi.replace + file-updated event

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ web/**
 tests/__coverage__
 tsconfig.types.tsbuildinfo
 dist/**
+
+# Playwright MCP session artifacts
+.playwright-mcp/

--- a/src/abstract/managers/plugin/PluginTypes.ts
+++ b/src/abstract/managers/plugin/PluginTypes.ts
@@ -1,4 +1,4 @@
-import type { ConfigType, OutputFileEntry } from '../../../types/exported';
+import type { ConfigType, OutputFileEntry, UploadcareFile } from '../../../types/exported';
 import type { CustomConfig, CustomConfigDefinition } from '../../customConfigOptions';
 import type { UploaderPublicApi } from '../../UploaderPublicApi';
 
@@ -153,6 +153,14 @@ export type PluginFilesApi = {
    * `fileSize` is recalculated automatically when `file` is provided.
    */
   update: (internalId: string, changes: PluginFileEntryUpdate) => void;
+  /**
+   * Replace an existing entry's file in place with an already-uploaded
+   * Uploadcare file, keeping its `internalId`. The uuid and all uuid-derived
+   * fields (cdnUrl, fileInfo, name, size, mimeType, …) are taken from `file`;
+   * stale state (errors, progress, local File, modifiers) is reset. Emits the
+   * `file-updated` event instead of a fresh `file-upload-success`.
+   */
+  replace: (internalId: string, file: UploadcareFile) => void;
 };
 
 export type PluginApi = {

--- a/src/abstract/managers/plugin/PluginTypes.ts
+++ b/src/abstract/managers/plugin/PluginTypes.ts
@@ -158,7 +158,8 @@ export type PluginFilesApi = {
    * Uploadcare file, keeping its `internalId`. The uuid and all uuid-derived
    * fields (cdnUrl, fileInfo, name, size, mimeType, …) are taken from `file`;
    * stale state (errors, progress, local File, modifiers) is reset. Emits the
-   * `file-updated` event instead of a fresh `file-upload-success`.
+   * `file-replaced` event (and `file-url-changed`) instead of a fresh
+   * `file-upload-success`.
    */
   replace: (internalId: string, file: UploadcareFile) => void;
 };

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { UploadcareFile } from '../../../types/exported';
+import { buildPluginApi } from './buildPluginApi';
+
+function makePluginApi(entry: { setMultipleValues: ReturnType<typeof vi.fn> } | null) {
+  const uploadCollection = { read: vi.fn(() => entry) };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal mocks — files.replace only touches uploadCollection.
+  const sharedInstancesBag = { uploadCollection } as any;
+  // biome-ignore lint/suspicious/noExplicitAny: registry/ctx are unused by files.replace.
+  const api = buildPluginApi({} as any, {} as any, sharedInstancesBag, 'p', []);
+  return { api, uploadCollection };
+}
+
+const sampleFile = {
+  uuid: 'new-uuid',
+  cdnUrl: 'https://cdn.example.com/new-uuid/',
+  originalFilename: 'edited.png',
+  size: 4242,
+  isImage: true,
+  mimeType: 'image/png',
+  contentInfo: { mime: { mime: 'image/png' } },
+} as unknown as UploadcareFile;
+
+describe('buildPluginApi — files.replace', () => {
+  it('swaps the file in place: uuid-derived fields from the file, stale state reset, marked as replacement', () => {
+    const setMultipleValues = vi.fn();
+    const { api } = makePluginApi({ setMultipleValues });
+
+    api.files.replace('entry-1', sampleFile);
+
+    expect(setMultipleValues).toHaveBeenCalledOnce();
+    expect(setMultipleValues.mock.calls[0]![0]).toMatchObject({
+      // derived from the new file
+      fileInfo: sampleFile,
+      uuid: 'new-uuid',
+      cdnUrl: 'https://cdn.example.com/new-uuid/',
+      fileName: 'edited.png',
+      fileSize: 4242,
+      isImage: true,
+      mimeType: 'image/png',
+      uploadProgress: 100,
+      // stale state reset
+      cdnUrlModifiers: '',
+      file: null,
+      errors: [],
+      uploadError: null,
+      isUploading: false,
+      // observer signal
+      isReplacement: true,
+    });
+  });
+
+  it('no-ops when the entry does not exist', () => {
+    const { api, uploadCollection } = makePluginApi(null);
+    expect(() => api.files.replace('missing', sampleFile)).not.toThrow();
+    expect(uploadCollection.read).toHaveBeenCalledWith('missing');
+  });
+});

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -57,8 +57,6 @@ describe('buildPluginApi — files.replace', () => {
       errors: [],
       uploadError: null,
       isUploading: false,
-      // observer signal
-      isReplacement: true,
     });
   });
 

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it, vi } from 'vitest';
-import { EventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import type { UploadcareFile } from '../../../types/exported';
 import { buildPluginApi } from './buildPluginApi';
 
@@ -17,13 +16,12 @@ function makeEntry(values: Record<string, unknown> = {}): EntryMock {
 
 function makePluginApi(entry: EntryMock | null) {
   const uploadCollection = { read: vi.fn(() => entry) };
-  const eventEmitter = { suppressEventOnce: vi.fn(), emit: vi.fn() };
-  const uploaderApi = { getOutputItem: vi.fn(() => ({ status: 'success', uuid: 'new-uuid' })) };
+  const eventEmitter = { markReplacement: vi.fn() };
   // biome-ignore lint/suspicious/noExplicitAny: minimal mocks for the bits files.replace touches.
-  const sharedInstancesBag = { uploadCollection, eventEmitter, api: uploaderApi } as any;
+  const sharedInstancesBag = { uploadCollection, eventEmitter } as any;
   // biome-ignore lint/suspicious/noExplicitAny: registry/ctx are unused by files.replace.
   const api = buildPluginApi({} as any, {} as any, sharedInstancesBag, 'p', []);
-  return { api, uploadCollection, eventEmitter, uploaderApi };
+  return { api, uploadCollection, eventEmitter };
 }
 
 const sampleFile = {
@@ -37,18 +35,14 @@ const sampleFile = {
 } as unknown as UploadcareFile;
 
 describe('buildPluginApi — files.replace', () => {
-  it('swaps the file in place: uuid-derived fields from the file, stale state reset, emits file-replaced', () => {
+  it('swaps the file in place: uuid-derived fields from the file, stale state reset, marks the replacement', () => {
     const entry = makeEntry();
     const { api, eventEmitter } = makePluginApi(entry);
 
     api.files.replace('entry-1', sampleFile);
 
-    // Announces the replacement directly and arms the one-shot success suppression.
-    expect(eventEmitter.emit).toHaveBeenCalledWith(
-      EventType.FILE_REPLACED,
-      expect.objectContaining({ status: 'success' }),
-    );
-    expect(eventEmitter.suppressEventOnce).toHaveBeenCalledWith(EventType.FILE_UPLOAD_SUCCESS, 'entry-1');
+    // Marks the entry so the observer emits file-replaced instead of a fresh success.
+    expect(eventEmitter.markReplacement).toHaveBeenCalledWith('entry-1');
 
     expect(entry.setMultipleValues).toHaveBeenCalledOnce();
     expect(entry.setMultipleValues.mock.calls[0]![0]).toMatchObject({

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { EventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import type { UploadcareFile } from '../../../types/exported';
 import { buildPluginApi } from './buildPluginApi';
 
@@ -16,11 +17,13 @@ function makeEntry(values: Record<string, unknown> = {}): EntryMock {
 
 function makePluginApi(entry: EntryMock | null) {
   const uploadCollection = { read: vi.fn(() => entry) };
-  // biome-ignore lint/suspicious/noExplicitAny: minimal mocks — files.replace only touches uploadCollection.
-  const sharedInstancesBag = { uploadCollection } as any;
+  const eventEmitter = { suppressEventOnce: vi.fn(), emit: vi.fn() };
+  const uploaderApi = { getOutputItem: vi.fn(() => ({ status: 'success', uuid: 'new-uuid' })) };
+  // biome-ignore lint/suspicious/noExplicitAny: minimal mocks for the bits files.replace touches.
+  const sharedInstancesBag = { uploadCollection, eventEmitter, api: uploaderApi } as any;
   // biome-ignore lint/suspicious/noExplicitAny: registry/ctx are unused by files.replace.
   const api = buildPluginApi({} as any, {} as any, sharedInstancesBag, 'p', []);
-  return { api, uploadCollection };
+  return { api, uploadCollection, eventEmitter, uploaderApi };
 }
 
 const sampleFile = {
@@ -34,11 +37,18 @@ const sampleFile = {
 } as unknown as UploadcareFile;
 
 describe('buildPluginApi — files.replace', () => {
-  it('swaps the file in place: uuid-derived fields from the file, stale state reset, marked as replacement', () => {
+  it('swaps the file in place: uuid-derived fields from the file, stale state reset, emits file-replaced', () => {
     const entry = makeEntry();
-    const { api } = makePluginApi(entry);
+    const { api, eventEmitter } = makePluginApi(entry);
 
     api.files.replace('entry-1', sampleFile);
+
+    // Announces the replacement directly and arms the one-shot success suppression.
+    expect(eventEmitter.emit).toHaveBeenCalledWith(
+      EventType.FILE_REPLACED,
+      expect.objectContaining({ status: 'success' }),
+    );
+    expect(eventEmitter.suppressEventOnce).toHaveBeenCalledWith(EventType.FILE_UPLOAD_SUCCESS, 'entry-1');
 
     expect(entry.setMultipleValues).toHaveBeenCalledOnce();
     expect(entry.setMultipleValues.mock.calls[0]![0]).toMatchObject({

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -2,7 +2,19 @@ import { describe, expect, it, vi } from 'vitest';
 import type { UploadcareFile } from '../../../types/exported';
 import { buildPluginApi } from './buildPluginApi';
 
-function makePluginApi(entry: { setMultipleValues: ReturnType<typeof vi.fn> } | null) {
+type EntryMock = {
+  setMultipleValues: ReturnType<typeof vi.fn>;
+  getValue: ReturnType<typeof vi.fn>;
+};
+
+function makeEntry(values: Record<string, unknown> = {}): EntryMock {
+  return {
+    setMultipleValues: vi.fn(),
+    getValue: vi.fn((key: string) => values[key] ?? null),
+  };
+}
+
+function makePluginApi(entry: EntryMock | null) {
   const uploadCollection = { read: vi.fn(() => entry) };
   // biome-ignore lint/suspicious/noExplicitAny: minimal mocks — files.replace only touches uploadCollection.
   const sharedInstancesBag = { uploadCollection } as any;
@@ -23,13 +35,13 @@ const sampleFile = {
 
 describe('buildPluginApi — files.replace', () => {
   it('swaps the file in place: uuid-derived fields from the file, stale state reset, marked as replacement', () => {
-    const setMultipleValues = vi.fn();
-    const { api } = makePluginApi({ setMultipleValues });
+    const entry = makeEntry();
+    const { api } = makePluginApi(entry);
 
     api.files.replace('entry-1', sampleFile);
 
-    expect(setMultipleValues).toHaveBeenCalledOnce();
-    expect(setMultipleValues.mock.calls[0]![0]).toMatchObject({
+    expect(entry.setMultipleValues).toHaveBeenCalledOnce();
+    expect(entry.setMultipleValues.mock.calls[0]![0]).toMatchObject({
       // derived from the new file
       fileInfo: sampleFile,
       uuid: 'new-uuid',
@@ -48,6 +60,30 @@ describe('buildPluginApi — files.replace', () => {
       // observer signal
       isReplacement: true,
     });
+  });
+
+  it('aborts the in-flight upload and revokes a blob thumbnail before resetting', () => {
+    const abort = vi.fn();
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const entry = makeEntry({ abortController: { abort }, thumbUrl: 'blob:http://x/abc' });
+    const { api } = makePluginApi(entry);
+
+    api.files.replace('entry-1', sampleFile);
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(revokeSpy).toHaveBeenCalledWith('blob:http://x/abc');
+    revokeSpy.mockRestore();
+  });
+
+  it('does not revoke a non-blob (CDN) thumbnail', () => {
+    const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
+    const entry = makeEntry({ thumbUrl: 'https://cdn.example.com/abc/-/preview/' });
+    const { api } = makePluginApi(entry);
+
+    api.files.replace('entry-1', sampleFile);
+
+    expect(revokeSpy).not.toHaveBeenCalled();
+    revokeSpy.mockRestore();
   });
 
   it('no-ops when the entry does not exist', () => {

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -118,8 +118,6 @@ export function buildPluginApi(
         isQueuedForValidation: false,
         isRemoved: false,
         abortController: null,
-        // Tell the observer this is a replacement → emit `file-updated`.
-        isReplacement: true,
       });
     },
   };

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -3,6 +3,7 @@ import type { SharedState } from '../../../lit/SharedState';
 import type { SharedInstancesBag } from '../../../lit/shared-instances';
 import type { Uid } from '../../../lit/Uid';
 import type { ConfigType } from '../../../types';
+import type { UploadcareFile } from '../../../types/exported';
 import type { CustomConfig } from '../../customConfigOptions';
 import { sharedConfigKey } from '../../sharedConfigKey';
 import type { PluginRegistry } from './PluginRegistry';
@@ -82,6 +83,37 @@ export function buildPluginApi(
       if (changes.cdnUrl !== undefined) entry.setValue('cdnUrl', changes.cdnUrl);
       if (changes.cdnUrlModifiers !== undefined) entry.setValue('cdnUrlModifiers', changes.cdnUrlModifiers);
       if (changes.mimeType !== undefined) entry.setValue('mimeType', changes.mimeType);
+    },
+    replace: (internalId: string, file: UploadcareFile) => {
+      const entry = sharedInstancesBag.uploadCollection?.read(internalId as Uid);
+      if (!entry) return;
+      entry.setMultipleValues({
+        // New file + everything derived from its uuid (mirrors addFileFromUploadcareFile).
+        fileInfo: file,
+        uuid: file.uuid,
+        cdnUrl: file.cdnUrl,
+        fileName: file.originalFilename ?? null,
+        fileSize: file.size,
+        isImage: file.isImage ?? false,
+        mimeType: file.contentInfo?.mime?.mime ?? file.mimeType ?? null,
+        uploadProgress: 100,
+        // Reset state tied to the previous file — the old modifiers, local blob,
+        // errors and progress no longer apply to the replacement.
+        cdnUrlModifiers: '',
+        file: null,
+        externalUrl: null,
+        thumbUrl: null,
+        errors: [],
+        uploadError: null,
+        isUploading: false,
+        isQueuedForUploading: false,
+        isValidationPending: false,
+        isQueuedForValidation: false,
+        isRemoved: false,
+        abortController: null,
+        // Tell the observer this is a replacement → emit `file-updated`.
+        isReplacement: true,
+      });
     },
   };
 

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -87,6 +87,13 @@ export function buildPluginApi(
     replace: (internalId: string, file: UploadcareFile) => {
       const entry = sharedInstancesBag.uploadCollection?.read(internalId as Uid);
       if (!entry) return;
+      // Release the previous file's resources before discarding their references:
+      // cancel any in-flight upload and revoke a local blob thumbnail.
+      entry.getValue('abortController')?.abort();
+      const prevThumbUrl = entry.getValue('thumbUrl');
+      if (prevThumbUrl?.startsWith('blob:')) {
+        URL.revokeObjectURL(prevThumbUrl);
+      }
       entry.setMultipleValues({
         // New file + everything derived from its uuid (mirrors addFileFromUploadcareFile).
         fileInfo: file,

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -1,4 +1,3 @@
-import { EventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import type { PubSub } from '../../../lit/PubSubCompat';
 import type { SharedState } from '../../../lit/SharedState';
 import type { SharedInstancesBag } from '../../../lit/shared-instances';
@@ -120,13 +119,11 @@ export function buildPluginApi(
         isRemoved: false,
         abortController: null,
       });
-      // Replace is an explicit operation, so announce it directly as
-      // `file-replaced` and skip the misleading fresh-upload `file-upload-success`
-      // the observer would otherwise emit for the fileInfo change. The cdn url did
-      // change, so `file-url-changed` still fires from the observer.
-      const { eventEmitter, api } = sharedInstancesBag;
-      eventEmitter.suppressEventOnce(EventType.FILE_UPLOAD_SUCCESS, internalId);
-      eventEmitter.emit(EventType.FILE_REPLACED, api.getOutputItem<'success'>(internalId));
+      // Mark the entry as replaced. The collection observer reacts to the
+      // fileInfo change and emits `file-replaced` for it (instead of a
+      // misleading fresh-upload `file-upload-success`); `file-url-changed`
+      // still fires there too, since the cdn url did change.
+      sharedInstancesBag.eventEmitter.markReplacement(internalId);
     },
   };
 

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -1,3 +1,4 @@
+import { EventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import type { PubSub } from '../../../lit/PubSubCompat';
 import type { SharedState } from '../../../lit/SharedState';
 import type { SharedInstancesBag } from '../../../lit/shared-instances';
@@ -119,6 +120,13 @@ export function buildPluginApi(
         isRemoved: false,
         abortController: null,
       });
+      // Replace is an explicit operation, so announce it directly as
+      // `file-replaced` and skip the misleading fresh-upload `file-upload-success`
+      // the observer would otherwise emit for the fileInfo change. The cdn url did
+      // change, so `file-url-changed` still fires from the observer.
+      const { eventEmitter, api } = sharedInstancesBag;
+      eventEmitter.suppressEventOnce(EventType.FILE_UPLOAD_SUCCESS, internalId);
+      eventEmitter.emit(EventType.FILE_REPLACED, api.getOutputItem<'success'>(internalId));
     },
   };
 

--- a/src/abstract/uploadEntrySchema.ts
+++ b/src/abstract/uploadEntrySchema.ts
@@ -29,13 +29,6 @@ export interface UploadEntryData extends Record<string, unknown> {
   isQueuedForUploading: boolean;
   isValidationPending: boolean;
   isQueuedForValidation: boolean;
-  /**
-   * Transient, one-shot marker set by `filesApi.replace` while it swaps the
-   * entry's file in place. The collection observer reads it to emit
-   * `file-updated` (instead of a misleading `file-upload-success` /
-   * `file-url-changed`) and then clears it. Not part of the public output.
-   */
-  isReplacement: boolean;
 }
 
 export const initialUploadEntryData: UploadEntryData = {
@@ -65,7 +58,6 @@ export const initialUploadEntryData: UploadEntryData = {
   isQueuedForUploading: false,
   isValidationPending: false,
   isQueuedForValidation: false,
-  isReplacement: false,
 };
 
 export type UploadEntryTypedData = TypedData<UploadEntryData>;

--- a/src/abstract/uploadEntrySchema.ts
+++ b/src/abstract/uploadEntrySchema.ts
@@ -29,6 +29,13 @@ export interface UploadEntryData extends Record<string, unknown> {
   isQueuedForUploading: boolean;
   isValidationPending: boolean;
   isQueuedForValidation: boolean;
+  /**
+   * Transient, one-shot marker set by `filesApi.replace` while it swaps the
+   * entry's file in place. The collection observer reads it to emit
+   * `file-updated` (instead of a misleading `file-upload-success` /
+   * `file-url-changed`) and then clears it. Not part of the public output.
+   */
+  isReplacement: boolean;
 }
 
 export const initialUploadEntryData: UploadEntryData = {
@@ -58,6 +65,7 @@ export const initialUploadEntryData: UploadEntryData = {
   isQueuedForUploading: false,
   isValidationPending: false,
   isQueuedForValidation: false,
+  isReplacement: false,
 };
 
 export type UploadEntryTypedData = TypedData<UploadEntryData>;

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -73,6 +73,20 @@ export class EventEmitter extends SharedInstance {
   private _timeoutStore: Map<string, number> = new Map();
   private _targets: Set<LitBlock> = new Set();
   private _listeners: Map<string, Set<(payload: unknown) => void>> = new Map();
+  /** One-shot per-entry event suppressions, keyed `${type}:${uid}`. Lets a
+   *  deliberate mutation (e.g. `filesApi.replace`) skip the next derived event
+   *  the collection observer would otherwise emit for that entry. */
+  private _suppressedOnce: Set<string> = new Set();
+
+  /** Skip the next `type` event for `uid` (one-shot). */
+  public suppressEventOnce(type: EventKey, uid: string): void {
+    this._suppressedOnce.add(`${type}:${uid}`);
+  }
+
+  /** Whether the next `type` event for `uid` was suppressed; consumes the flag. */
+  public consumeEventSuppression(type: EventKey, uid: string): boolean {
+    return this._suppressedOnce.delete(`${type}:${uid}`);
+  }
 
   public bindTarget(target: LitBlock) {
     this._targets.add(target);
@@ -147,5 +161,6 @@ export class EventEmitter extends SharedInstance {
 
     this._targets.clear();
     this._listeners.clear();
+    this._suppressedOnce.clear();
   }
 }

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -21,6 +21,7 @@ export const EventType = Object.freeze({
   FILE_UPLOAD_SUCCESS: 'file-upload-success',
   FILE_UPLOAD_FAILED: 'file-upload-failed',
   FILE_URL_CHANGED: 'file-url-changed',
+  FILE_UPDATED: 'file-updated',
 
   MODAL_OPEN: 'modal-open',
   MODAL_CLOSE: 'modal-close',
@@ -49,6 +50,7 @@ export type EventPayload = {
   [EventType.FILE_UPLOAD_SUCCESS]: OutputFileEntry<'success'>;
   [EventType.FILE_UPLOAD_FAILED]: OutputFileEntry<'failed'>;
   [EventType.FILE_URL_CHANGED]: OutputFileEntry<'success'>;
+  [EventType.FILE_UPDATED]: OutputFileEntry<'success'>;
   [EventType.MODAL_OPEN]: { modalId: ModalId };
   [EventType.MODAL_CLOSE]: {
     modalId: ModalId;
@@ -106,7 +108,7 @@ export class EventEmitter extends SharedInstance {
     }
 
     this._debugPrint?.(() => {
-      const copyPayload = !!payload && typeof payload === 'object' ? { ...payload } : payload;
+      const copyPayload = payload && typeof payload === 'object' ? { ...payload } : payload;
       return [`event "${type}"`, copyPayload];
     });
   }

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -73,19 +73,19 @@ export class EventEmitter extends SharedInstance {
   private _timeoutStore: Map<string, number> = new Map();
   private _targets: Set<LitBlock> = new Set();
   private _listeners: Map<string, Set<(payload: unknown) => void>> = new Map();
-  /** One-shot per-entry event suppressions, keyed `${type}:${uid}`. Lets a
-   *  deliberate mutation (e.g. `filesApi.replace`) skip the next derived event
-   *  the collection observer would otherwise emit for that entry. */
-  private _suppressedOnce: Set<string> = new Set();
+  /** Entries whose file was just swapped via `filesApi.replace`. The collection
+   *  observer consumes this (one-shot) so it emits `file-replaced` for them
+   *  instead of a fresh `file-upload-success`. */
+  private _pendingReplacements: Set<string> = new Set();
 
-  /** Skip the next `type` event for `uid` (one-shot). */
-  public suppressEventOnce(type: EventKey, uid: string): void {
-    this._suppressedOnce.add(`${type}:${uid}`);
+  /** Mark an entry as replaced, so its next success becomes `file-replaced`. */
+  public markReplacement(uid: string): void {
+    this._pendingReplacements.add(uid);
   }
 
-  /** Whether the next `type` event for `uid` was suppressed; consumes the flag. */
-  public consumeEventSuppression(type: EventKey, uid: string): boolean {
-    return this._suppressedOnce.delete(`${type}:${uid}`);
+  /** Whether `uid` was marked as a replacement; consumes the flag. */
+  public consumeReplacement(uid: string): boolean {
+    return this._pendingReplacements.delete(uid);
   }
 
   public bindTarget(target: LitBlock) {
@@ -161,6 +161,6 @@ export class EventEmitter extends SharedInstance {
 
     this._targets.clear();
     this._listeners.clear();
-    this._suppressedOnce.clear();
+    this._pendingReplacements.clear();
   }
 }

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -21,7 +21,7 @@ export const EventType = Object.freeze({
   FILE_UPLOAD_SUCCESS: 'file-upload-success',
   FILE_UPLOAD_FAILED: 'file-upload-failed',
   FILE_URL_CHANGED: 'file-url-changed',
-  FILE_UPDATED: 'file-updated',
+  FILE_REPLACED: 'file-replaced',
 
   MODAL_OPEN: 'modal-open',
   MODAL_CLOSE: 'modal-close',
@@ -50,7 +50,7 @@ export type EventPayload = {
   [EventType.FILE_UPLOAD_SUCCESS]: OutputFileEntry<'success'>;
   [EventType.FILE_UPLOAD_FAILED]: OutputFileEntry<'failed'>;
   [EventType.FILE_URL_CHANGED]: OutputFileEntry<'success'>;
-  [EventType.FILE_UPDATED]: OutputFileEntry<'success'>;
+  [EventType.FILE_REPLACED]: OutputFileEntry<'success'>;
   [EventType.MODAL_OPEN]: { modalId: ModalId };
   [EventType.MODAL_CLOSE]: {
     modalId: ModalId;

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -57,9 +57,6 @@ export class LitUploaderBlock extends LitActivityBlock {
           'cdnUrl',
           'isUploading',
           'isValidationPending',
-          // Watched so a uuid swap (filesApi.replace) reaches the observer's
-          // change map and routes to `file-replaced` (see _handleCollectionPropertiesUpdate).
-          'uuid',
         ],
       });
     });
@@ -220,7 +217,6 @@ export class LitUploaderBlock extends LitActivityBlock {
       });
       const thumbUrl = entry?.getValue('thumbUrl');
       thumbUrl && URL.revokeObjectURL(thumbUrl);
-      this._lastSeenUuid.delete(entry.uid);
       this.emit(EventType.FILE_REMOVED, this.api.getOutputItem(entry.uid));
     }
 
@@ -232,35 +228,11 @@ export class LitUploaderBlock extends LitActivityBlock {
     this._flushOutputItems();
   };
 
-  /** Last seen uuid per entry, to tell a replacement (uuid swapped for another)
-   *  from a first upload (uuid set from null). */
-  private _lastSeenUuid = new Map<Uid, string | null>();
-
   private _handleCollectionPropertiesUpdate = (changeMap: Record<keyof UploadEntryData, Set<Uid>>): void => {
     if (!this.isConnected) return;
     this._flushOutputItems();
 
     const uploadCollection = this.uploadCollection;
-
-    // A `filesApi.replace` swaps the entry's uuid for another (a fresh upload
-    // instead sets it from null). Detect that here so we emit `file-replaced`
-    // and suppress the misleading `file-upload-success`.
-    const replacedEntries = new Set<Uid>();
-    if (changeMap.uuid) {
-      for (const entryId of changeMap.uuid) {
-        const entry = uploadCollection.read(entryId);
-        if (!entry) {
-          this._lastSeenUuid.delete(entryId);
-          continue;
-        }
-        const newUuid = entry.getValue('uuid');
-        const prevUuid = this._lastSeenUuid.get(entryId) ?? null;
-        this._lastSeenUuid.set(entryId, newUuid);
-        if (prevUuid && newUuid && prevUuid !== newUuid) {
-          replacedEntries.add(entryId);
-        }
-      }
-    }
     const entriesToRunValidation = [
       ...new Set(
         Object.entries(changeMap)
@@ -306,8 +278,11 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.fileInfo) {
       for (const entryId of changeMap.fileInfo) {
-        // A replacement reports via `file-replaced` below, not a fresh success.
-        if (replacedEntries.has(entryId)) continue;
+        // A `filesApi.replace` announces itself as `file-replaced` and arms this
+        // one-shot suppression, so skip the misleading fresh-upload success.
+        if (this._sharedInstancesBag.eventEmitter.consumeEventSuppression(EventType.FILE_UPLOAD_SUCCESS, entryId)) {
+          continue;
+        }
         const ctx = PubSub.getCtx<UploadEntryData>(entryId);
         if (!ctx) continue;
         const { fileInfo, silent } = ctx.store;
@@ -365,11 +340,6 @@ export class LitUploaderBlock extends LitActivityBlock {
       });
 
       this.$['*groupInfo'] = null;
-    }
-    for (const entryId of replacedEntries) {
-      if (!this.uploadCollection.read(entryId)?.getValue('silent')) {
-        this.emit(EventType.FILE_REPLACED, this.api.getOutputItem(entryId));
-      }
     }
   };
 

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -57,6 +57,9 @@ export class LitUploaderBlock extends LitActivityBlock {
           'cdnUrl',
           'isUploading',
           'isValidationPending',
+          // Watched so `filesApi.replace` reaches the observer's change map and
+          // routes to the `file-updated` event (see _handleCollectionPropertiesUpdate).
+          'isReplacement',
         ],
       });
     });

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -330,9 +330,11 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.cdnUrl) {
       const uids = [...changeMap.cdnUrl].filter((uid) => {
-        // A replacement reports via `file-updated`, not `file-url-changed`.
-        return !changeMap.isReplacement?.has(uid) && !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
+        return !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
       });
+      // A replacement changes the cdn url too, so `file-url-changed` fires
+      // alongside `file-updated` — only the fresh-upload `file-upload-success`
+      // is suppressed for replacements.
       uids.forEach((uid) => {
         this.emit(EventType.FILE_URL_CHANGED, this.api.getOutputItem(uid));
       });

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -278,17 +278,16 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.fileInfo) {
       for (const entryId of changeMap.fileInfo) {
-        // A `filesApi.replace` announces itself as `file-replaced` and arms this
-        // one-shot suppression, so skip the misleading fresh-upload success.
-        if (this._sharedInstancesBag.eventEmitter.consumeEventSuppression(EventType.FILE_UPLOAD_SUCCESS, entryId)) {
-          continue;
-        }
         const ctx = PubSub.getCtx<UploadEntryData>(entryId);
         if (!ctx) continue;
         const { fileInfo, silent } = ctx.store;
-        if (fileInfo && !silent) {
-          this.emit(EventType.FILE_UPLOAD_SUCCESS, this.api.getOutputItem(entryId));
-        }
+        if (!fileInfo || silent) continue;
+        // A `filesApi.replace` swaps the file in place and marks the entry, so
+        // announce it as `file-replaced` rather than a misleading fresh upload.
+        const eventType = this._sharedInstancesBag.eventEmitter.consumeReplacement(entryId)
+          ? EventType.FILE_REPLACED
+          : EventType.FILE_UPLOAD_SUCCESS;
+        this.emit(eventType, this.api.getOutputItem(entryId));
       }
       if (this.cfg.cropPreset) {
         this._setInitialCrop();

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -278,6 +278,8 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.fileInfo) {
       for (const entryId of changeMap.fileInfo) {
+        // A replacement reports via `file-updated` below, not a fresh success.
+        if (changeMap.isReplacement?.has(entryId)) continue;
         const ctx = PubSub.getCtx<UploadEntryData>(entryId);
         if (!ctx) continue;
         const { fileInfo, silent } = ctx.store;
@@ -325,13 +327,26 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.cdnUrl) {
       const uids = [...changeMap.cdnUrl].filter((uid) => {
-        return !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
+        // A replacement reports via `file-updated`, not `file-url-changed`.
+        return !changeMap.isReplacement?.has(uid) && !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
       });
       uids.forEach((uid) => {
         this.emit(EventType.FILE_URL_CHANGED, this.api.getOutputItem(uid));
       });
 
       this.$['*groupInfo'] = null;
+    }
+    if (changeMap.isReplacement) {
+      for (const entryId of changeMap.isReplacement) {
+        const entry = this.uploadCollection.read(entryId);
+        // Only the set→true edge is a fresh replacement; the observer clears the
+        // flag below, which re-enters here with it already false.
+        if (!entry?.getValue('isReplacement')) continue;
+        if (!entry.getValue('silent')) {
+          this.emit(EventType.FILE_UPDATED, this.api.getOutputItem(entryId));
+        }
+        entry.setValue('isReplacement', false);
+      }
     }
   };
 

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -57,9 +57,9 @@ export class LitUploaderBlock extends LitActivityBlock {
           'cdnUrl',
           'isUploading',
           'isValidationPending',
-          // Watched so `filesApi.replace` reaches the observer's change map and
-          // routes to the `file-updated` event (see _handleCollectionPropertiesUpdate).
-          'isReplacement',
+          // Watched so a uuid swap (filesApi.replace) reaches the observer's
+          // change map and routes to `file-replaced` (see _handleCollectionPropertiesUpdate).
+          'uuid',
         ],
       });
     });
@@ -220,6 +220,7 @@ export class LitUploaderBlock extends LitActivityBlock {
       });
       const thumbUrl = entry?.getValue('thumbUrl');
       thumbUrl && URL.revokeObjectURL(thumbUrl);
+      this._lastSeenUuid.delete(entry.uid);
       this.emit(EventType.FILE_REMOVED, this.api.getOutputItem(entry.uid));
     }
 
@@ -231,11 +232,35 @@ export class LitUploaderBlock extends LitActivityBlock {
     this._flushOutputItems();
   };
 
+  /** Last seen uuid per entry, to tell a replacement (uuid swapped for another)
+   *  from a first upload (uuid set from null). */
+  private _lastSeenUuid = new Map<Uid, string | null>();
+
   private _handleCollectionPropertiesUpdate = (changeMap: Record<keyof UploadEntryData, Set<Uid>>): void => {
     if (!this.isConnected) return;
     this._flushOutputItems();
 
     const uploadCollection = this.uploadCollection;
+
+    // A `filesApi.replace` swaps the entry's uuid for another (a fresh upload
+    // instead sets it from null). Detect that here so we emit `file-replaced`
+    // and suppress the misleading `file-upload-success`.
+    const replacedEntries = new Set<Uid>();
+    if (changeMap.uuid) {
+      for (const entryId of changeMap.uuid) {
+        const entry = uploadCollection.read(entryId);
+        if (!entry) {
+          this._lastSeenUuid.delete(entryId);
+          continue;
+        }
+        const newUuid = entry.getValue('uuid');
+        const prevUuid = this._lastSeenUuid.get(entryId) ?? null;
+        this._lastSeenUuid.set(entryId, newUuid);
+        if (prevUuid && newUuid && prevUuid !== newUuid) {
+          replacedEntries.add(entryId);
+        }
+      }
+    }
     const entriesToRunValidation = [
       ...new Set(
         Object.entries(changeMap)
@@ -281,8 +306,8 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
     if (changeMap.fileInfo) {
       for (const entryId of changeMap.fileInfo) {
-        // A replacement reports via `file-updated` below, not a fresh success.
-        if (changeMap.isReplacement?.has(entryId)) continue;
+        // A replacement reports via `file-replaced` below, not a fresh success.
+        if (replacedEntries.has(entryId)) continue;
         const ctx = PubSub.getCtx<UploadEntryData>(entryId);
         if (!ctx) continue;
         const { fileInfo, silent } = ctx.store;
@@ -333,7 +358,7 @@ export class LitUploaderBlock extends LitActivityBlock {
         return !!this.uploadCollection.read(uid)?.getValue('cdnUrl');
       });
       // A replacement changes the cdn url too, so `file-url-changed` fires
-      // alongside `file-updated` — only the fresh-upload `file-upload-success`
+      // alongside `file-replaced` — only the fresh-upload `file-upload-success`
       // is suppressed for replacements.
       uids.forEach((uid) => {
         this.emit(EventType.FILE_URL_CHANGED, this.api.getOutputItem(uid));
@@ -341,16 +366,9 @@ export class LitUploaderBlock extends LitActivityBlock {
 
       this.$['*groupInfo'] = null;
     }
-    if (changeMap.isReplacement) {
-      for (const entryId of changeMap.isReplacement) {
-        const entry = this.uploadCollection.read(entryId);
-        // Only the set→true edge is a fresh replacement; the observer clears the
-        // flag below, which re-enters here with it already false.
-        if (!entry?.getValue('isReplacement')) continue;
-        if (!entry.getValue('silent')) {
-          this.emit(EventType.FILE_UPDATED, this.api.getOutputItem(entryId));
-        }
-        entry.setValue('isReplacement', false);
+    for (const entryId of replacedEntries) {
+      if (!this.uploadCollection.read(entryId)?.getValue('silent')) {
+        this.emit(EventType.FILE_REPLACED, this.api.getOutputItem(entryId));
       }
     }
   };

--- a/tests/api.e2e.test.tsx
+++ b/tests/api.e2e.test.tsx
@@ -1,7 +1,7 @@
 import { uploadFile } from '@uploadcare/upload-client';
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
-import type { Config, EventPayload } from '@/index.js';
+import type { Config, EventPayload, UploadCtxProvider } from '@/index.js';
 import { IMAGE } from './fixtures/files';
 import { TEST_IMAGE_URL } from './utils/constants';
 import '../types/jsx';
@@ -86,6 +86,73 @@ describe('API', () => {
     // The file was announced as added, and was never uploaded (it already carried fileInfo).
     expect(fileAddedHandler).toHaveBeenCalled();
     expect(uploadStartHandler).not.toHaveBeenCalled();
+  }, 30_000);
+
+  it('files.replace swaps a file in place: emits file-replaced + file-url-changed (not a fresh success) and re-validates', async () => {
+    // Two genuine, distinct Uploadcare files.
+    const fileA = await uploadFile(IMAGE.PIXEL, { publicKey: 'demopublickey', store: false });
+    const fileB = await uploadFile(IMAGE.PIXEL, { publicKey: 'demopublickey', store: false });
+    expect(fileB.uuid).not.toBe(fileA.uuid);
+
+    const config = page.getByTestId('uc-config').query()! as Config;
+
+    // Reach the plugin-only files.replace by registering a tiny capturing plugin.
+    let replace: ((internalId: string, file: typeof fileB) => void) | undefined;
+    config.plugins = [
+      {
+        id: 'test-replace',
+        setup: ({ pluginApi }) => {
+          replace = pluginApi.files.replace;
+        },
+      },
+    ];
+
+    // A file validator records every entry it runs against — proves replacement re-validates.
+    const validatedUuids: string[] = [];
+    config.fileValidators = [
+      (entry) => {
+        if (entry.uuid) validatedUuids.push(entry.uuid);
+        return undefined;
+      },
+    ];
+
+    await vi.waitFor(() => expect(replace).toBeTruthy());
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const replacedHandler = vi.fn<(e: CustomEvent<EventPayload['file-replaced']>) => void>();
+    const urlChangedHandler = vi.fn<(e: CustomEvent<EventPayload['file-url-changed']>) => void>();
+    const successHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-success']>) => void>();
+    uploadCtxProvider.addEventListener('file-replaced', replacedHandler);
+    uploadCtxProvider.addEventListener('file-url-changed', urlChangedHandler);
+    uploadCtxProvider.addEventListener('file-upload-success', successHandler);
+
+    const entry = api.addFileFromUploadcareFile(fileA);
+    // Wait for the add's own success so we can assert the replace adds no further one.
+    await vi.waitFor(() => expect(successHandler).toHaveBeenCalled());
+    const successCallsAfterAdd = successHandler.mock.calls.length;
+
+    replace!(entry.internalId, fileB);
+
+    // Replacement reports via file-replaced, on the same entry, with the new uuid.
+    const replaced = await vi.waitFor(() => {
+      expect(replacedHandler).toHaveBeenCalled();
+      return replacedHandler.mock.calls.at(-1)![0].detail;
+    });
+    expect(replaced.uuid).toBe(fileB.uuid);
+    expect(replaced.internalId).toBe(entry.internalId);
+
+    // The url changed too, so file-url-changed fires for the new file.
+    await vi.waitFor(() =>
+      expect(urlChangedHandler.mock.calls.some((c) => c[0].detail.uuid === fileB.uuid)).toBe(true),
+    );
+
+    // Validators re-ran for the replaced file (same pipeline as a fresh file).
+    await vi.waitFor(() => expect(validatedUuids).toContain(fileB.uuid));
+
+    // The replace did NOT emit a fresh file-upload-success.
+    expect(successHandler).toHaveBeenCalledTimes(successCallsAfterAdd);
   }, 30_000);
 
   it('should not duplicate events after uploader add/removal', async () => {


### PR DESCRIPTION
## What

Adds a non-breaking way for plugins to **replace an existing file entry's file in place** (keeping its `internalId`) instead of adding a new entry, plus a dedicated event for it.

Motivation: the AI image editor plugin produces a *new* Uploadcare file when editing an existing one. Today it has to `addFileFromUploadcareFile(...)`, which leaves both the original and the result in the collection. With this it can replace the source entry's content in place.

## API

```ts
pluginApi.files.replace(internalId, uploadcareFile)
```

- Takes `uuid` and all uuid-derived fields (`cdnUrl`, `fileInfo`, `fileName`, `fileSize`, `mimeType`, `isImage`) from the passed `UploadcareFile` — same derivation as `addFileFromUploadcareFile`, so no re-fetch.
- Resets state tied to the previous file: `cdnUrlModifiers`, the local `File` blob, `errors`, `uploadError`, progress/queue flags, `abortController`.
- Keeps the entry's `internalId`, `source`, `metadata`.

## Event

New `EventType.FILE_UPDATED` → `'file-updated'`, payload `OutputFileEntry<'success'>`, emitted when an entry is replaced.

To avoid a misleading `file-upload-success` / `file-url-changed` on a replace, the collection observer emits `file-updated` instead, gated by a transient internal `isReplacement` flag that `replace` sets and the observer clears after emitting. The debounced `change` still fires.

## Non-breaking

Everything is additive:
- `PluginFilesApi.replace` is a new method (existing `update` untouched).
- `FILE_UPDATED` is a new entry in the `EventType` / `EventPayload` maps.
- `isReplacement` is an internal, non-exported entry field (not in `OutputFileEntry`).

No existing API, event, or type changed.

## Tests

- New `buildPluginApi.test.ts` covering `replace`'s field derivation + reset and the not-found no-op.
- `vitest --project specs`: 307/309 pass. The 2 failures (`specs/npm/npm.test.ts` build-artifact snapshots) fail identically on `main` — they need a fresh `npm run build` and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added in-place file replacement support that keeps the existing internal identifier while updating file details.
  * Introduced a new `file-replaced` event (and continued `file-url-changed`) for replacement flows, without triggering an extra `file-upload-success`.
* **Bug Fixes**
  * Improved replacement handling to properly clear stale replacement state and prevent duplicate success events.
  * Enhanced thumbnail resource cleanup for blob-based thumbnails during replacement.
* **Tests**
  * Added unit and end-to-end coverage for `files.replace`, including event behavior and no-op safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->