### PR TITLE
fix(config): keep dedicated CDN domains in cdn-cname verbatim

### DIFF
--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -7,7 +7,7 @@ import { toKebabCase } from '../../utils/toKebabCase';
 import { runAssertions } from './assertions';
 import './config.css';
 import { LitBlock } from '../../lit/LitBlock';
-import { type ComputedPropertyControllers, computeProperty } from './computed-properties';
+import { type ComputedPropertyControllers, type ComputedPropertyValues, computeProperty } from './computed-properties';
 import { initialConfig } from './initialConfig';
 import { normalizeConfigValue } from './normalizeConfigValue';
 
@@ -62,6 +62,7 @@ export class Config extends LitBlock {
   } as unknown as LitBlock['init$'] & ConfigType;
 
   private _computationControllers: ComputedPropertyControllers = new Map();
+  private _computedValues: ComputedPropertyValues = new Map();
   private _pluginChangeUnsubscribe?: () => void;
   private _mutationObserver?: MutationObserver;
 
@@ -415,6 +416,7 @@ export class Config extends LitBlock {
         setValue: this._setValue.bind(this),
         getValue: this._getValue.bind(this),
         computationControllers: this._computationControllers,
+        computedValues: this._computedValues,
       });
     };
 

--- a/src/blocks/Config/computed-properties.test.ts
+++ b/src/blocks/Config/computed-properties.test.ts
@@ -1,5 +1,7 @@
+import { getPrefixedCdnBaseSync } from '@uploadcare/cname-prefix/sync';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { computeProperty } from './computed-properties';
+import { type ComputedPropertyValues, computeProperty } from './computed-properties';
+import { DEFAULT_CDN_CNAME, DEFAULT_PREFIXED_CDN_BASE_DOMAIN } from './initialConfig';
 
 type AnyRecord = Record<string, any>;
 const makeGetter = (values: AnyRecord) => (key: string) => values[key] as any;
@@ -15,6 +17,7 @@ describe('computeProperty', () => {
         setValue: setValue as any,
         getValue: makeGetter({ enableVideoRecording: true, cameraModes: 'photo' }) as any,
         computationControllers: new Map(),
+        computedValues: new Map(),
       });
       expect(setValue).toHaveBeenCalledWith('cameraModes', 'photo,video');
     });
@@ -26,6 +29,7 @@ describe('computeProperty', () => {
         setValue: setValue as any,
         getValue: makeGetter({ enableVideoRecording: false, cameraModes: 'photo,video' }) as any,
         computationControllers: new Map(),
+        computedValues: new Map(),
       });
       expect(setValue).toHaveBeenCalledWith('cameraModes', 'photo');
     });
@@ -37,6 +41,7 @@ describe('computeProperty', () => {
         setValue: setValue as any,
         getValue: makeGetter({ enableVideoRecording: null, cameraModes: 'photo,video' }) as any,
         computationControllers: new Map(),
+        computedValues: new Map(),
       });
       expect(setValue).toHaveBeenCalledWith('cameraModes', 'photo,video');
     });
@@ -50,6 +55,7 @@ describe('computeProperty', () => {
         setValue: setValue as any,
         getValue: makeGetter({ defaultCameraMode: 'video', cameraModes: 'photo,video' }) as any,
         computationControllers: new Map(),
+        computedValues: new Map(),
       });
       expect(setValue).toHaveBeenCalledWith('cameraModes', 'video,photo');
     });
@@ -61,8 +67,79 @@ describe('computeProperty', () => {
         setValue: setValue as any,
         getValue: makeGetter({ defaultCameraMode: null, cameraModes: 'photo,video' }) as any,
         computationControllers: new Map(),
+        computedValues: new Map(),
       });
       expect(setValue).toHaveBeenCalledWith('cameraModes', 'photo,video');
+    });
+  });
+
+  describe('cdnCname / pubkey', () => {
+    const derived = (pubkey: string) => getPrefixedCdnBaseSync(pubkey, DEFAULT_PREFIXED_CDN_BASE_DOMAIN);
+
+    const computeCdnCname = (values: AnyRecord, computedValues: ComputedPropertyValues = new Map()) => {
+      const setValue = vi.fn();
+      computeProperty({
+        key: 'pubkey',
+        setValue: setValue as any,
+        getValue: makeGetter({ cdnCnamePrefixed: DEFAULT_PREFIXED_CDN_BASE_DOMAIN, ...values }) as any,
+        computationControllers: new Map(),
+        computedValues,
+      });
+      return setValue;
+    };
+
+    it('derives the prefixed base when cdnCname is the default', async () => {
+      const setValue = computeCdnCname({ pubkey: 'demopublickey', cdnCname: DEFAULT_CDN_CNAME });
+      await vi.waitFor(() => expect(setValue).toHaveBeenCalledWith('cdnCname', derived('demopublickey')));
+    });
+
+    it('derives the prefixed base when cdnCname is the prefixed zone apex', async () => {
+      const setValue = computeCdnCname({ pubkey: 'demopublickey', cdnCname: 'https://ucarecd.net' });
+      await vi.waitFor(() => expect(setValue).toHaveBeenCalledWith('cdnCname', derived('demopublickey')));
+    });
+
+    it('keeps a dedicated domain inside the prefixed zone verbatim', () => {
+      const setValue = computeCdnCname({ pubkey: 'demopublickey', cdnCname: 'https://custom.ucarecd.net' });
+      expect(setValue).toHaveBeenCalledWith('cdnCname', 'https://custom.ucarecd.net');
+    });
+
+    it('keeps a dedicated domain on a sub-zone verbatim', () => {
+      const setValue = computeCdnCname({ pubkey: 'demopublickey', cdnCname: 'https://1nnim0cit9.s.ucarecd.net' });
+      expect(setValue).toHaveBeenCalledWith('cdnCname', 'https://1nnim0cit9.s.ucarecd.net');
+    });
+
+    it('keeps a custom CNAME verbatim', () => {
+      const setValue = computeCdnCname({ pubkey: 'demopublickey', cdnCname: 'https://cdn.example.com' });
+      expect(setValue).toHaveBeenCalledWith('cdnCname', 'https://cdn.example.com');
+    });
+
+    it('re-derives its own previously computed value when pubkey changes', async () => {
+      const computedValues: ComputedPropertyValues = new Map();
+      const values: AnyRecord = { pubkey: 'first-key', cdnCname: DEFAULT_CDN_CNAME };
+
+      const firstSetValue = computeCdnCname(values, computedValues);
+      await vi.waitFor(() => expect(firstSetValue).toHaveBeenCalledWith('cdnCname', derived('first-key')));
+
+      // The computed value is written back into the config; a pubkey change
+      // must re-derive it instead of treating it as a user-provided domain.
+      values.cdnCname = derived('first-key');
+      values.pubkey = 'second-key';
+      const secondSetValue = computeCdnCname(values, computedValues);
+      await vi.waitFor(() => expect(secondSetValue).toHaveBeenCalledWith('cdnCname', derived('second-key')));
+    });
+
+    it('does not clobber a dedicated domain when pubkey changes', () => {
+      const computedValues: ComputedPropertyValues = new Map();
+      const values: AnyRecord = { pubkey: 'first-key', cdnCname: 'https://custom.ucarecd.net' };
+
+      const firstSetValue = computeCdnCname(values, computedValues);
+      expect(firstSetValue).toHaveBeenCalledWith('cdnCname', 'https://custom.ucarecd.net');
+
+      // The verbatim pass-through above must not be recorded as the
+      // property's own output, so a pubkey change keeps it untouched.
+      values.pubkey = 'second-key';
+      const secondSetValue = computeCdnCname(values, computedValues);
+      expect(secondSetValue).toHaveBeenCalledWith('cdnCname', 'https://custom.ucarecd.net');
     });
   });
 });

--- a/src/blocks/Config/computed-properties.ts
+++ b/src/blocks/Config/computed-properties.ts
@@ -1,4 +1,4 @@
-import { getPrefixedCdnBaseAsync, isPrefixedCdnBase } from '@uploadcare/cname-prefix/async';
+import { getPrefixedCdnBaseAsync, isSameCdnHost } from '@uploadcare/cname-prefix/async';
 import type { ConfigType } from '../../types/index';
 import { deserializeCsv, serializeCsv } from '../../utils/comma-separated';
 import { isPromiseLike } from '../../utils/isPromiseLike';
@@ -16,6 +16,12 @@ type ComputedPropertyArgs<TKey extends ConfigKey, TDeps extends DepKeys<TKey>> =
 
 type ComputedPropertyOptions = {
   signal: AbortSignal;
+  /**
+   * The value this computed property wrote on its previous run (per Config
+   * instance). Lets a property recognize its own output when it is fed back
+   * as input and re-derive it, while leaving user-provided values untouched.
+   */
+  lastComputedValue: unknown;
 };
 
 type ComputedPropertyFn<TKey extends ConfigKey, TDeps extends DepKeys<TKey>> = (
@@ -30,6 +36,9 @@ type ComputedPropertyDeclaration<TKey extends ConfigKey, TDeps extends DepKeys<T
 };
 
 export type ComputedPropertyControllers = Map<ComputedPropertyFn<any, any>, AbortController>;
+
+/** Last value written by each computed property, per Config instance. */
+export type ComputedPropertyValues = Map<ComputedPropertyFn<any, any>, unknown>;
 
 const defineComputedProperty = <TKey extends ConfigKey, TDeps extends DepKeys<TKey>>(
   declaration: ComputedPropertyDeclaration<TKey, TDeps>,
@@ -73,11 +82,17 @@ const COMPUTED_PROPERTIES = [
   defineComputedProperty({
     key: 'cdnCname',
     deps: ['pubkey', 'cdnCnamePrefixed'] as const,
-    fn: ({ pubkey, cdnCname, cdnCnamePrefixed }) => {
+    fn: ({ pubkey, cdnCname, cdnCnamePrefixed }, { lastComputedValue }) => {
       const pk = pubkey();
       const cname = cdnCname();
       const prefixed = cdnCnamePrefixed();
-      if (pk && (cname === DEFAULT_CDN_CNAME || isPrefixedCdnBase(cname, prefixed))) {
+      // Derive the per-project prefixed base when cdnCname is untouched, is a
+      // value this property computed earlier (re-derive on pubkey change), or
+      // explicitly targets the prefixed zone apex (e.g. bare `ucarecd.net`).
+      // Any other value — including a dedicated domain inside the prefixed
+      // zone like `custom.ucarecd.net` — is the user's and is kept verbatim.
+      const shouldDerive = cname === DEFAULT_CDN_CNAME || cname === lastComputedValue || isSameCdnHost(cname, prefixed);
+      if (pk && shouldDerive) {
         return getPrefixedCdnBaseAsync(pk, prefixed);
       }
 
@@ -94,6 +109,7 @@ type ComputePropertyOptions<TKey extends ConfigKey> = {
   setValue: ConfigSetter;
   getValue: ConfigGetter;
   computationControllers: ComputedPropertyControllers;
+  computedValues: ComputedPropertyValues;
 };
 
 export const computeProperty = <TKey extends ConfigKey>({
@@ -101,6 +117,7 @@ export const computeProperty = <TKey extends ConfigKey>({
   setValue,
   getValue,
   computationControllers,
+  computedValues,
 }: ComputePropertyOptions<TKey>) => {
   for (const computed of COMPUTED_PROPERTIES) {
     if (!computed.deps.includes(key)) continue;
@@ -117,10 +134,22 @@ export const computeProperty = <TKey extends ConfigKey>({
     computationControllers.get(computed.fn)?.abort();
     computationControllers.set(computed.fn, abortController);
 
+    // Record provenance only when the property transformed its input: a value
+    // returned verbatim (pass-through) is the user's, not the property's, and
+    // must not be recognized as `lastComputedValue` on later runs.
+    const inputValue = getValue(computed.key);
+    const recordAndSetValue = (value: ConfigValue<typeof computed.key>) => {
+      if (value !== inputValue) {
+        computedValues.set(computed.fn, value);
+      }
+      setValue(computed.key, value);
+    };
+
     let result: ConfigValue<typeof computed.key> | Promise<ConfigValue<typeof computed.key>>;
     try {
       result = computed.fn(args as ComputedPropertyArgs<typeof computed.key, typeof computed.deps>, {
         signal: abortController.signal,
+        lastComputedValue: computedValues.get(computed.fn),
       });
     } catch (error) {
       if (computationControllers.get(computed.fn) === abortController) {
@@ -135,7 +164,7 @@ export const computeProperty = <TKey extends ConfigKey>({
           if (abortController.signal.aborted) {
             return;
           }
-          setValue(computed.key, resolvedValue);
+          recordAndSetValue(resolvedValue);
         })
         .catch((error) => {
           if (abortController.signal.aborted) {
@@ -149,7 +178,7 @@ export const computeProperty = <TKey extends ConfigKey>({
           }
         });
     } else {
-      setValue(computed.key, result);
+      recordAndSetValue(result);
     }
   }
 };


### PR DESCRIPTION
## What

An explicit `cdn-cname` pointing inside the prefixed CDN zone — a dedicated domain like `custom.ucarecd.net` or `<name>.s.ucarecd.net` — was silently clobbered with the derived `<hash>.ucarecd.net` base. Customers with a static dedicated hostname had to resort to the `cdnCname=... cdnCnamePrefixed="https://ucarecdn.com"` workaround.

## How

- The `cdnCname` computed property now derives the prefixed base only when the value is the untouched default, the prefixed zone apex itself (bare `ucarecd.net`), or the property's **own previously computed output**. Anything else is the user's and is kept verbatim.
- "Own output" is tracked via a per-instance provenance map (`lastComputedValue`), since a derived hash prefix is indistinguishable from a custom name by shape. The written-back derived value still re-derives when `pubkey` changes, while verbatim pass-throughs are never recorded — so a user's dedicated domain survives pubkey changes too.
- Switched from `isPrefixedCdnBase` (matched any subdomain of the zone — the root cause) to `isSameCdnHost` (hostname equality) from `@uploadcare/cname-prefix`.

## Dependency

⚠️ Requires the next `@uploadcare/cname-prefix` release (with `isSameCdnHost`, ships from uploadcare/uploadcare-js-api-clients#574) and a dependency bump before merging.

## Verification

- `computed-properties.test.ts`: 12/12 — incl. dedicated-domain verbatim cases, apex derivation, re-derive-own-value on pubkey change, and no-clobber of a dedicated domain on pubkey change.
- `tsc --noEmit` and biome clean; pre-commit hooks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automatic handling of CDN-related settings, making derived values update more reliably when related inputs change.

* **Bug Fixes**
  * Fixed cases where computed settings could overwrite customized CDN hostnames or fail to refresh after changes.
  * Preserved dedicated domains, subdomains, and custom CNAMEs while still updating defaults when appropriate.
  * Expanded test coverage for computed settings behavior and CDN hostname updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->