### PR TITLE
feat(m9a): ChildBlock UI adapter base + first leaf-block ports (Copyright, Icon, ProgressBar)

### DIFF
--- a/src/blocks/Copyright/Copyright.ts
+++ b/src/blocks/Copyright/Copyright.ts
@@ -1,11 +1,9 @@
 import { html } from 'lit';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './copyright.css';
 
-export class Copyright extends LitBlock {
-  public override initCallback(): void {
-    super.initCallback();
-
+export class Copyright extends ChildBlock {
+  protected override controllerReady(): void {
     this.subConfigValue('removeCopyright', (value) => {
       this.toggleAttribute('hidden', !!value);
     });

--- a/src/blocks/Icon/Icon.ts
+++ b/src/blocks/Icon/Icon.ts
@@ -1,11 +1,12 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
-import { LitBlock } from '../../lit/LitBlock';
+import type { PluginController } from '../../abstract/managers/plugin';
+import { ChildBlock } from '../../lit/ChildBlock';
 import type { IconHrefResolver } from '../../types/index';
 import './icon.css';
 
-export class Icon extends LitBlock {
+export class Icon extends ChildBlock {
   @property({ type: String })
   public name = '';
 
@@ -16,21 +17,30 @@ export class Icon extends LitBlock {
   private _pluginSvg: string | null = null;
 
   private _iconHrefResolver: IconHrefResolver | null = null;
-  private _unsubscribePlugins?: () => void;
+  private _pluginManager: PluginController | null = null;
 
-  public override initCallback(): void {
-    super.initCallback();
+  public override connectedCallback(): void {
+    super.connectedCallback();
     this.setAttribute('aria-hidden', 'true');
+  }
 
+  protected override controllerReady(): void {
     this.subConfigValue('iconHrefResolver', (resolver: IconHrefResolver | null) => {
       this._iconHrefResolver = resolver;
       this._updateResolvedHref();
     });
 
-    const pluginManager = this._sharedInstancesBag.pluginManager;
-    if (pluginManager?.onPluginsChange) {
-      this._unsubscribePlugins = pluginManager.onPluginsChange(() => this._updateResolvedHref());
-    }
+    this.trackSub(
+      this.bag.when('pluginManager', (pluginManager) => {
+        this._pluginManager = pluginManager;
+        this.trackSub(pluginManager.onPluginsChange(() => this._updateResolvedHref()));
+        this._updateResolvedHref();
+      }),
+    );
+  }
+
+  protected override controllerReleased(): void {
+    this._pluginManager = null;
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
@@ -47,8 +57,7 @@ export class Icon extends LitBlock {
       return;
     }
 
-    const pluginManager = this._sharedInstancesBag.pluginManager;
-    const pluginIcon = pluginManager?.snapshot().icons.find((icon) => icon.name === this.name);
+    const pluginIcon = this._pluginManager?.snapshot().icons.find((icon) => icon.name === this.name);
 
     if (pluginIcon) {
       this._pluginSvg = pluginIcon.svg;
@@ -75,12 +84,6 @@ export class Icon extends LitBlock {
       </svg>`,
       )}
     `;
-  }
-
-  public override disconnectedCallback(): void {
-    this._unsubscribePlugins?.();
-    this._unsubscribePlugins = undefined;
-    super.disconnectedCallback();
   }
 }
 

--- a/src/blocks/Icon/Icon.ts
+++ b/src/blocks/Icon/Icon.ts
@@ -17,6 +17,8 @@ export class Icon extends ChildBlock {
   private _pluginSvg: string | null = null;
 
   private _iconHrefResolver: IconHrefResolver | null = null;
+  // Transiently null until the shared PluginController registers (bag.when) —
+  // render falls back to the sprite href meanwhile.
   private _pluginManager: PluginController | null = null;
 
   public override connectedCallback(): void {

--- a/src/blocks/ProgressBar/ProgressBar.ts
+++ b/src/blocks/ProgressBar/ProgressBar.ts
@@ -3,9 +3,9 @@ import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 
-export class ProgressBar extends LitBlock {
+export class ProgressBar extends ChildBlock {
   @property({ type: Boolean, noAccessor: true })
   public hasFileName = false;
 

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -25,6 +25,10 @@ const ChildBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
  * nanostores. Rendering is gated until a controller is adopted (matching
  * v1's `shouldUpdate` gate on ctx init); do controller-dependent setup in
  * `controllerReady`, never in `connectedCallback`.
+ * Note: while the render gate is closed Lit still clears its
+ * changed-properties tracking, so pre-adoption property writes will not
+ * appear in `changedProperties` at the first real render — read current
+ * values instead of `changedProperties.has(...)` in `firstUpdated`.
  */
 export abstract class ChildBlock extends ChildBlockBase {
   public static styleAttrs: string[] = [];
@@ -95,7 +99,6 @@ export abstract class ChildBlock extends ChildBlockBase {
 
   protected override willUpdate(changed: PropertyValues<this>): void {
     super.willUpdate(changed);
-    if (changed.has('ctxName')) this._watchRegistry();
     // Re-provide the effective ctx-name downward so v1 children nested under
     // a ported block keep resolving their ctx exactly as they would under a
     // v1 parent.
@@ -121,6 +124,10 @@ export abstract class ChildBlock extends ChildBlockBase {
   }
 
   protected override shouldUpdate(changed: PropertyValues<this>): boolean {
+    // ctx-name may arrive or change while the render gate below is still
+    // closed (willUpdate never runs then) — react to it here, where Lit
+    // calls in even for gated updates.
+    if (changed.has('ctxName')) this._watchRegistry();
     // v1 parity: SymbioteCompatMixin gates rendering until the ctx is
     // initialized; here the gate is controller adoption.
     if (!this._controller) {

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -1,0 +1,219 @@
+import { ContextConsumer, ContextProvider } from '@lit/context';
+import { LitElement, type PropertyValues } from 'lit';
+import { property, state } from 'lit/decorators.js';
+import type { UploaderController } from '../abstract/controllers/UploaderController';
+import { UploaderRegistry } from '../abstract/UploaderRegistry';
+import type { ConfigType } from '../types';
+import { LightDomMixin } from './LightDomMixin';
+import { PubSub } from './PubSubCompat';
+import { RegisterableElementMixin } from './RegisterableElementMixin';
+import type { SharedState } from './SharedState';
+import { ctxNameContext } from './SymbioteCompatMixin';
+import { createSharedInstancesBag, type SharedInstancesBag } from './shared-instances';
+
+const ChildBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
+
+/**
+ * Base class for blocks ported off `SymbioteCompatMixin` (M9). Resolves the
+ * per-ctx `UploaderController` by ctx-name — from the element's own
+ * `ctx-name` attribute or, when absent, from the nearest v1 ancestor's
+ * `ctxNameContext` provider — via `UploaderRegistry.whenAvailable`, which
+ * fires synchronously when a controller is already registered and again
+ * across a remount, so subclasses re-adopt without losing bindings.
+ *
+ * Subclasses read controllers directly: no `$` proxy, no `init$`, no
+ * nanostores. Rendering is gated until a controller is adopted (matching
+ * v1's `shouldUpdate` gate on ctx init); do controller-dependent setup in
+ * `controllerReady`, never in `connectedCallback`.
+ */
+export abstract class ChildBlock extends ChildBlockBase {
+  public static styleAttrs: string[] = [];
+
+  @property({ attribute: 'ctx-name' })
+  public ctxName: string | undefined = undefined;
+
+  @state()
+  private _inheritedCtxName: string | undefined = undefined;
+
+  private _controller: UploaderController | null = null;
+  private _watchedCtxName: string | undefined = undefined;
+  private _registryUnsub?: () => void;
+  private _subs: Array<() => void> = [];
+  private _ctxNameProvider: ContextProvider<{ __context__: string | undefined }> | undefined = undefined;
+
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: `ContextConsumer` subscribes by side effect — the field keeps it alive for the host's lifetime.
+  private _ctxNameConsumer = new ContextConsumer(this, {
+    context: ctxNameContext,
+    callback: (value) => {
+      if (!value) return;
+      this._inheritedCtxName = value;
+      this._watchRegistry();
+    },
+    subscribe: true,
+  });
+
+  /** The element's own `ctx-name` attribute wins over the inherited context (v1 parity). */
+  protected get effectiveCtxName(): string | undefined {
+    return this.ctxName || this._inheritedCtxName;
+  }
+
+  protected get uploader(): UploaderController {
+    if (!this._controller) {
+      throw new Error(
+        `${this.tagName.toLowerCase()}: UploaderController is not available yet. ` +
+          'Read it in controllerReady() or use uploaderOrNull for guarded access.',
+      );
+    }
+    return this._controller;
+  }
+
+  protected get uploaderOrNull(): UploaderController | null {
+    return this._controller;
+  }
+
+  /**
+   * Shared v1 manager/controller instances for this ctx. Getters throw until
+   * the instance registers — inside `controllerReady` prefer `bag.when(name,
+   * cb)` (async-safe) over direct getters.
+   */
+  protected bag: SharedInstancesBag = createSharedInstancesBag(() => {
+    const ctxName = this.effectiveCtxName;
+    const ctx = ctxName ? PubSub.getCtx<SharedState>(ctxName) : null;
+    if (!ctx) {
+      throw new Error(`${this.tagName.toLowerCase()}: shared context is not initialized yet.`);
+    }
+    return ctx;
+  });
+
+  public override connectedCallback(): void {
+    super.connectedCallback();
+    for (const attr of (this.constructor as typeof ChildBlock).styleAttrs) {
+      if (!this.hasAttribute(attr)) this.setAttribute(attr, '');
+    }
+    this._watchRegistry();
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+    if (changed.has('ctxName')) this._watchRegistry();
+    // Re-provide the effective ctx-name downward so v1 children nested under
+    // a ported block keep resolving their ctx exactly as they would under a
+    // v1 parent.
+    const effective = this.effectiveCtxName;
+    if (effective) {
+      if (!this._ctxNameProvider) {
+        this._ctxNameProvider = new ContextProvider(this, {
+          context: ctxNameContext,
+          initialValue: effective,
+        });
+      } else {
+        this._ctxNameProvider.setValue(effective);
+      }
+    }
+  }
+
+  public override disconnectedCallback(): void {
+    this._registryUnsub?.();
+    this._registryUnsub = undefined;
+    this._watchedCtxName = undefined;
+    this._releaseController();
+    super.disconnectedCallback();
+  }
+
+  protected override shouldUpdate(changed: PropertyValues<this>): boolean {
+    // v1 parity: SymbioteCompatMixin gates rendering until the ctx is
+    // initialized; here the gate is controller adoption.
+    if (!this._controller) {
+      return false;
+    }
+    return super.shouldUpdate(changed);
+  }
+
+  private _watchRegistry(): void {
+    const ctxName = this.effectiveCtxName;
+    if (!this.isConnected || !ctxName || ctxName === this._watchedCtxName) {
+      return;
+    }
+    this._registryUnsub?.();
+    this._watchedCtxName = ctxName;
+    this._registryUnsub = UploaderRegistry.whenAvailable(ctxName, (ctrl) => this._adoptController(ctrl));
+  }
+
+  private _adoptController(ctrl: UploaderController): void {
+    if (this._controller === ctrl) return;
+    this._releaseController();
+    this._controller = ctrl;
+    const rerender = () => this.requestUpdate();
+    for (const subscribe of this.subscriptionsFor(ctrl)) {
+      this._subs.push(subscribe(rerender));
+    }
+    this._subs.push(ctrl.config.subscribe(() => this._syncTestId(ctrl)));
+    this._syncTestId(ctrl);
+    this.controllerReady(ctrl);
+    this.requestUpdate();
+  }
+
+  private _releaseController(): void {
+    const ctrl = this._controller;
+    for (const unsub of this._subs) {
+      try {
+        unsub();
+      } catch {
+        // Teardown must be isolated: one throwing unsubscriber must not
+        // prevent the rest from running.
+      }
+    }
+    this._subs = [];
+    this._controller = null;
+    if (ctrl) this.controllerReleased(ctrl);
+  }
+
+  private _syncTestId(ctrl: UploaderController): void {
+    if (ctrl.config.get('testMode')) {
+      this.setAttribute('data-testid', this.tagName.toLowerCase());
+    } else {
+      this.removeAttribute('data-testid');
+    }
+  }
+
+  /** Track a subscription for auto-teardown on controller release / disconnect. */
+  protected trackSub(unsub: () => void): void {
+    this._subs.push(unsub);
+  }
+
+  /**
+   * Per-key config subscription: fires immediately with the current value,
+   * then on every change of that key (`Object.is` dedup over the coarse
+   * config notification). Same contract as v1 `LitBlock.subConfigValue`.
+   * Call from `controllerReady` or later; auto-tracked.
+   */
+  protected subConfigValue<K extends keyof ConfigType>(key: K, callback: (value: ConfigType[K]) => void): () => void {
+    const config = this.uploader.config;
+    let last = config.get(key);
+    callback(last);
+    const unsub = config.subscribe(() => {
+      const next = config.get(key);
+      if (!Object.is(next, last)) {
+        last = next;
+        callback(next);
+      }
+    });
+    this.trackSub(unsub);
+    return unsub;
+  }
+
+  /**
+   * Controller-change subscriptions that should trigger a re-render — return
+   * `subscribe` functions (e.g. `(l) => ctrl.config.subscribe(l)`). Wired on
+   * adoption, torn down on release.
+   */
+  protected subscriptionsFor(_ctrl: UploaderController): Array<(listener: () => void) => () => void> {
+    return [];
+  }
+
+  /** Called after a controller is adopted (initial and on re-adoption). */
+  protected controllerReady(_ctrl: UploaderController): void {}
+
+  /** Called after the controller is released (disconnect or re-adoption). */
+  protected controllerReleased(_ctrl: UploaderController): void {}
+}

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -138,11 +138,19 @@ export abstract class ChildBlock extends ChildBlockBase {
 
   private _watchRegistry(): void {
     const ctxName = this.effectiveCtxName;
-    if (!this.isConnected || !ctxName || ctxName === this._watchedCtxName) {
+    if (!this.isConnected || ctxName === this._watchedCtxName) {
       return;
     }
     this._registryUnsub?.();
+    this._registryUnsub = undefined;
     this._watchedCtxName = ctxName;
+    // Scope switch (or ctx-name removed entirely): drop the current controller
+    // right away so the render gate closes instead of serving the previous
+    // scope's data while the new controller is still pending.
+    this._releaseController();
+    if (!ctxName) {
+      return;
+    }
     this._registryUnsub = UploaderRegistry.whenAvailable(ctxName, (ctrl) => this._adoptController(ctrl));
   }
 
@@ -165,9 +173,13 @@ export abstract class ChildBlock extends ChildBlockBase {
     for (const unsub of this._subs) {
       try {
         unsub();
-      } catch {
+      } catch (err) {
         // Teardown must be isolated: one throwing unsubscriber must not
         // prevent the rest from running.
+        console.warn(
+          `[uc] ${this.tagName.toLowerCase()}: a subscription teardown threw during controller release`,
+          err,
+        );
       }
     }
     this._subs = [];

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -1,5 +1,5 @@
 import { html } from 'lit';
-import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { UploaderController } from '@/abstract/controllers/UploaderController';
 import type { Config } from '@/index.ts';
@@ -12,6 +12,8 @@ class TestChildBlock extends ChildBlock {
   public static override styleAttrs = ['test-child-style'];
   public readyCount = 0;
   public releasedCount = 0;
+  public throwOnRelease = false;
+  public cleanupRanAfterThrow = false;
 
   protected override subscriptionsFor(ctrl: UploaderController) {
     return [(listener: () => void) => ctrl.config.subscribe(listener)];
@@ -19,6 +21,14 @@ class TestChildBlock extends ChildBlock {
 
   protected override controllerReady(): void {
     this.readyCount += 1;
+    if (this.throwOnRelease) {
+      this.trackSub(() => {
+        throw new Error('boom');
+      });
+      this.trackSub(() => {
+        this.cleanupRanAfterThrow = true;
+      });
+    }
   }
 
   protected override controllerReleased(): void {
@@ -158,6 +168,44 @@ describe('ChildBlock', () => {
     child.setAttribute('ctx-name', ctxName);
     await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
     expect(child.readyCount).toBe(1);
+  });
+
+  it('releases the controller and re-gates when ctx-name switches to a not-yet-available ctx', async () => {
+    const ctxNameA = getCtxName();
+    const ctxNameB = getCtxName();
+    page.render(<uc-config ctx-name={ctxNameA} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxNameA });
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+
+    child.setAttribute('ctx-name', ctxNameB);
+    await expect.poll(() => child.releasedCount).toBe(1);
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected getter
+    expect((child as any).uploaderOrNull).toBeNull();
+
+    append('uc-config', { 'ctx-name': ctxNameB, pubkey: 'otherkey' });
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('otherkey');
+    expect(child.readyCount).toBe(2);
+  });
+
+  it('isolates a throwing unsubscriber during release, warns, and finishes teardown', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = document.createElement('test-child-block');
+    child.throwOnRelease = true;
+    child.setAttribute('ctx-name', ctxName);
+    document.body.append(child);
+    appended.push(child);
+    await expect.poll(() => child.readyCount).toBe(1);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      child.remove();
+      expect(child.releasedCount).toBe(1);
+      expect(child.cleanupRanAfterThrow).toBe(true);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('teardown threw'), expect.any(Error));
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 
   it('throws a descriptive error when uploader is read before adoption', () => {

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -148,6 +148,18 @@ describe('ChildBlock', () => {
     await expect.poll(() => child.readyCount).toBe(2);
   });
 
+  it('adopts when ctx-name is set after connection', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block');
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(child.readyCount).toBe(0);
+
+    child.setAttribute('ctx-name', ctxName);
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+    expect(child.readyCount).toBe(1);
+  });
+
   it('throws a descriptive error when uploader is read before adoption', () => {
     const child = document.createElement('test-child-block');
     // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected getter

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -1,0 +1,156 @@
+import { html } from 'lit';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { UploaderController } from '@/abstract/controllers/UploaderController';
+import type { Config } from '@/index.ts';
+import { ChildBlock } from '@/lit/ChildBlock';
+import { LitBlock } from '@/lit/LitBlock';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+class TestChildBlock extends ChildBlock {
+  public static override styleAttrs = ['test-child-style'];
+  public readyCount = 0;
+  public releasedCount = 0;
+
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.config.subscribe(listener)];
+  }
+
+  protected override controllerReady(): void {
+    this.readyCount += 1;
+  }
+
+  protected override controllerReleased(): void {
+    this.releasedCount += 1;
+  }
+
+  public override render() {
+    return html`<span class="pk">${this.uploaderOrNull?.config.get('pubkey') ?? ''}</span>`;
+  }
+}
+
+class TestV1Host extends LitBlock {
+  public override render() {
+    return html`${this.yield('')}`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-child-block': TestChildBlock;
+    'test-v1-host': TestV1Host;
+  }
+}
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+  if (!customElements.get('test-child-block')) customElements.define('test-child-block', TestChildBlock);
+  if (!customElements.get('test-v1-host')) customElements.define('test-v1-host', TestV1Host);
+});
+
+const appended: HTMLElement[] = [];
+const append = <K extends keyof HTMLElementTagNameMap>(tag: K, attrs: Record<string, string> = {}) => {
+  const el = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  document.body.append(el);
+  appended.push(el);
+  return el;
+};
+
+afterEach(() => {
+  for (const el of appended) el.remove();
+  appended.length = 0;
+});
+
+describe('ChildBlock', () => {
+  it('adopts the controller via its own ctx-name attribute and renders', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+    expect(child.readyCount).toBe(1);
+    expect(child.hasAttribute('test-child-style')).toBe(true);
+  });
+
+  it('does not render before a controller is available', async () => {
+    const child = append('test-child-block', { 'ctx-name': getCtxName() });
+    await new Promise((resolve) => setTimeout(resolve, 50));
+    expect(child.querySelector('.pk')).toBeNull();
+    expect(child.readyCount).toBe(0);
+  });
+
+  it('inherits ctx-name from a v1 ancestor via context', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const host = append('test-v1-host', { 'ctx-name': ctxName });
+    const child = document.createElement('test-child-block');
+    host.append(child);
+
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+  });
+
+  it('re-renders on controller change notifications (subscriptionsFor)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+
+    const config = page.getByTestId('uc-config').query()! as Config;
+    config.pubkey = 'otherkey';
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('otherkey');
+  });
+
+  it('subConfigValue fires immediately and dedupes per key', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+
+    const seen: unknown[] = [];
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected test helper
+    (child as any).subConfigValue('multiple', (v: boolean) => seen.push(v));
+    expect(seen).toEqual([true]);
+
+    const config = page.getByTestId('uc-config').query()! as Config;
+    config.pubkey = 'unrelated-change';
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(seen).toEqual([true]); // unrelated key change must not re-fire
+
+    config.multiple = false;
+    await expect.poll(() => seen.length).toBe(2);
+    expect(seen).toEqual([true, false]);
+  });
+
+  it('reflects data-testid under testMode and removes it when off', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.getAttribute('data-testid')).toBe('test-child-block');
+
+    const config = page.getByTestId('uc-config').query()! as Config;
+    config.testMode = false;
+    await expect.poll(() => child.hasAttribute('data-testid')).toBe(false);
+  });
+
+  it('releases subscriptions on disconnect and re-adopts on reconnect', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+
+    child.remove();
+    expect(child.releasedCount).toBe(1);
+
+    document.body.append(child);
+    await expect.poll(() => child.readyCount).toBe(2);
+  });
+
+  it('throws a descriptive error when uploader is read before adoption', () => {
+    const child = document.createElement('test-child-block');
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected getter
+    expect(() => (child as any).uploader).toThrowError(/test-child-block/);
+  });
+});

--- a/tests/blocks/copyright.e2e.test.tsx
+++ b/tests/blocks/copyright.e2e.test.tsx
@@ -1,0 +1,49 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderCopyright = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-copyright ctx-name={ctxName}></uc-copyright>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  return { ctxName, config };
+};
+
+describe('uc-copyright', () => {
+  it('renders the "Powered by Uploadcare" link', async () => {
+    renderCopyright();
+    const link = page.getByText('Powered by Uploadcare', { exact: true });
+    await expect.element(link).toBeVisible();
+    expect((link.query() as HTMLAnchorElement).href).toContain('uploadcare.com');
+    expect(link.query()?.classList.contains('uc-credits')).toBe(true);
+  });
+
+  it('hides when removeCopyright is set, shows again when unset', async () => {
+    const { config } = renderCopyright();
+    const el = () => document.querySelector('uc-copyright')!;
+    await expect.element(page.getByText('Powered by Uploadcare', { exact: true })).toBeVisible();
+
+    config.removeCopyright = true;
+    await expect.poll(() => el().hasAttribute('hidden')).toBe(true);
+
+    config.removeCopyright = false;
+    await expect.poll(() => el().hasAttribute('hidden')).toBe(false);
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderCopyright();
+    await expect.element(page.getByTestId('uc-copyright')).toBeInTheDocument();
+  });
+});

--- a/tests/blocks/icon.e2e.test.tsx
+++ b/tests/blocks/icon.e2e.test.tsx
@@ -1,0 +1,98 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, Icon, UploaderPlugin } from '@/index.ts';
+import { delay } from '@/utils/delay';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderIcon = (name: string) => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-icon ctx-name={ctxName}></uc-icon>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const icon = document.querySelector('uc-icon')! as Icon;
+  // `name` isn't part of the JSX `CustomElement<Icon>` attribute typing
+  // (only reflected properties are), so it's set as a JS property post-render.
+  icon.name = name;
+  return { ctxName, config, icon };
+};
+
+const useHref = () => document.querySelector('uc-icon svg use')?.getAttribute('href');
+
+describe('uc-icon', () => {
+  it('renders a sprite reference for the given name and is aria-hidden', async () => {
+    const { icon } = renderIcon('upload');
+    await expect.poll(useHref).toBe('#uc-icon-upload');
+    expect(icon.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('updates the sprite reference when name changes', async () => {
+    const { icon } = renderIcon('upload');
+    await expect.poll(useHref).toBe('#uc-icon-upload');
+    icon.name = 'close';
+    await expect.poll(useHref).toBe('#uc-icon-close');
+  });
+
+  it('resolves the href through iconHrefResolver when configured', async () => {
+    const { config } = renderIcon('upload');
+    config.iconHrefResolver = (name: string) => `/sprite.svg#${name}`;
+    await expect.poll(useHref).toBe('/sprite.svg#upload');
+
+    config.iconHrefResolver = null;
+    await expect.poll(useHref).toBe('#uc-icon-upload');
+  });
+
+  it('renders a plugin-registered icon inline, overriding the sprite', async () => {
+    // The plugin registry is only wired up to `cfg.plugins` changes when a
+    // `*lazyPlugins` list has been published to the shared ctx — that only
+    // happens once a solution block (e.g. `uc-file-uploader-regular`) is
+    // present. Without one, `LazyPluginLoader` sees zero entries and never
+    // subscribes to plugin config changes at all, so `config.plugins` writes
+    // would be silently dropped.
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-icon ctx-name={ctxName} class="icon-under-test"></uc-icon>
+        <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      </>,
+    );
+    const config = page.getByTestId('uc-config').query()! as Config;
+    // The solution block renders its own internal `uc-icon`s, so scope all
+    // lookups to our icon under test instead of querying the whole document.
+    const testedIcon = () => document.querySelector('uc-icon.icon-under-test')!;
+    (testedIcon() as Icon).name = 'my-plugin-icon';
+    const testedIconHref = () => testedIcon().querySelector('svg use')?.getAttribute('href');
+    await expect.poll(testedIconHref).toBe('#uc-icon-my-plugin-icon');
+
+    const plugin: UploaderPlugin = {
+      id: 'icon-test-plugin',
+      setup: ({ pluginApi }) => {
+        pluginApi.registry.registerIcon({
+          name: 'my-plugin-icon',
+          svg: '<svg viewBox="0 0 24 24"><rect width="24" height="24"/></svg>',
+        });
+      },
+    };
+    await delay(0);
+    config.plugins = [plugin];
+
+    await expect.poll(() => testedIcon().querySelector('svg[viewBox="0 0 24 24"] rect')).toBeTruthy();
+    expect(testedIcon().querySelector('svg use')).toBeNull();
+  });
+
+  it('renders an empty reference when name is empty', async () => {
+    renderIcon('');
+    await expect.poll(() => document.querySelector('uc-icon svg use')).toBeTruthy();
+    expect(useHref()).toBe('');
+  });
+});

--- a/tests/blocks/progress-bar.e2e.test.tsx
+++ b/tests/blocks/progress-bar.e2e.test.tsx
@@ -1,0 +1,107 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { ProgressBar } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderBar = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-progress-bar ctx-name={ctxName}></uc-progress-bar>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const bar = document.querySelector('uc-progress-bar')! as ProgressBar;
+  return { bar };
+};
+
+const progressVar = (bar: ProgressBar) => bar.style.getPropertyValue('--l-progress-value');
+
+describe('uc-progress-bar', () => {
+  it('renders the progress structure', async () => {
+    renderBar();
+    await expect.poll(() => document.querySelector('uc-progress-bar .uc-progress')).toBeTruthy();
+    expect(document.querySelector('uc-progress-bar .uc-fake-progress')).toBeTruthy();
+  });
+
+  it('reflects value into --l-progress-value and never moves backward while visible', async () => {
+    const { bar } = renderBar();
+    bar.value = 30;
+    await expect.poll(() => progressVar(bar)).toBe('30');
+    bar.value = 10;
+    // monotonic: stays at 30 while visible
+    await expect.poll(() => progressVar(bar)).toBe('30');
+    bar.value = 55;
+    await expect.poll(() => progressVar(bar)).toBe('55');
+  });
+
+  it('clamps non-finite and out-of-range values', async () => {
+    const { bar } = renderBar();
+    bar.value = 150;
+    await expect.poll(() => progressVar(bar)).toBe('100');
+
+    // reset via hide (progress resets to the normalized current value).
+    // Each property set must flush its own Lit update cycle (synchronous
+    // writes in the same tick would batch into a single `updated()` pass
+    // that only sees the final `visible`/`value`, masking the reset).
+    bar.visible = false;
+    await bar.updateComplete;
+    bar.value = Number.NaN;
+    await bar.updateComplete;
+    bar.visible = true;
+    await expect.poll(() => progressVar(bar)).toBe('0');
+
+    bar.visible = false;
+    await bar.updateComplete;
+    bar.value = -5;
+    await bar.updateComplete;
+    bar.visible = true;
+    await expect.poll(() => progressVar(bar)).toBe('0');
+  });
+
+  it('toggles the hidden class and resets progress when hidden', async () => {
+    const { bar } = renderBar();
+    bar.value = 40;
+    await expect.poll(() => progressVar(bar)).toBe('40');
+
+    bar.visible = false;
+    await expect.poll(() => bar.classList.contains('uc-progress-bar--hidden')).toBe(true);
+
+    // Setting `value` while still hidden, then flushing before flipping
+    // `visible` back — flipping both in the same tick would let the
+    // `value` branch see the already-true `visible` and skip the reset.
+    bar.value = 20;
+    await bar.updateComplete;
+    bar.visible = true;
+    await expect.poll(() => bar.classList.contains('uc-progress-bar--hidden')).toBe(false);
+    // reset happened while hidden: 20 replaces the old 40
+    await expect.poll(() => progressVar(bar)).toBe('20');
+  });
+
+  it('hides the fake-progress line once a real value arrives (on animation iteration)', async () => {
+    const { bar } = renderBar();
+    const fakeLine = () => document.querySelector('uc-progress-bar .uc-fake-progress')!;
+    await expect.poll(() => fakeLine()).toBeTruthy();
+    expect(fakeLine().classList.contains('uc-fake-progress--hidden')).toBe(false);
+
+    bar.value = 10;
+    await expect.poll(() => progressVar(bar)).toBe('10');
+    fakeLine().dispatchEvent(new Event('animationiteration'));
+    await expect.poll(() => fakeLine().classList.contains('uc-fake-progress--hidden')).toBe(true);
+  });
+
+  it('hides the fake-progress line when not visible (on animation iteration)', async () => {
+    const { bar } = renderBar();
+    const fakeLine = () => document.querySelector('uc-progress-bar .uc-fake-progress')!;
+    bar.visible = false;
+    await expect.poll(() => bar.classList.contains('uc-progress-bar--hidden')).toBe(true);
+    fakeLine().dispatchEvent(new Event('animationiteration'));
+    await expect.poll(() => fakeLine().classList.contains('uc-fake-progress--hidden')).toBe(true);
+  });
+});

--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -3,6 +3,7 @@
 type LitElement = import('lit').LitElement;
 type UploadCtxProvider = import('../dist/index.ts').UploadCtxProvider;
 type Config = import('../dist/index.ts').Config;
+type Copyright = import('../dist/index.ts').Copyright;
 type FileUploaderInline = import('../dist/index.ts').FileUploaderInline;
 type FileUploaderRegular = import('../dist/index.ts').FileUploaderRegular;
 type FileUploaderMinimal = import('../dist/index.ts').FileUploaderMinimal;
@@ -66,6 +67,7 @@ declare namespace JSX {
     'uc-presence-toggle': CustomElement<PresenceToggle>;
     'uc-slider-ui': CustomElement<SliderUi>;
     'uc-icon': CustomElement<Icon>;
+    'uc-copyright': CustomElement<Copyright>;
     'uc-img': CustomElement<Img> & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
     'uc-simple-btn': CustomElement<SimpleBtn>;
     'uc-start-from': CustomElement<StartFrom>;


### PR DESCRIPTION
First slice of M9 in the v1→v2 strangler migration ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7): introduces the `ChildBlock` UI adapter base class and ports the first block group off `$`/`SymbioteCompatMixin`.

## Coverage first (AGENTS.md #1)
Purely additive parity backfill before any refactor: block-level e2e suites for Copyright (3), Icon (5), ProgressBar (6) pinned against v1 behavior, then kept green **unchanged** through the ports. Copyright/Icon 100% lines; ProgressBar 97.61% (single defensive null-guard, unreachable via public surface).

## ChildBlock (`src/lit/ChildBlock.ts`, +9 e2e tests, 98.8% lines)
Controller-direct element base: resolves the per-ctx `UploaderController` by ctx-name (own attribute, or `ctxNameContext` inherited from any v1 ancestor) through `UploaderRegistry.whenAvailable` — re-adopts across remounts, re-provides ctx-name downward so v1 children under ported parents keep resolving. Keeps the v1 semantics blocks rely on: render gating until ctx availability, `data-testid` under `testMode`, `styleAttrs`, per-key `subConfigValue`. No `$`, no `init$`, no nanostores — and deliberately **no ctx-owner protocol**: `couldBeCtxOwner`/`ctxOwner` predate async state attach and are retired in the next slice (M9b) instead of replicated.

Final-review hardening included: a late-arriving `ctx-name` attribute now reaches `_watchRegistry` from `shouldUpdate` (Lit skips `willUpdate` while the render gate is closed — the trigger there could deadlock adoption; TDD-pinned).

## Ports (exemplar spread of the pattern)
- **ProgressBar** — pure property-driven block: base-class swap only, mechanics byte-identical.
- **Copyright** — `controllerReady` + `subConfigValue('removeCopyright')`.
- **Icon** — config resolver + plugin icon registry via `bag.when('pluginManager')` + `trackSub` auto-teardown.

Ported blocks intentionally leave `blocksRegistry`: verified no lookup can match them (`waitForBlockInCtx` filters activity blocks; `_hasCtxOwner` filters `LitUploaderBlock`), and ctx-teardown counting still keys off v1 blocks, which outlive these leaves until M10.

## Gate
tsc:app ✅ build (attw/publint/size-limit) ✅ specs 571 ✅ locales ✅ e2e 214/214 ✅ lint ✅

> Note: `npm run test:e2e` can intermittently exit non-zero despite 214/214 passing, via an unhandled `Modal.closeDialog → "*router" is not available` teardown race from the router-navigation/api specs. Reproduced with the identical stack on the base commit (`4e460668`, 1/6 runs) — **pre-existing on `feat/v2-migration`**, untouched by this diff; follow-up fix planned alongside M9b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added context-aware child components with automatic controller adoption, config-driven updates, and improved lifecycle handling.
  * Added JSX/TypeScript typings for `uc-copyright`.
  * Enhanced `uc-icon` rendering with resolver support, plugin-provided icons, and consistent `aria-hidden` behavior.
* **Bug Fixes**
  * Progress bar behavior remains stable across value updates, clamping, visibility changes, and fake-progress transitions.
* **Tests**
  * Added end-to-end coverage for context-aware child lifecycle, `uc-copyright` visibility, `uc-icon` resolution/plugin paths, and `uc-progress-bar` rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->