### PR TITLE
fix(modal): ignore native dialog close arriving after ctx teardown

### DIFF
--- a/src/blocks/Modal/Modal.ts
+++ b/src/blocks/Modal/Modal.ts
@@ -31,16 +31,24 @@ export class Modal extends LitBlock {
 
   /** WARNING: Do not rename/change this, it's used in dashboard */
   protected closeDialog = (): void => {
+    // The native <dialog> "close" event is dispatched from a queued task and
+    // can land after this block's ctx was torn down (deferred destroyCtx once
+    // the last block disconnects) — there is no router to notify then, and
+    // nothing left to close.
+    const router = this._getSharedContextInstance('*router', false);
+    if (!router) {
+      return;
+    }
     // Only close when *this* modal is the one currently in the foreground slot.
     // `hide()` fires the native `<dialog>` "close" event even when we hid this
     // modal programmatically to switch to another — without this guard that
     // stale close would tear down the modal we just navigated to.
-    if (this.router.modal !== (this.id as RegisteredActivityType)) {
+    if (router.modal !== (this.id as RegisteredActivityType)) {
       return;
     }
     // Close the foreground modal slot; the router owns the close transition
     // (and the `modal-close` event).
-    this.router.closeModal();
+    router.closeModal();
   };
 
   private _handleDialogClose = (): void => {

--- a/tests/blocks/modal.e2e.test.tsx
+++ b/tests/blocks/modal.e2e.test.tsx
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
+import { PubSub } from '@/lit/PubSubCompat';
 import { getCtxName } from '../utils/getCtxName';
 import { cleanup } from '../utils/test-renderer';
 import '../../types/jsx';
@@ -27,9 +28,9 @@ describe('uc-modal teardown', () => {
     expect(dialog).toBeTruthy();
 
     // Unmount everything; the ctx destroys via a deferred task once the last
-    // block disconnects.
+    // block disconnects. Wait for the destruction fact, not a fixed delay.
     cleanup();
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
 
     // The native <dialog> "close" event is dispatched from a queued task and
     // can land exactly here in real teardowns. It must be a no-op, not an

--- a/tests/blocks/modal.e2e.test.tsx
+++ b/tests/blocks/modal.e2e.test.tsx
@@ -1,0 +1,50 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { getCtxName } from '../utils/getCtxName';
+import { cleanup } from '../utils/test-renderer';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+describe('uc-modal teardown', () => {
+  it('ignores a native dialog "close" event arriving after the ctx is torn down', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      </>,
+    );
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+    // Capture the live dialog before unmounting; the Modal's "close" listener
+    // stays attached to it after removal.
+    const dialog = document.querySelector('uc-modal dialog');
+    expect(dialog).toBeTruthy();
+
+    // Unmount everything; the ctx destroys via a deferred task once the last
+    // block disconnects.
+    cleanup();
+    await new Promise((resolve) => setTimeout(resolve, 20));
+
+    // The native <dialog> "close" event is dispatched from a queued task and
+    // can land exactly here in real teardowns. It must be a no-op, not an
+    // uncaught "context manager for key \"*router\" is not available" error.
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      dialog?.dispatchEvent(new Event('close'));
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the pre-existing intermittent non-zero `npm run test:e2e` exit noted in #1004: the native `<dialog>` "close" event is dispatched from a queued task and can land after the block's ctx was destroyed (deferred `destroyCtx` once the last block disconnects). `Modal.closeDialog` then hit the **required** `*router` shared-instance getter and threw an uncaught `context manager for key "*router" is not available` (originating from `router-navigation` / `api` e2e teardowns) — Vitest traps it as an Unhandled Error and fails the run despite 214/214 tests passing.

Reproduced on `feat/v2-migration` base (`4e460668`, 1/6 single-file runs) before the fix; **6/6 clean** after.

**Fix:** resolve the router as optional in `closeDialog` and bail out when the ctx is gone — same containment pattern as M8's teardown telemetry race (74c111a9). `closeDialog`'s name/signature untouched (dashboard-coupled).

**Test:** deterministic regression in `tests/blocks/modal.e2e.test.tsx` — open the modal, unmount everything, let the deferred ctx destroy run, dispatch `close` on the captured dialog, assert no window error. Fails on the old code, passes now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved modal closing during page teardown to avoid errors when the router is unavailable.
  * Ensured modal close actions only close the currently active modal.

* **Tests**
  * Added an end-to-end browser test covering post-teardown modal closing, asserting it performs safely without triggering errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->