### PR TITLE
refactor(m9b): retire the ctx-owner hack — UploadEventsController as a per-ctx shared instance

### DIFF
--- a/src/abstract/applyInitialCrop.test.ts
+++ b/src/abstract/applyInitialCrop.test.ts
@@ -21,18 +21,27 @@ describe('applyInitialCrop', () => {
     vi.useRealTimers();
   });
 
-  it('is a no-op when cropPreset is empty/unparseable and there is nothing to crop (no entry mutated)', () => {
-    // Empty collection: findItems() finds nothing to iterate, regardless of
-    // what parseCropPreset makes of an empty/garbage preset string.
+  it('is a no-op when cropPreset is empty or fully invalid — eligible entries stay uncropped', () => {
+    const cdnUrl = 'https://cdn.example.com/uuid/';
+    const id = collection.add({
+      isImage: true,
+      fileInfo: fileInfo(800, 600),
+      cdnUrl,
+      cdnUrlModifiers: null,
+    });
+
     expect(() => applyInitialCrop(collection, '')).not.toThrow();
-    expect(collection.size).toBe(0);
 
     // 'not-a-preset' is unparseable and makes parseCropPreset itself warn —
     // suppress that unrelated noise so the assertion stays about applyInitialCrop.
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     expect(() => applyInitialCrop(collection, 'not-a-preset')).not.toThrow();
-    expect(collection.size).toBe(0);
     warnSpy.mockRestore();
+
+    // A rejected preset must not fall through to the 1:1 default crop.
+    const entry = collection.read(id);
+    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(entry?.getValue('cdnUrl')).toBe(cdnUrl);
   });
 
   it('applies a centered crop modifier + rewritten cdnUrl to an image entry without an existing crop modifier', () => {

--- a/src/abstract/applyInitialCrop.test.ts
+++ b/src/abstract/applyInitialCrop.test.ts
@@ -1,0 +1,150 @@
+import type { UploadcareFile } from '@uploadcare/upload-client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createCdnUrl } from '../utils/cdn-utils';
+import { applyInitialCrop } from './applyInitialCrop';
+import { UploadCollectionController } from './controllers/UploadCollectionController';
+
+const imageInfo = (width: number, height: number) => ({ width, height }) as UploadcareFile['imageInfo'];
+
+const fileInfo = (width: number, height: number) => ({ imageInfo: imageInfo(width, height) }) as UploadcareFile;
+
+describe('applyInitialCrop', () => {
+  let collection: UploadCollectionController;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    collection = new UploadCollectionController();
+  });
+
+  afterEach(() => {
+    collection.destroy();
+    vi.useRealTimers();
+  });
+
+  it('is a no-op when cropPreset is empty/unparseable and there is nothing to crop (no entry mutated)', () => {
+    // Empty collection: findItems() finds nothing to iterate, regardless of
+    // what parseCropPreset makes of an empty/garbage preset string.
+    expect(() => applyInitialCrop(collection, '')).not.toThrow();
+    expect(collection.size).toBe(0);
+
+    // 'not-a-preset' is unparseable and makes parseCropPreset itself warn —
+    // suppress that unrelated noise so the assertion stays about applyInitialCrop.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    expect(() => applyInitialCrop(collection, 'not-a-preset')).not.toThrow();
+    expect(collection.size).toBe(0);
+    warnSpy.mockRestore();
+  });
+
+  it('applies a centered crop modifier + rewritten cdnUrl to an image entry without an existing crop modifier', () => {
+    const cdnUrl = 'https://cdn.example.com/uuid/';
+    const id = collection.add({
+      isImage: true,
+      fileInfo: fileInfo(800, 600),
+      cdnUrl,
+      cdnUrlModifiers: null,
+    });
+
+    applyInitialCrop(collection, '4:3');
+
+    const entry = collection.read(id);
+    const cdnUrlModifiers = entry?.getValue('cdnUrlModifiers');
+    expect(cdnUrlModifiers).toContain('crop/');
+    expect(cdnUrlModifiers).toContain('-/preview/');
+    // 800x600 at a 4:3 aspect ratio is already 4:3 — full-frame centered crop.
+    expect(cdnUrlModifiers).toContain('crop/800x600/0,0');
+    expect(entry?.getValue('cdnUrl')).toBe(createCdnUrl(cdnUrl, cdnUrlModifiers ?? undefined));
+  });
+
+  it('skips entries that already have /crop/ in cdnUrlModifiers (values unchanged)', () => {
+    const cdnUrl = 'https://cdn.example.com/uuid/';
+    const existingModifiers = '-/crop/100x100/0,0/';
+    const id = collection.add({
+      isImage: true,
+      fileInfo: fileInfo(800, 600),
+      cdnUrl,
+      cdnUrlModifiers: existingModifiers,
+    });
+
+    applyInitialCrop(collection, '4:3');
+
+    const entry = collection.read(id);
+    expect(entry?.getValue('cdnUrlModifiers')).toBe(existingModifiers);
+    expect(entry?.getValue('cdnUrl')).toBe(cdnUrl);
+  });
+
+  it('skips non-image entries and entries without fileInfo', () => {
+    const nonImageId = collection.add({
+      isImage: false,
+      fileInfo: fileInfo(800, 600),
+      cdnUrl: 'https://cdn.example.com/a/',
+      cdnUrlModifiers: null,
+    });
+    const noFileInfoId = collection.add({
+      isImage: true,
+      fileInfo: null,
+      cdnUrl: 'https://cdn.example.com/b/',
+      cdnUrlModifiers: null,
+    });
+
+    applyInitialCrop(collection, '4:3');
+
+    expect(collection.read(nonImageId)?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(collection.read(noFileInfoId)?.getValue('cdnUrlModifiers')).toBeNull();
+  });
+
+  it('warns + skips when fileInfo.imageInfo is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const id = collection.add({
+      isImage: true,
+      fileInfo: {} as UploadcareFile,
+      cdnUrl: 'https://cdn.example.com/uuid/',
+      cdnUrlModifiers: null,
+    });
+
+    applyInitialCrop(collection, '4:3');
+
+    const entry = collection.read(id);
+    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith('Failed to get image info for entry', entry?.uid);
+
+    warnSpy.mockRestore();
+  });
+
+  it('warns + skips when cdnUrl is missing', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const id = collection.add({
+      isImage: true,
+      fileInfo: fileInfo(800, 600),
+      cdnUrl: null,
+      cdnUrlModifiers: null,
+    });
+
+    applyInitialCrop(collection, '4:3');
+
+    const entry = collection.read(id);
+    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(warnSpy).toHaveBeenCalledWith('Failed to get cdnUrl for entry', entry?.uid);
+
+    warnSpy.mockRestore();
+  });
+
+  it('falls back to a 1:1 aspect ratio when the preset lacks numeric width/height (square crop for a square source)', () => {
+    const cdnUrl = 'https://cdn.example.com/uuid/';
+    const id = collection.add({
+      isImage: true,
+      fileInfo: fileInfo(500, 500),
+      cdnUrl,
+      cdnUrlModifiers: null,
+    });
+
+    // 'free' is parsed by parseCropPreset into a preset with hasFreeform=true
+    // and width/height forced to 0 (not numeric-positive) — triggering the
+    // 1:1 fallback in applyInitialCrop.
+    applyInitialCrop(collection, 'free');
+
+    const entry = collection.read(id);
+    const cdnUrlModifiers = entry?.getValue('cdnUrlModifiers');
+    // A 500x500 source at aspect ratio 1 crops to the full square: 500x500 at 0,0.
+    expect(cdnUrlModifiers).toContain('crop/500x500/0,0');
+  });
+});

--- a/src/abstract/applyInitialCrop.ts
+++ b/src/abstract/applyInitialCrop.ts
@@ -13,7 +13,10 @@ import type { UploadCollectionController } from './controllers/UploadCollectionC
  */
 export function applyInitialCrop(collection: UploadCollectionController, cropPreset: ConfigType['cropPreset']): void {
   const parsed = parseCropPreset(cropPreset);
-  if (!parsed) return;
+  // `parseCropPreset` never returns a falsy value — an empty or fully-invalid
+  // preset yields an empty list. Bail out then: a rejected preset must not
+  // fall through to the 1:1 default and crop images nobody asked to crop.
+  if (parsed.length === 0) return;
 
   const [aspectRatioPreset] = parsed;
   const entries = collection

--- a/src/abstract/applyInitialCrop.ts
+++ b/src/abstract/applyInitialCrop.ts
@@ -1,0 +1,56 @@
+import { calculateMaxCenteredCropFrame } from '../blocks/CloudImageEditor/src/crop-utils';
+import { parseCropPreset } from '../blocks/CloudImageEditor/src/lib/parseCropPreset';
+import type { ConfigType } from '../types';
+import { createCdnUrl, createCdnUrlModifiers } from '../utils/cdn-utils';
+import type { UploadCollectionController } from './controllers/UploadCollectionController';
+
+/**
+ * Apply the configured `cropPreset` as an initial centered crop to every
+ * uploaded image entry that doesn't already carry a crop modifier. Pure
+ * collection logic — extracted from `LitUploaderBlock._setInitialCrop` so the
+ * upload-events wiring (which triggers it on upload success) can live outside
+ * the element layer.
+ */
+export function applyInitialCrop(collection: UploadCollectionController, cropPreset: ConfigType['cropPreset']): void {
+  const parsed = parseCropPreset(cropPreset);
+  if (!parsed) return;
+
+  const [aspectRatioPreset] = parsed;
+  const entries = collection
+    .findItems(
+      (entry) =>
+        !!entry.getValue('fileInfo') &&
+        entry.getValue('isImage') &&
+        !entry.getValue('cdnUrlModifiers')?.includes('/crop/'),
+    )
+    .map((id) => collection.read(id))
+    .filter(Boolean);
+
+  for (const entry of entries) {
+    const fileInfo = entry.getValue('fileInfo');
+    if (!fileInfo || !fileInfo.imageInfo) {
+      console.warn('Failed to get image info for entry', entry.uid);
+      continue;
+    }
+    const { width, height } = fileInfo.imageInfo;
+    const expectedAspectRatio =
+      typeof aspectRatioPreset?.width === 'number' &&
+      typeof aspectRatioPreset?.height === 'number' &&
+      aspectRatioPreset.width > 0 &&
+      aspectRatioPreset.height > 0
+        ? aspectRatioPreset.width / aspectRatioPreset.height
+        : 1;
+
+    const crop = calculateMaxCenteredCropFrame(width, height, expectedAspectRatio);
+    const cdnUrlModifiers = createCdnUrlModifiers(`crop/${crop.width}x${crop.height}/${crop.x},${crop.y}`, 'preview');
+    const cdnUrl = entry.getValue('cdnUrl');
+    if (!cdnUrl) {
+      console.warn('Failed to get cdnUrl for entry', entry.uid);
+      continue;
+    }
+    entry.setMultipleValues({
+      cdnUrlModifiers,
+      cdnUrl: createCdnUrl(cdnUrl, cdnUrlModifiers),
+    });
+  }
+}

--- a/src/blocks/CameraSource/CameraSource.ts
+++ b/src/blocks/CameraSource/CameraSource.ts
@@ -51,7 +51,6 @@ export type CameraMode = 'photo' | 'video';
 export type CameraStatus = 'shot' | 'retake' | 'accept' | 'play' | 'stop' | 'pause' | 'resume';
 
 export class CameraSource extends LitUploaderBlock {
-  public override couldBeCtxOwner = true;
   private _unsubPermissions: (() => void) | null = null;
 
   private _capturing = false;

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -53,7 +53,6 @@ const AUTO_MODE_INLINE_THRESHOLD = 3;
 
 export class DynamicBtn extends LitUploaderBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-dynamic-btn'];
-  public override couldBeCtxOwner = true;
 
   private _unregisterOnFileAddHook?: () => void;
 

--- a/src/blocks/ExternalSource/ExternalSource.ts
+++ b/src/blocks/ExternalSource/ExternalSource.ts
@@ -23,7 +23,6 @@ const SOCIAL_SOURCE_MAPPING: Record<string, string> = {
 export type ActivityParams = { externalSourceType: string };
 
 export class ExternalSource extends LitUploaderBlock {
-  public override couldBeCtxOwner = true;
   private _messageBridge?: MessageBridge;
 
   private _iframeRef = createRef<HTMLIFrameElement>();

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -28,8 +28,6 @@ const FileItemState = Object.freeze({
 type FileItemStateValue = (typeof FileItemState)[keyof typeof FileItemState];
 
 export class FileItem extends FileItemConfig {
-  protected override couldBeCtxOwner = true;
-
   @state()
   private _pauseRender = true;
 

--- a/src/blocks/SimpleBtn/SimpleBtn.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.ts
@@ -8,7 +8,6 @@ import '../Icon/Icon';
 
 export class SimpleBtn extends LitUploaderBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-simple-btn'];
-  public override couldBeCtxOwner = true;
 
   @property({ attribute: 'dropzone', type: Boolean })
   public dropzone = true;

--- a/src/blocks/SourceBtn/SourceBtn.ts
+++ b/src/blocks/SourceBtn/SourceBtn.ts
@@ -14,8 +14,6 @@ export type SourceButtonConfig = {
 };
 
 export class SourceBtn extends LitUploaderBlock {
-  public override couldBeCtxOwner = true;
-
   @property({ attribute: false })
   public source?: SourceButtonConfig;
 

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -24,7 +24,6 @@ export type Summary = {
 };
 
 export class UploadList extends LitUploaderBlock {
-  public override couldBeCtxOwner = true;
   public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
 
   @state()

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,5 +1,6 @@
 // @ts-check
 
+import { applyInitialCrop } from '../abstract/applyInitialCrop';
 import { uploaderBlockCtx } from '../abstract/CTX';
 import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
@@ -7,11 +8,8 @@ import { UploadController } from '../abstract/controllers/UploadController';
 import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
 import { ValidationController } from '../abstract/controllers/ValidationController';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
-import { calculateMaxCenteredCropFrame } from '../blocks/CloudImageEditor/src/crop-utils';
-import { parseCropPreset } from '../blocks/CloudImageEditor/src/lib/parseCropPreset';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
-import { createCdnUrl, createCdnUrlModifiers } from '../utils/cdn-utils';
 import { ExternalUploadSource, UploadSource } from '../utils/UploadSource';
 import { getOutputData } from './getOutputData';
 import { LitActivityBlock } from './LitActivityBlock';
@@ -20,22 +18,8 @@ import type { Uid } from './Uid';
 export class LitUploaderBlock extends LitActivityBlock {
   public static extSrcList: Readonly<typeof ExternalUploadSource>;
   public static sourceTypes: Readonly<typeof UploadSource>;
-  protected couldBeCtxOwner = false;
-
-  private _isCtxOwner = false;
-
-  private _uploadEvents?: UploadEventsController;
 
   public override init$ = uploaderBlockCtx(this);
-
-  private get _hasCtxOwner(): boolean {
-    return this.hasBlockInCtx((block) => {
-      if (block instanceof LitUploaderBlock) {
-        return block._isCtxOwner && block.isConnected && block !== this;
-      }
-      return false;
-    });
-  }
 
   public override initCallback(): void {
     super.initCallback();
@@ -100,9 +84,52 @@ export class LitUploaderBlock extends LitActivityBlock {
       });
     });
 
-    if (!this._hasCtxOwner && this.couldBeCtxOwner) {
-      this._initCtxOwner();
-    }
+    // The collection→events derivation lives in the DOM-free UploadEventsController,
+    // a per-ctx shared instance — first-write-wins, so exactly one is created no
+    // matter how many blocks register it or in what order they connect/disconnect.
+    this._addSharedContextInstance('*uploadEvents', (sharedInstancesBag) => {
+      const uploader = this.sharedCtx.uploaderController();
+      const ctx = sharedInstancesBag.ctx;
+      const uploadEvents = new UploadEventsController({
+        collection: uploader.collection,
+        config: uploader.config,
+        validation: sharedInstancesBag.validationManager,
+        // Emit parity with LitBlock.emit: EventEmitter dispatch + telemetry
+        // mirror, guarded for teardown (emissions can race ctx destruction).
+        emit: (type, payload, options) => {
+          const eventEmitter = ctx.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
+          if (!eventEmitter) return;
+          eventEmitter.emit(type, payload, options);
+          const resolvedPayload = typeof payload === 'function' ? payload() : payload;
+          try {
+            sharedInstancesBag.telemetryManager.sendEvent({
+              eventType: type,
+              payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
+            });
+          } catch (err) {
+            this.debugPrint('telemetry unavailable for an upload event report', err);
+          }
+        },
+        getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>
+          sharedInstancesBag.api.getOutputItem<TStatus>(uid),
+        getOutputCollectionState: () => sharedInstancesBag.api.getOutputCollectionState(),
+        getOutputData: () => getOutputData(sharedInstancesBag),
+        buildUploadOptions: () => sharedInstancesBag.uploadController.buildUploadOptions(),
+        runOnAddHooks: (entry) =>
+          void sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+        applyInitialCrop: () => applyInitialCrop(uploader.collection, uploader.config.get('cropPreset')),
+        uploadTrigger: () => ctx.read('*uploadTrigger'),
+        setUploadList: (list) => ctx.pub('*uploadList', list),
+        getCollectionState: () => ctx.read('*collectionState'),
+        setCollectionState: (state) => ctx.pub('*collectionState', state),
+        getCommonProgress: () => ctx.read('*commonProgress'),
+        setCommonProgress: (progress) => ctx.pub('*commonProgress', progress),
+        setGroupInfo: (group) => ctx.pub('*groupInfo', group),
+        getCollectionErrors: () => ctx.read('*collectionErrors'),
+      });
+      uploadEvents.observe();
+      return uploadEvents;
+    });
   }
 
   public getAPI(): UploaderPublicApi {
@@ -129,105 +156,8 @@ export class LitUploaderBlock extends LitActivityBlock {
     return this._getSharedContextInstance('*uploadController');
   }
 
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-
-    if (this._isCtxOwner) {
-      this._uploadEvents?.unobserve();
-    }
-  }
-
-  public override connectedCallback(): void {
-    super.connectedCallback();
-
-    if (this._isCtxOwner) {
-      this._uploadEvents?.observe();
-    }
-  }
-
-  private _initCtxOwner(): void {
-    this._isCtxOwner = true;
-
-    // The collection→events derivation lives in the DOM-free UploadEventsController;
-    // this block just wires its collaborators (api, validation, plugin hooks) and
-    // the v1 `*`-shared-state sinks.
-    this._uploadEvents = new UploadEventsController({
-      collection: this.uploadCollection,
-      config: this.sharedCtx.uploaderController().config,
-      validation: this.validationManager,
-      emit: (type, payload, options) => this.emit(type, payload, options),
-      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => this.api.getOutputItem<TStatus>(uid),
-      getOutputCollectionState: () => this.api.getOutputCollectionState(),
-      getOutputData: () => this.getOutputData(),
-      buildUploadOptions: () => this.uploadController.buildUploadOptions(),
-      runOnAddHooks: (entry) =>
-        void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
-      applyInitialCrop: () => this._setInitialCrop(),
-      uploadTrigger: () => this.$['*uploadTrigger'],
-      setUploadList: (list) => {
-        this.$['*uploadList'] = list;
-      },
-      getCollectionState: () => this.$['*collectionState'],
-      setCollectionState: (state) => {
-        this.$['*collectionState'] = state;
-      },
-      getCommonProgress: () => this.$['*commonProgress'],
-      setCommonProgress: (progress) => {
-        this.$['*commonProgress'] = progress;
-      },
-      setGroupInfo: (group) => {
-        this.$['*groupInfo'] = group;
-      },
-      getCollectionErrors: () => this.$['*collectionErrors'],
-    });
-    this._uploadEvents.observe();
-
-    // Upload-queue concurrency is owned by the UploadController, which syncs it
-    // from `maxConcurrentRequests` itself.
-  }
-
-  private _setInitialCrop(): void {
-    const cropPreset = parseCropPreset(this.cfg.cropPreset);
-    if (!cropPreset) return;
-
-    const [aspectRatioPreset] = cropPreset;
-    const entries = this.uploadCollection
-      .findItems(
-        (entry) =>
-          !!entry.getValue('fileInfo') &&
-          entry.getValue('isImage') &&
-          !entry.getValue('cdnUrlModifiers')?.includes('/crop/'),
-      )
-      .map((id) => this.uploadCollection.read(id))
-      .filter(Boolean);
-
-    for (const entry of entries) {
-      const fileInfo = entry.getValue('fileInfo');
-      if (!fileInfo || !fileInfo.imageInfo) {
-        console.warn('Failed to get image info for entry', entry.uid);
-        continue;
-      }
-      const { width, height } = fileInfo.imageInfo;
-      const expectedAspectRatio =
-        typeof aspectRatioPreset?.width === 'number' &&
-        typeof aspectRatioPreset?.height === 'number' &&
-        aspectRatioPreset.width > 0 &&
-        aspectRatioPreset.height > 0
-          ? aspectRatioPreset.width / aspectRatioPreset.height
-          : 1;
-
-      const crop = calculateMaxCenteredCropFrame(width, height, expectedAspectRatio);
-      const cdnUrlModifiers = createCdnUrlModifiers(`crop/${crop.width}x${crop.height}/${crop.x},${crop.y}`, 'preview');
-      const cdnUrl = entry.getValue('cdnUrl');
-      if (!cdnUrl) {
-        console.warn('Failed to get cdnUrl for entry', entry.uid);
-        continue;
-      }
-      entry.setMultipleValues({
-        cdnUrlModifiers,
-        cdnUrl: createCdnUrl(cdnUrl, cdnUrlModifiers),
-      });
-    }
+  public get uploadEvents(): UploadEventsController {
+    return this._getSharedContextInstance('*uploadEvents');
   }
 
   public getOutputData(): OutputFileEntry[] {

--- a/src/lit/SharedState.ts
+++ b/src/lit/SharedState.ts
@@ -4,6 +4,7 @@ import type { RouterController } from '../abstract/controllers/RouterController'
 import type { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
 import type { UploadController } from '../abstract/controllers/UploadController';
+import type { UploadEventsController } from '../abstract/controllers/UploadEventsController';
 import type { ValidationController } from '../abstract/controllers/ValidationController';
 import type { LocaleDefinition } from '../abstract/localeRegistry';
 import type { A11y } from '../abstract/managers/a11y';
@@ -104,6 +105,7 @@ type DynamicUploaderBlockState = {
   '*validationManager': ValidationController;
   '*secureUploadsManager': SecureUploadsController;
   '*uploadController': UploadController;
+  '*uploadEvents': UploadEventsController;
 };
 
 type LocaleState = {

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -3,6 +3,7 @@ import type { RouterController } from '../abstract/controllers/RouterController'
 import type { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
 import type { UploadController } from '../abstract/controllers/UploadController';
+import type { UploadEventsController } from '../abstract/controllers/UploadEventsController';
 import type { ValidationController } from '../abstract/controllers/ValidationController';
 import type { A11y } from '../abstract/managers/a11y';
 import type { LocaleManager } from '../abstract/managers/LocaleManager';
@@ -84,6 +85,7 @@ const instanceKeyMap = {
   uploadCollection: '*uploadCollection',
   secureUploadsManager: '*secureUploadsManager',
   uploadController: '*uploadController',
+  uploadEvents: '*uploadEvents',
   api: '*publicApi',
   validationManager: '*validationManager',
 } satisfies Record<string, keyof SharedState>;
@@ -151,6 +153,9 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
     },
     get uploadController(): UploadController {
       return getSharedInstance(getCtx(), '*uploadController');
+    },
+    get uploadEvents(): UploadEventsController {
+      return getSharedInstance(getCtx(), '*uploadEvents');
     },
     get api(): UploaderPublicApi {
       return getSharedInstance(getCtx(), '*publicApi');

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -5,6 +5,7 @@ import type { UploaderController } from '@/abstract/controllers/UploaderControll
 import type { Config } from '@/index.ts';
 import { ChildBlock } from '@/lit/ChildBlock';
 import { LitBlock } from '@/lit/LitBlock';
+import { delay } from '@/utils/delay';
 import { getCtxName } from '../utils/getCtxName';
 import '../../types/jsx';
 
@@ -87,7 +88,7 @@ describe('ChildBlock', () => {
 
   it('does not render before a controller is available', async () => {
     const child = append('test-child-block', { 'ctx-name': getCtxName() });
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    await delay(50);
     expect(child.querySelector('.pk')).toBeNull();
     expect(child.readyCount).toBe(0);
   });
@@ -162,7 +163,7 @@ describe('ChildBlock', () => {
     const ctxName = getCtxName();
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
     const child = append('test-child-block');
-    await new Promise((resolve) => setTimeout(resolve, 20));
+    await delay(20);
     expect(child.readyCount).toBe(0);
 
     child.setAttribute('ctx-name', ctxName);

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -5,7 +5,6 @@ import type { UploaderController } from '@/abstract/controllers/UploaderControll
 import type { Config } from '@/index.ts';
 import { ChildBlock } from '@/lit/ChildBlock';
 import { LitBlock } from '@/lit/LitBlock';
-import { delay } from '@/utils/delay';
 import { getCtxName } from '../utils/getCtxName';
 import '../../types/jsx';
 
@@ -88,7 +87,8 @@ describe('ChildBlock', () => {
 
   it('does not render before a controller is available', async () => {
     const child = append('test-child-block', { 'ctx-name': getCtxName() });
-    await delay(50);
+    // Wait for the (gated) initial update cycle to settle instead of a timed grace period.
+    await child.updateComplete;
     expect(child.querySelector('.pk')).toBeNull();
     expect(child.readyCount).toBe(0);
   });
@@ -163,7 +163,7 @@ describe('ChildBlock', () => {
     const ctxName = getCtxName();
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
     const child = append('test-child-block');
-    await delay(20);
+    await child.updateComplete;
     expect(child.readyCount).toBe(0);
 
     child.setAttribute('ctx-name', ctxName);

--- a/tests/blocks/icon.e2e.test.tsx
+++ b/tests/blocks/icon.e2e.test.tsx
@@ -1,7 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 import type { Config, Icon, UploaderPlugin } from '@/index.ts';
-import { delay } from '@/utils/delay';
 import { getCtxName } from '../utils/getCtxName';
 import '../../types/jsx';
 
@@ -83,7 +82,6 @@ describe('uc-icon', () => {
         });
       },
     };
-    await delay(0);
     config.plugins = [plugin];
 
     await expect.poll(() => testedIcon().querySelector('svg[viewBox="0 0 24 24"] rect')).toBeTruthy();

--- a/tests/blocks/upload-events-wiring.e2e.test.tsx
+++ b/tests/blocks/upload-events-wiring.e2e.test.tsx
@@ -1,0 +1,147 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type { EventPayload, UploadCtxProvider } from '@/index.js';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+/**
+ * M9b Task 2 — additive e2e pinning the documented upload-event surface
+ * (events on `<uc-upload-ctx-provider>` + `api.getOutputCollectionState()`)
+ * ahead of moving `UploadEventsController` to a per-ctx shared instance. This
+ * suite must pass unchanged before and after that rewiring — only documented
+ * surface is asserted, never `*`-key internals.
+ */
+describe('upload events wiring', () => {
+  it('fires file-upload-success and common-upload-success on uploadAll(), with a success-shaped collection state', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const uploadSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['file-upload-success']>) => void>();
+    const commonSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['common-upload-success']>) => void>();
+    uploadCtxProvider.addEventListener('file-upload-success', uploadSuccessHandler);
+    uploadCtxProvider.addEventListener('common-upload-success', commonSuccessHandler);
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    const successPayload = await vi.waitFor(
+      () => {
+        expect(uploadSuccessHandler).toHaveBeenCalled();
+        return uploadSuccessHandler.mock.calls[0][0].detail;
+      },
+      { timeout: 20_000 },
+    );
+    expect(successPayload).toMatchObject(expect.objectContaining({ status: 'success' }));
+
+    const commonPayload = await vi.waitFor(
+      () => {
+        expect(commonSuccessHandler).toHaveBeenCalled();
+        return commonSuccessHandler.mock.calls[0][0].detail;
+      },
+      { timeout: 20_000 },
+    );
+    expect(commonPayload).toMatchObject(expect.objectContaining({ status: 'success', successCount: 1 }));
+  }, 30_000);
+
+  it('fires change and reaches successCount 1 in getOutputCollectionState()', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const changeHandler = vi.fn<(e: CustomEvent<EventPayload['change']>) => void>();
+    uploadCtxProvider.addEventListener('change', changeHandler);
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    await expect.poll(() => changeHandler.mock.calls.length > 0, { timeout: 20_000 }).toBe(true);
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+  }, 30_000);
+
+  it('shares upload state across two ctx-providers on the same ctx, without doubling counts', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const firstProvider = page.getByTestId('uc-upload-ctx-provider').nth(0).query()! as UploadCtxProvider;
+    const secondProvider = page.getByTestId('uc-upload-ctx-provider').nth(1).query()! as UploadCtxProvider;
+    const api = firstProvider.api;
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+    await expect.poll(() => secondProvider.api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+
+    // A single upload should never be counted twice by either sink.
+    expect(firstProvider.api.getOutputCollectionState().totalCount).toBe(1);
+    expect(secondProvider.api.getOutputCollectionState().totalCount).toBe(1);
+  }, 30_000);
+
+  it('fires file-removed on removeFileByInternalId() and removeAllFiles()', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const removedHandler = vi.fn<(e: CustomEvent<EventPayload['file-removed']>) => void>();
+    uploadCtxProvider.addEventListener('file-removed', removedHandler);
+
+    const entry = api.addFileFromUrl(TEST_IMAGE_URL);
+    api.removeFileByInternalId(entry.internalId);
+
+    const removedPayload = await vi.waitFor(() => {
+      expect(removedHandler).toHaveBeenCalledOnce();
+      return removedHandler.mock.calls[0][0].detail;
+    });
+    expect(removedPayload).toMatchObject(expect.objectContaining({ internalId: entry.internalId, status: 'removed' }));
+
+    // A second file added and cleared via removeAllFiles() also fires file-removed.
+    const secondEntry = api.addFileFromUrl(TEST_IMAGE_URL);
+    api.removeAllFiles();
+
+    await vi.waitFor(() => {
+      expect(removedHandler).toHaveBeenCalledTimes(2);
+    });
+    const secondRemovedPayload = removedHandler.mock.calls[1][0].detail;
+    expect(secondRemovedPayload).toMatchObject(
+      expect.objectContaining({ internalId: secondEntry.internalId, status: 'removed' }),
+    );
+  }, 30_000);
+});

--- a/tests/blocks/upload-events-wiring.e2e.test.tsx
+++ b/tests/blocks/upload-events-wiring.e2e.test.tsx
@@ -144,4 +144,44 @@ describe('upload events wiring', () => {
       expect.objectContaining({ internalId: secondEntry.internalId, status: 'removed' }),
     );
   }, 30_000);
+
+  it('keeps deriving upload events after an owner-candidate block is removed', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const commonSuccessHandler = vi.fn<(e: CustomEvent<EventPayload['common-upload-success']>) => void>();
+    uploadCtxProvider.addEventListener('common-upload-success', commonSuccessHandler);
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+    await expect.poll(() => commonSuccessHandler.mock.calls.length, { timeout: 20_000 }).toBeGreaterThanOrEqual(1);
+    const callsBeforeRemoval = commonSuccessHandler.mock.calls.length;
+
+    // Remove the internal `uc-simple-btn` — under v1 semantics this was the
+    // ctx-owner candidate rendered by the solution first, and its removal
+    // could pause event derivation. Under M9b, `*uploadEvents` is a per-ctx
+    // shared instance independent of any single block's lifecycle.
+    document.querySelector('uc-simple-btn')?.remove();
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    // Proves event derivation kept running after the owner-candidate's removal:
+    // a second `common-upload-success` fires and successCount reaches 2.
+    await expect
+      .poll(() => commonSuccessHandler.mock.calls.length, { timeout: 20_000 })
+      .toBeGreaterThan(callsBeforeRemoval);
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(2);
+  }, 30_000);
 });


### PR DESCRIPTION
Second slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7). The `couldBeCtxOwner` protocol predates async state attach — shared state used to be created synchronously by whichever eligible tag mounted first, and the flag decided which block owned the `UploadEventsController` wiring. With the shared-instance map (first-write-wins) and async resolution (`bag.when`/`whenAvailable`), that guarantee comes from the architecture, so the hack goes away.

## Coverage first (AGENTS.md #1)
- `applyInitialCrop` extracted verbatim from `LitUploaderBlock._setInitialCrop` into a DOM-free helper with a full unit suite (100% lines; the `!parsed` guard is dead code carried over verbatim — the empty-preset no-op contract lives in the caller's `config.get('cropPreset')` gate).
- New `upload-events-wiring.e2e.test.tsx` pinning documented events + API state (success events incl. payload shapes, change/successCount, no double-counting across two same-ctx providers, file-removed) — written against the old wiring, kept green unchanged through the refactor.

## The rewiring
`*uploadEvents` is now a per-ctx shared instance registered in `LitUploaderBlock.initCallback` (after `*validationManager`, so its one eager dep resolves): all 18 controller deps re-expressed via bag/ctx closures, `observe()` at creation, `destroy()`→`unobserve()` at ctx teardown. Emit parity with `LitBlock.emit` (missing-emitter guard, resolved-payload telemetry mirror) plus teardown-safe telemetry (same containment pattern as the M8 upload-error path). Deleted: `couldBeCtxOwner`, `_isCtxOwner`, `_hasCtxOwner`, `_initCtxOwner`, `_uploadEvents`, `_setInitialCrop`, the owner-gated connect/disconnect observe wiring, and the flag line in SimpleBtn, SourceBtn, DynamicBtn, UploadList, FileItem, ExternalSource, CameraSource — all seven now clear of block-owned lifecycle state, unblocking their ChildBlock ports (M9c+).

**Intentional behavior fix:** in v1, disconnecting the owner block while the ctx stayed alive paused all upload-event derivation until reconnect. Now derivation runs for the ctx lifetime — pinned by a dedicated e2e (remove the owner-candidate mid-ctx, upload again, events still fire).

`ctxOwner` on `SymbioteCompatMixin` (init$-rewrite flag, CIE-only) is a different mechanism and stays until the mixin dies in M11.

## Gate (on the rebased head)
tsc:app ✅ build (attw/publint/size-limit) ✅ specs 578 ✅ locales ✅ e2e 223/223, exit 0 — the #1005 teardown-race fix holds ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic centered initial cropping for supported images based on the configured aspect ratio.
  * Added/expanded upload-event wiring coverage to ensure multiple uploader instances share consistent upload state and event behavior.
* **Bug Fixes**
  * Existing crop settings are preserved.
  * Invalid or incomplete image/preset data is safely skipped; when preset dimensions aren’t usable, the crop falls back to a 1:1 (square) aspect.
* **Tests**
  * Added unit tests for initial-crop behavior.
  * Added e2e tests validating upload events (success, change, removal, and correct counting) and improved e2e timing by waiting for Lit updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->