### PR TITLE
feat(m9c): ChildBlock l10n helper + SimpleBtn/SourceBtn/Spinner ports

### DIFF
--- a/src/blocks/SimpleBtn/SimpleBtn.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.ts
@@ -1,12 +1,13 @@
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './simple-btn.css';
 
 import '../DropArea/DropArea';
 import '../Icon/Icon';
 
-export class SimpleBtn extends LitUploaderBlock {
+export class SimpleBtn extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-simple-btn'];
 
   @property({ attribute: 'dropzone', type: Boolean })
@@ -16,12 +17,14 @@ export class SimpleBtn extends LitUploaderBlock {
   private _buttonTextKey = 'upload-file';
 
   private readonly _handleClick = () => {
-    this.api.initFlow();
+    this.bag.api.initFlow();
   };
 
-  public override initCallback(): void {
-    super.initCallback();
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
+  }
 
+  protected override controllerReady(): void {
     this.subConfigValue('multiple', (val) => {
       this._buttonTextKey = val ? 'upload-files' : 'upload-file';
     });

--- a/src/blocks/SourceBtn/SourceBtn.ts
+++ b/src/blocks/SourceBtn/SourceBtn.ts
@@ -1,6 +1,7 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './source-btn.css';
 
 import '../Icon/Icon';
@@ -13,7 +14,7 @@ export type SourceButtonConfig = {
   onClick: () => void | Promise<void>;
 };
 
-export class SourceBtn extends LitUploaderBlock {
+export class SourceBtn extends ChildBlock {
   @property({ attribute: false })
   public source?: SourceButtonConfig;
 
@@ -49,10 +50,14 @@ export class SourceBtn extends LitUploaderBlock {
     this._iconName = icon ?? id ?? 'default';
   }
 
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
+  }
+
   public activate(): void {
     if (!this.source) return;
 
-    this.telemetryManager.sendEvent({
+    this.bag.telemetryManager.sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         sourceId: this.source.id,

--- a/src/blocks/Spinner/Spinner.ts
+++ b/src/blocks/Spinner/Spinner.ts
@@ -1,8 +1,8 @@
 import { html } from 'lit';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './spinner.css';
 
-export class Spinner extends LitBlock {
+export class Spinner extends ChildBlock {
   public override render() {
     return html` <div class="uc-spinner"></div> `;
   }

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -5,6 +5,7 @@ import type { UploaderController } from '../abstract/controllers/UploaderControl
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import type { ConfigType } from '../types';
 import { LightDomMixin } from './LightDomMixin';
+import { createL10n } from './l10n';
 import { PubSub } from './PubSubCompat';
 import { RegisterableElementMixin } from './RegisterableElementMixin';
 import type { SharedState } from './SharedState';
@@ -75,19 +76,31 @@ export abstract class ChildBlock extends ChildBlockBase {
     return this._controller;
   }
 
-  /**
-   * Shared v1 manager/controller instances for this ctx. Getters throw until
-   * the instance registers — inside `controllerReady` prefer `bag.when(name,
-   * cb)` (async-safe) over direct getters.
-   */
-  protected bag: SharedInstancesBag = createSharedInstancesBag(() => {
+  private _requireCtx(): PubSub<SharedState> {
     const ctxName = this.effectiveCtxName;
     const ctx = ctxName ? PubSub.getCtx<SharedState>(ctxName) : null;
     if (!ctx) {
       throw new Error(`${this.tagName.toLowerCase()}: shared context is not initialized yet.`);
     }
     return ctx;
-  });
+  }
+
+  /**
+   * Shared v1 manager/controller instances for this ctx. Getters throw until
+   * the instance registers — inside `controllerReady` prefer `bag.when(name,
+   * cb)` (async-safe) over direct getters.
+   */
+  protected bag: SharedInstancesBag = createSharedInstancesBag(() => this._requireCtx());
+
+  /**
+   * Same contract as v1 `LitBlock.l10n` (`createL10n`): dictionary lookup with
+   * key fallback, template variables, pluralization. Reads route through the
+   * ctx's `*l10n/*` facade to `LocaleController`. Call at render time (the
+   * render gate guarantees the ctx exists); blocks that render l10n text
+   * should add `(l) => ctrl.locale.subscribe(l)` to `subscriptionsFor` so the
+   * text re-renders when the dictionary loads or the locale switches.
+   */
+  public l10n = createL10n(() => this._requireCtx());
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -16,7 +16,10 @@ class TestChildBlock extends ChildBlock {
   public cleanupRanAfterThrow = false;
 
   protected override subscriptionsFor(ctrl: UploaderController) {
-    return [(listener: () => void) => ctrl.config.subscribe(listener)];
+    return [
+      (listener: () => void) => ctrl.config.subscribe(listener),
+      (listener: () => void) => ctrl.locale.subscribe(listener),
+    ];
   }
 
   protected override controllerReady(): void {
@@ -36,7 +39,8 @@ class TestChildBlock extends ChildBlock {
   }
 
   public override render() {
-    return html`<span class="pk">${this.uploaderOrNull?.config.get('pubkey') ?? ''}</span>`;
+    return html`<span class="pk">${this.uploaderOrNull?.config.get('pubkey') ?? ''}</span
+      ><span class="l10n">${this.l10n('upload-file')}</span>`;
   }
 }
 
@@ -213,5 +217,21 @@ describe('ChildBlock', () => {
     const child = document.createElement('test-child-block');
     // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected getter
     expect(() => (child as any).uploader).toThrowError(/test-child-block/);
+  });
+
+  it('l10n resolves dictionary keys once the locale is loaded', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.querySelector('.l10n')?.textContent).toBe('Upload file');
+  });
+
+  it('l10n falls back to the key for unknown keys', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into the helper directly
+    expect((child as any).l10n('definitely-not-a-key')).toBe('definitely-not-a-key');
   });
 });

--- a/tests/blocks/simple-btn.e2e.test.tsx
+++ b/tests/blocks/simple-btn.e2e.test.tsx
@@ -1,0 +1,54 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderSimpleBtn = (children?: React.ReactNode) => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-simple-btn ctx-name={ctxName}>{children}</uc-simple-btn>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  return { ctxName, config };
+};
+
+describe('uc-simple-btn', () => {
+  it('renders the localized multi-file button text and the drop-area visual text', async () => {
+    renderSimpleBtn();
+    await expect.element(page.getByText('Upload files', { exact: true })).toBeVisible();
+    await expect.element(page.getByText('Drop files here', { exact: true })).toBeVisible();
+  });
+
+  it('renders the single-file button text when config.multiple is false', async () => {
+    const { config } = renderSimpleBtn();
+    await expect.element(page.getByText('Upload files', { exact: true })).toBeVisible();
+
+    config.multiple = false;
+    await expect.poll(() => document.querySelector('uc-simple-btn button span')?.textContent).toBe('Upload file');
+  });
+
+  it('wraps content in a uc-drop-area, enabled by default', async () => {
+    renderSimpleBtn();
+    const dropArea = () => document.querySelector('uc-simple-btn uc-drop-area');
+    await expect.poll(() => dropArea()).toBeTruthy();
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderSimpleBtn();
+    await expect.element(page.getByTestId('uc-simple-btn')).toBeInTheDocument();
+  });
+
+  it('yields extra light-DOM children into the button', async () => {
+    renderSimpleBtn(<span class="extra">X</span>);
+    await expect.poll(() => document.querySelector('uc-simple-btn span.extra')?.textContent).toBe('X');
+  });
+});

--- a/tests/blocks/source-btn.e2e.test.tsx
+++ b/tests/blocks/source-btn.e2e.test.tsx
@@ -1,0 +1,89 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `SourceButtonConfig` is not re-exported from `@/index.ts` (only the `SourceBtn`
+// class is), so it's imported directly from its source module.
+import type { SourceButtonConfig } from '@/blocks/SourceBtn/SourceBtn.ts';
+import type { Config, SourceBtn } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderSourceBtn = (props?: { textOnly?: boolean; iconOnly?: boolean }) => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-source-btn ctx-name={ctxName}></uc-source-btn>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const btn = document.querySelector('uc-source-btn')! as SourceBtn;
+  // `textOnly`/`iconOnly` are set as JS properties (same pattern as `.source`
+  // and `uc-icon`'s `.name` in icon.e2e.test.tsx) to avoid depending on the
+  // generated JSX attribute typing for these boolean properties.
+  if (props?.textOnly) btn.textOnly = true;
+  if (props?.iconOnly) btn.iconOnly = true;
+  return { ctxName, config, btn };
+};
+
+const iconName = () => document.querySelector('uc-source-btn uc-icon')?.getAttribute('name');
+const txtContent = () => document.querySelector('uc-source-btn .uc-txt')?.textContent;
+
+describe('uc-source-btn', () => {
+  it('renders the l10n of the label as aria-label and text; unknown key falls back to the key itself', async () => {
+    const { btn } = renderSourceBtn();
+    const source: SourceButtonConfig = { id: 'my-src', label: 'my-label-key', onClick: () => {} };
+    btn.source = source;
+
+    await expect
+      .poll(() => document.querySelector('uc-source-btn button')?.getAttribute('aria-label'))
+      .toBe('my-label-key');
+    await expect.poll(txtContent).toBe('my-label-key');
+    await expect.poll(iconName).toBe('my-src');
+  });
+
+  it('uses source.icon when set, instead of falling back to id', async () => {
+    const { btn } = renderSourceBtn();
+    btn.source = { id: 'my-src', label: 'my-label-key', icon: 'custom-icon', onClick: () => {} };
+
+    await expect.poll(iconName).toBe('custom-icon');
+  });
+
+  it('textOnly suppresses the icon', async () => {
+    const { btn } = renderSourceBtn({ textOnly: true });
+    btn.source = { id: 'my-src', label: 'my-label-key', onClick: () => {} };
+    await expect.poll(txtContent).toBe('my-label-key');
+    expect(document.querySelector('uc-source-btn uc-icon')).toBeNull();
+  });
+
+  it('iconOnly suppresses the text', async () => {
+    const { btn } = renderSourceBtn({ iconOnly: true });
+    btn.source = { id: 'my-src', label: 'my-label-key', onClick: () => {} };
+    await expect.poll(iconName).toBe('my-src');
+    expect(document.querySelector('uc-source-btn .uc-txt')).toBeNull();
+  });
+
+  it('clicking the button invokes source.onClick', async () => {
+    const { btn } = renderSourceBtn();
+    const onClick = vi.fn();
+    btn.source = { id: 'my-src', label: 'my-label-key', onClick };
+    await expect.poll(iconName).toBe('my-src');
+
+    (document.querySelector('uc-source-btn button') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(onClick).toHaveBeenCalledOnce());
+  });
+
+  it('with no source set, falls back to the "default" icon without crashing', async () => {
+    renderSourceBtn();
+    await expect.poll(iconName).toBe('default');
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderSourceBtn();
+    await expect.element(page.getByTestId('uc-source-btn')).toBeInTheDocument();
+  });
+});

--- a/tests/blocks/spinner.e2e.test.tsx
+++ b/tests/blocks/spinner.e2e.test.tsx
@@ -1,0 +1,32 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderSpinner = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-spinner ctx-name={ctxName}></uc-spinner>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  return { ctxName };
+};
+
+describe('uc-spinner', () => {
+  it('renders the spinner div', async () => {
+    renderSpinner();
+    await expect.poll(() => document.querySelector('uc-spinner div.uc-spinner')).toBeTruthy();
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderSpinner();
+    await expect.element(page.getByTestId('uc-spinner')).toBeInTheDocument();
+  });
+});

--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -25,6 +25,7 @@ type EditorToolbar = import('../dist/index.ts').EditorToolbar;
 type Icon = import('../dist/index.ts').Icon;
 type Img = import('../dist/index.ts').Img;
 type SimpleBtn = import('../dist/index.ts').SimpleBtn;
+type Spinner = import('../dist/index.ts').Spinner;
 type StartFrom = import('../dist/index.ts').StartFrom;
 type DropArea = import('../dist/index.ts').DropArea;
 type SourceBtn = import('../dist/index.ts').SourceBtn;
@@ -70,6 +71,7 @@ declare namespace JSX {
     'uc-copyright': CustomElement<Copyright>;
     'uc-img': CustomElement<Img> & React.DetailedHTMLProps<React.ImgHTMLAttributes<HTMLImageElement>, HTMLImageElement>;
     'uc-simple-btn': CustomElement<SimpleBtn>;
+    'uc-spinner': CustomElement<Spinner>;
     'uc-start-from': CustomElement<StartFrom>;
     'uc-drop-area': CustomElement<DropArea>;
     'uc-source-btn': CustomElement<SourceBtn>;


### PR DESCRIPTION
Third slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7): the first l10n-consuming blocks move off `SymbioteCompatMixin`.

## Coverage first (AGENTS.md #1)
Additive parity e2e suites for SimpleBtn (5), SourceBtn (7), Spinner (2) pinned against v1 behavior — rendered DOM only, no compat-layer internals — then kept green **unchanged** through the ports. All waits are condition-based (`expect.poll`/`vi.waitFor`/`expect.element`); no timed delays.

## `ChildBlock.l10n`
Reuses the existing `createL10n` factory over the same lazy ctx resolver the `bag` uses (extracted as `_requireCtx()` — behavior-identical). Full v1 contract for free: dictionary lookup, key fallback, template variables, pluralization (incl. `locale-id` via the `*l10n/*` facade — verified end-to-end). Locale re-render stays opt-in per block via `subscriptionsFor` → `ctrl.locale.subscribe`. TDD'd (13/13 on the ChildBlock suite).

## Ports (pattern now spans five blocks)
- **SimpleBtn** — l10n + `subConfigValue('multiple')` + `bag.api.initFlow()`; renders the same v1 `uc-drop-area`/`uc-icon` subtree — first ported-parent→ported-child nesting, ctx-name re-provision verified for both v1 and ported children.
- **SourceBtn** — surgical deltas only: base swap, `bag.telemetryManager`, locale subscription; `SourceButtonConfig`, props, `activate()`, template byte-identical. Consumers (SourceList, DynamicBtn, PrimaryAction) untouched and covered by their suites.
- **Spinner** — two-line base swap.

Final-review note for the next slices (not a defect here, v1-parity): property-derived state driven by `changedProperties.has(...)` in `willUpdate` (SourceBtn's `_applySource`) should also re-derive from current values in `controllerReady` — added to the port checklist.

## Gate
tsc:app ✅ build (attw/publint/size-limit) ✅ specs 578 ✅ locales ✅ e2e 239/239, exit 0, no flake ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added localization support for upload and source buttons, including locale-aware updates and fallback text.
  - Added the `uc-spinner` component for loading indicators.
  - Improved source button behavior with configurable icons, text-only, and icon-only display modes.
  - Added support for localized single-file and multi-file labels in the simple upload button.
  - Registered `uc-spinner` for JSX usage.
- **Tests**
  - Added coverage for localization, button interactions, loading indicators, display modes, and test identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->