### PR TITLE
feat(m9d): PrimaryAction/DropDown/Select ports + SourceBtn pre-adoption hardening

### DIFF
--- a/src/blocks/DropDown/DropDown.ts
+++ b/src/blocks/DropDown/DropDown.ts
@@ -1,11 +1,11 @@
 import { html } from 'lit';
 
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import { UID } from '../../utils/UID';
 import './drop-down.css';
 import { state } from 'lit/decorators.js';
 
-export class DropDown extends LitBlock {
+export class DropDown extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-drop-down'];
 
   @state()

--- a/src/blocks/DynamicBtn/PrimaryAction.ts
+++ b/src/blocks/DynamicBtn/PrimaryAction.ts
@@ -1,6 +1,7 @@
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { ChildBlock } from '../../lit/ChildBlock';
 import type { Uid } from '../../lit/Uid';
 import type { OutputCollectionState, OutputCollectionStatus } from '../../types';
 import { UploadSource } from '../../utils/UploadSource';
@@ -10,7 +11,7 @@ import './primary-action.css';
 import '../Icon/Icon';
 import '../Thumb/Thumb';
 
-export class PrimaryAction extends LitUploaderBlock {
+export class PrimaryAction extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-primary-action'];
 
   private static readonly SOURCE_TEXT_CONFIG: Record<string, { action: string }> = {
@@ -33,9 +34,11 @@ export class PrimaryAction extends LitUploaderBlock {
   @state()
   private _isMultiple = false;
 
-  public override initCallback(): void {
-    super.initCallback();
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
+  }
 
+  protected override controllerReady(): void {
     this.subConfigValue('dynamicButtonShowFirstIcon', (value) => {
       this.showIcon = value;
     });
@@ -122,7 +125,7 @@ export class PrimaryAction extends LitUploaderBlock {
 
   private _handleClick() {
     if (this.hasEntries) {
-      this.router.navigate('upload-list');
+      this.bag.router.navigate('upload-list');
       return;
     }
 

--- a/src/blocks/Select/Select.ts
+++ b/src/blocks/Select/Select.ts
@@ -1,6 +1,6 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './select.css';
 
 type SelectOption = {
@@ -8,7 +8,7 @@ type SelectOption = {
   value: string;
 };
 
-export class Select extends LitBlock {
+export class Select extends ChildBlock {
   @property({ type: String, attribute: false })
   public value = '';
 

--- a/src/blocks/SourceBtn/SourceBtn.ts
+++ b/src/blocks/SourceBtn/SourceBtn.ts
@@ -30,6 +30,13 @@ export class SourceBtn extends ChildBlock {
   @state()
   private _srcTypeKey = '';
 
+  protected override controllerReady(): void {
+    // A `source` set while the render gate was closed never reaches
+    // `willUpdate` (Lit clears changed-properties for gated cycles) —
+    // re-derive from the current value on adoption.
+    this._applySource(this.source);
+  }
+
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
 

--- a/tests/blocks/drop-down.e2e.test.tsx
+++ b/tests/blocks/drop-down.e2e.test.tsx
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, DropDown } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderDropDown = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-drop-down ctx-name={ctxName}></uc-drop-down>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const dropDown = document.querySelector('uc-drop-down')! as DropDown;
+  return { ctxName, config, dropDown };
+};
+
+// `content-for` light-DOM projection (LightDomMixin) is adopted from the
+// element's own childNodes read fresh on its first `update()` pass — plain DOM
+// appends performed synchronously right after `page.render` (before Lit's
+// microtask-scheduled first update) land in time, without depending on the
+// generated JSX attribute typing for the `content-for` attribute (which isn't
+// a typed HTML/React attribute).
+const appendContentFor = (host: Element, slot: string, tagName: string, text: string): Element => {
+  const el = document.createElement(tagName);
+  el.setAttribute('content-for', slot);
+  el.textContent = text;
+  host.appendChild(el);
+  return el;
+};
+
+describe('uc-drop-down', () => {
+  it('renders a popover-target button and a matching popover content div', async () => {
+    const { dropDown } = renderDropDown();
+    await dropDown.updateComplete;
+
+    const button = dropDown.querySelector('button.uc-dropdown-btn') as HTMLButtonElement | null;
+    const content = dropDown.querySelector('[popover]') as HTMLElement | null;
+
+    expect(button).toBeTruthy();
+    expect(content).toBeTruthy();
+    expect(button!.hasAttribute('popovertarget')).toBe(true);
+    expect(content!.getAttribute('popover')).toBe('auto');
+    expect(content!.id).toBeTruthy();
+    expect(button!.getAttribute('popovertarget')).toBe(content!.id);
+  });
+
+  it('projects content-for="dd-header-button" into the header button and content-for="dd-content" into the popover content', async () => {
+    const { dropDown } = renderDropDown();
+    const header = appendContentFor(dropDown, 'dd-header-button', 'span', 'Open menu');
+    const content = appendContentFor(dropDown, 'dd-content', 'div', 'Menu body');
+
+    await expect.poll(() => dropDown.querySelector('button.uc-dropdown-btn span')?.textContent).toBe('Open menu');
+    const contentHost = dropDown.querySelector('[popover]');
+    await expect.poll(() => contentHost?.querySelector('div')?.textContent).toBe('Menu body');
+
+    // real light-DOM child adoption: same node instances, moved into place
+    expect(dropDown.querySelector('button.uc-dropdown-btn')?.contains(header)).toBe(true);
+    expect(contentHost?.contains(content)).toBe(true);
+  });
+
+  it('sets the uc-drop-down style attribute on the host', async () => {
+    const { dropDown } = renderDropDown();
+    await expect.poll(() => dropDown.hasAttribute('uc-drop-down')).toBe(true);
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderDropDown();
+    await expect.element(page.getByTestId('uc-drop-down')).toBeInTheDocument();
+  });
+});

--- a/tests/blocks/primary-action.e2e.test.tsx
+++ b/tests/blocks/primary-action.e2e.test.tsx
@@ -1,0 +1,185 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+// `SourceButtonConfig` is not re-exported from `@/index.ts` (only the `SourceBtn`
+// class is), so it's imported directly from its source module — same pattern as
+// tests/blocks/source-btn.e2e.test.tsx.
+import type { SourceButtonConfig } from '@/blocks/SourceBtn/SourceBtn.ts';
+import type { Config, Icon, OutputCollectionState, OutputCollectionStatus, PrimaryAction } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+// `PrimaryAction.entries` only reads `status`, `allEntries`, the per-status
+// counts, `isSuccess`, and `totalCount` (see src/blocks/DynamicBtn/PrimaryAction.ts).
+// Fixtures below are plain objects shaped to satisfy just those fields; the
+// cast is narrowed to the public `OutputCollectionState` shape (not `any`).
+type Entries = OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
+
+// Booleans are driven as JS properties on `config` after render (same pattern
+// as tests/blocks/simple-btn.e2e.test.tsx's `config.multiple = false`), not as
+// JSX attributes: the render-jsx `CommonDOMRenderer` maps a `false`-valued JSX
+// prop to `removeAttribute` (see node_modules/render-jsx dom renderer), which
+// is a no-op on an attribute that was never present — so `dynamicButtonShowFirstIcon={false}`
+// would silently fail to override the `true` default.
+const renderPrimaryAction = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-primary-action ctx-name={ctxName}></uc-primary-action>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const btn = document.querySelector('uc-primary-action')! as PrimaryAction;
+  return { ctxName, config, btn };
+};
+
+const buttonText = () => document.querySelector('uc-primary-action button span')?.textContent;
+const ariaLabel = () => document.querySelector('uc-primary-action button')?.getAttribute('aria-label');
+const iconEl = () => document.querySelector('uc-primary-action uc-icon');
+const thumbEl = () => document.querySelector('uc-primary-action uc-thumb');
+// PrimaryAction binds `<uc-icon .name=...>` as a JS property (not an
+// attribute), so the icon's identity must be read off the `.name` property —
+// `getAttribute('name')` is never set here.
+const iconName = () => (iconEl() as Icon | null)?.name;
+
+describe('uc-primary-action', () => {
+  it('with no entries, renders the localized "upload from …" composition as text and aria-label', async () => {
+    // BRIEF CORRECTION: the brief's fixture used `label: 'from-device'`, but
+    // that string is not an en.ts l10n key at all (grep confirms no such key
+    // anywhere in src/locales) — l10n would fall back to the raw key and
+    // produce the nonsensical "Upload from-device". The real production
+    // label for the local source is `src-type-local` (see
+    // src/plugins/localSourcePlugin.ts), whose l10n value is "From device".
+    // This test pins that real composition instead.
+    const { btn } = renderPrimaryAction();
+    const onClick = vi.fn();
+    const source: SourceButtonConfig = { id: 'local', label: 'src-type-local', onClick };
+    btn.source = source;
+    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('Upload from device');
+    expect(ariaLabel()).toBe('Upload from device');
+  });
+
+  it('renders the header-uploading text with count while uploading', async () => {
+    const { btn } = renderPrimaryAction();
+    btn.entries = { status: 'uploading', uploadingCount: 2, allEntries: [{}], totalCount: 2 } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('Uploading 2 files');
+  });
+
+  it('renders the header-failed text with count when failed', async () => {
+    const { btn } = renderPrimaryAction();
+    btn.entries = { status: 'failed', failedCount: 1, allEntries: [{}], totalCount: 1 } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('1 error');
+  });
+
+  it('renders the header-succeed text with count on success', async () => {
+    const { btn } = renderPrimaryAction();
+    btn.entries = {
+      status: 'success',
+      successCount: 3,
+      allEntries: [{}, {}, {}],
+      isSuccess: true,
+      totalCount: 3,
+    } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('3 files uploaded');
+  });
+
+  it('renders the source icon when dynamicButtonShowFirstIcon is truthy and there are no entries', async () => {
+    const { config, btn } = renderPrimaryAction();
+    config.dynamicButtonShowFirstIcon = true;
+    btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
+    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+
+    await expect.poll(iconName).toBe('my-icon');
+  });
+
+  it('does not render the source icon when dynamicButtonShowFirstIcon is false', async () => {
+    const { config, btn } = renderPrimaryAction();
+    config.dynamicButtonShowFirstIcon = false;
+    btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
+    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('Upload from device');
+    expect(iconEl()).toBeNull();
+  });
+
+  it('renders a uc-thumb for a single successful image entry when not multiple', async () => {
+    const { config, btn } = renderPrimaryAction();
+    config.multiple = false;
+    await expect.poll(() => config.multiple).toBe(false);
+    btn.entries = {
+      status: 'success',
+      successCount: 1,
+      isSuccess: true,
+      totalCount: 1,
+      allEntries: [{ isImage: true, internalId: 'test-uid' }],
+    } as unknown as Entries;
+
+    await expect.poll(() => thumbEl()).toBeTruthy();
+  });
+
+  it('renders neither a thumb nor an icon for a single successful image entry when multiple', async () => {
+    const { config, btn } = renderPrimaryAction();
+    config.multiple = true;
+    config.dynamicButtonShowFirstIcon = true;
+    btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
+    btn.entries = {
+      status: 'success',
+      successCount: 1,
+      isSuccess: true,
+      totalCount: 1,
+      allEntries: [{ isImage: true, internalId: 'test-uid' }],
+    } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('1 file uploaded');
+    expect(thumbEl()).toBeNull();
+    expect(iconEl()).toBeNull();
+  });
+
+  it('clicking with no entries invokes source.onClick', async () => {
+    const { btn } = renderPrimaryAction();
+    const onClick = vi.fn();
+    btn.source = { id: 'local', label: 'src-type-local', onClick };
+    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+    await expect.poll(buttonText).toBe('Upload from device');
+
+    (document.querySelector('uc-primary-action button') as HTMLButtonElement).click();
+    await vi.waitFor(() => expect(onClick).toHaveBeenCalledOnce());
+  });
+
+  it('clicking with entries present does NOT invoke source.onClick (navigates instead)', async () => {
+    const { btn } = renderPrimaryAction();
+    const onClick = vi.fn();
+    btn.source = { id: 'local', label: 'src-type-local', onClick };
+    btn.entries = {
+      status: 'success',
+      successCount: 1,
+      isSuccess: true,
+      totalCount: 1,
+      allEntries: [{ isImage: false, internalId: 'test-uid' }],
+    } as unknown as Entries;
+    await expect.poll(buttonText).toBe('1 file uploaded');
+
+    // `_handleClick` is synchronous and branches on `hasEntries` before ever
+    // touching `source.onClick`, so no wait is needed to observe the result;
+    // still flush one update cycle so any (deliberately unobserved) router
+    // navigation settles before the assertion.
+    (document.querySelector('uc-primary-action button') as HTMLButtonElement).click();
+    await btn.updateComplete;
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderPrimaryAction();
+    await expect.element(page.getByTestId('uc-primary-action')).toBeInTheDocument();
+  });
+});

--- a/tests/blocks/select.e2e.test.tsx
+++ b/tests/blocks/select.e2e.test.tsx
@@ -1,0 +1,122 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, Select } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const renderSelect = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-select ctx-name={ctxName}></uc-select>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const select = document.querySelector('uc-select')! as Select;
+  return { ctxName, config, select };
+};
+
+const innerSelect = () => document.querySelector('uc-select select') as HTMLSelectElement | null;
+
+describe('uc-select', () => {
+  it('renders one native <option> per options entry, with matching text and value', async () => {
+    const { select } = renderSelect();
+    select.options = [
+      { text: 'One', value: 'v1' },
+      { text: 'Two', value: 'v2' },
+      { text: 'Three', value: 'v3' },
+    ];
+
+    await expect.poll(() => innerSelect()?.querySelectorAll('option').length).toBe(3);
+    const options = Array.from(innerSelect()!.querySelectorAll('option'));
+    expect(options.map((o) => o.textContent)).toEqual(['One', 'Two', 'Three']);
+    expect(options.map((o) => o.value)).toEqual(['v1', 'v2', 'v3']);
+  });
+
+  it('reflects .value into the native select', async () => {
+    const { select } = renderSelect();
+    select.options = [
+      { text: 'One', value: 'v1' },
+      { text: 'Two', value: 'v2' },
+    ];
+    // The native `<select>`'s `.value` binding and its `<option>` children are
+    // committed as part of the same Lit template; a browser can only select a
+    // value once the matching `<option>` exists in the DOM. Flushing the
+    // `options` update first (one `updateComplete`) before setting `.value`
+    // mirrors how a real consumer must sequence these two writes.
+    await select.updateComplete;
+    select.value = 'v2';
+
+    await expect.poll(() => innerSelect()?.value).toBe('v2');
+  });
+
+  it('user-selecting an option updates .value and dispatches a change event on the host', async () => {
+    const { select } = renderSelect();
+    select.options = [
+      { text: 'One', value: 'v1' },
+      { text: 'Two', value: 'v2' },
+    ];
+    // See the ordering note above: flush the options render before setting
+    // `.value` so the assertion actually exercises the reflection rather than
+    // accidentally matching the browser's own "first option" default.
+    await select.updateComplete;
+    select.value = 'v1';
+    await expect.poll(() => innerSelect()?.value).toBe('v1');
+
+    const onChange = vi.fn();
+    select.addEventListener('change', onChange);
+
+    const nativeSelect = innerSelect()!;
+    nativeSelect.value = 'v2';
+    nativeSelect.dispatchEvent(new Event('change'));
+
+    await expect.poll(() => select.value).toBe('v2');
+    expect(onChange).toHaveBeenCalledOnce();
+  });
+
+  it('disabled reflects onto the inner select and the host attribute', async () => {
+    const { select } = renderSelect();
+    select.disabled = true;
+
+    await expect.poll(() => innerSelect()?.disabled).toBe(true);
+    expect(select.hasAttribute('disabled')).toBe(true);
+
+    select.disabled = false;
+    await expect.poll(() => innerSelect()?.disabled).toBe(false);
+    expect(select.hasAttribute('disabled')).toBe(false);
+  });
+
+  it('disabled suppresses the host change dispatch', async () => {
+    const { select } = renderSelect();
+    select.options = [
+      { text: 'One', value: 'v1' },
+      { text: 'Two', value: 'v2' },
+    ];
+    await select.updateComplete;
+    select.value = 'v1';
+    select.disabled = true;
+    await expect.poll(() => innerSelect()?.disabled).toBe(true);
+
+    const onChange = vi.fn();
+    select.addEventListener('change', onChange);
+
+    const nativeSelect = innerSelect()!;
+    nativeSelect.value = 'v2';
+    nativeSelect.dispatchEvent(new Event('change'));
+    await select.updateComplete;
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(select.value).toBe('v1');
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderSelect();
+    await expect.element(page.getByTestId('uc-select')).toBeInTheDocument();
+  });
+});

--- a/tests/blocks/source-btn.e2e.test.tsx
+++ b/tests/blocks/source-btn.e2e.test.tsx
@@ -86,4 +86,23 @@ describe('uc-source-btn', () => {
     renderSourceBtn();
     await expect.element(page.getByTestId('uc-source-btn')).toBeInTheDocument();
   });
+
+  it('applies a source set while the render gate was still closed', async () => {
+    const ctxName = getCtxName();
+    // Mount the button BEFORE any ctx exists, then set the property — the
+    // scheduled update flushes gated, so Lit clears changedProperties.
+    const btn = document.createElement('uc-source-btn');
+    btn.setAttribute('ctx-name', ctxName);
+    document.body.append(btn);
+    await btn.updateComplete;
+    btn.source = { id: 'late-src', label: 'late-label-key', onClick: () => {} };
+    await btn.updateComplete;
+
+    // Now create the ctx; the button adopts and must render the label it was
+    // given pre-adoption, not the stale defaults.
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    await expect.poll(() => btn.querySelector('.uc-txt')?.textContent).toBe('late-label-key');
+    await expect.poll(() => btn.querySelector('uc-icon')?.getAttribute('name')).toBe('late-src');
+    btn.remove();
+  });
 });

--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -41,6 +41,9 @@ type ExternalSource = import('../dist/index.ts').ExternalSource;
 type CloudImageEditorActivity = import('../dist/index.ts').CloudImageEditorActivity;
 type FormInput = import('../dist/index.ts').FormInput;
 type CloudImageEditorBlock = import('../dist/index.ts').CloudImageEditorBlock;
+type PrimaryAction = import('../dist/index.ts').PrimaryAction;
+type DropDown = import('../dist/index.ts').DropDown;
+type Select = import('../dist/index.ts').Select;
 
 type CommonHtmlAttributes<T> = Partial<
   Pick<React.HTMLAttributes<T>, 'id' | 'children' | 'hidden'> & { class: React.HTMLAttributes<T>['className'] }
@@ -93,5 +96,8 @@ declare namespace JSX {
     'uc-file-uploader-inline': CustomElement<FileUploaderInline>;
     'uc-upload-ctx-provider': CustomElement<UploadCtxProvider>;
     'uc-config': CustomElement<Config>;
+    'uc-primary-action': CustomElement<PrimaryAction>;
+    'uc-drop-down': CustomElement<DropDown>;
+    'uc-select': CustomElement<Select>;
   }
 }


### PR DESCRIPTION
Fourth slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7). Nine blocks now run on `ChildBlock`.

## Coverage first (AGENTS.md #1)
Additive parity suites for PrimaryAction (11 — header texts pinned against the real `en.ts` strings incl. pluralized keys), DropDown (4), Select (6), kept green **unchanged** through the ports. All condition-waited; no timed delays.

## Ports
- **PrimaryAction** — first `bag.router` use (`navigate('upload-list')` from a render-gated click; pre-adoption unreachability verified against the registry/init flow, v1-parity throw semantics). l10n + two `subConfigValue`s move to `controllerReady`; template/getters byte-identical.
- **DropDown / Select** — two-line base swaps (compat-free prop/slot blocks).

## SourceBtn hardening (real bug, TDD-pinned)
M9c's final review flagged that a `.source` set while the render gate is closed flushes gated — Lit clears `changedProperties`, so `willUpdate` never re-applies it. RED confirmed the trap (element mounted before its ctx exists → stale default icon/empty label forever); fix re-derives `_applySource(this.source)` in `controllerReady`.

The final review swept all nine ported blocks for the same shape: PrimaryAction/DropDown/Select/SimpleBtn/Spinner/Copyright are immune by construction (render-time derivation); Icon is safe via its existing subscriptions; ProgressBar's `visible` branch is a known low-reachability instance queued for the next slice. Port checklist updated: *derive at render time → immune; `changedProperties`-gated derivation → needs a `controllerReady` re-derive.*

Thumb is deliberately excluded — it shares `FileItemConfig` (entry-subscription base) with the unported FileItem; that trio is its own slice.

## Gate
tsc:app ✅ build (attw/publint/size-limit) ✅ specs 578 ✅ locales ✅ e2e 261/261, exit 0, no flake ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added JSX type support for `uc-primary-action`, `uc-drop-down`, and `uc-select`.
  * Improved component initialization and state handling for upload actions, source buttons, dropdowns, and select controls.

* **Bug Fixes**
  * Ensured source button labels and icons update correctly when configuration loads late.
  * Improved primary-action navigation and click behavior.

* **Tests**
  * Added end-to-end coverage for dropdown, primary action, select, and source button behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->