### PR TITLE
feat(m9e): FileItem family ports + proxyUrl extraction + carried-over hardenings

### DIFF
--- a/src/abstract/secureDeliveryProxyUrl.test.ts
+++ b/src/abstract/secureDeliveryProxyUrl.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
+import { resolveSecureDeliveryProxyUrl, type SecureDeliveryProxyConfig } from './secureDeliveryProxyUrl';
+
+const cdnUrl = 'https://ucarecdn.com/uuid-1234/-/crop/100x100/100,100/-/preview/300x300/photo.jpg';
+
+describe('resolveSecureDeliveryProxyUrl', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+  let onResolverError: Mock<(error: unknown, context: string) => void>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    onResolverError = vi.fn<(error: unknown, context: string) => void>();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  it('uses the resolver when only it is set, and passes it through unaltered', async () => {
+    const resolver = vi.fn().mockResolvedValue('https://resolved.example.com/photo.jpg');
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: '',
+      secureDeliveryProxyUrlResolver: resolver,
+    };
+
+    const result = await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(result).toBe('https://resolved.example.com/photo.jpg');
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(onResolverError).not.toHaveBeenCalled();
+  });
+
+  it('warns when both secureDeliveryProxy and secureDeliveryProxyUrlResolver are set, then uses the resolver', async () => {
+    const resolver = vi.fn().mockResolvedValue('https://resolved.example.com/photo.jpg');
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: 'https://proxy.example.com/{{previewUrl}}',
+      secureDeliveryProxyUrlResolver: resolver,
+    };
+
+    const result = await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(warnSpy).toHaveBeenCalledExactlyOnceWith(
+      'Both secureDeliveryProxy and secureDeliveryProxyUrlResolver are set. The secureDeliveryProxyUrlResolver will be used.',
+    );
+    expect(result).toBe('https://resolved.example.com/photo.jpg');
+  });
+
+  it('calls the resolver with uuid, cdnUrlModifiers, and fileName extracted from the url', async () => {
+    const resolver = vi.fn().mockResolvedValue('https://resolved.example.com/photo.jpg');
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: '',
+      secureDeliveryProxyUrlResolver: resolver,
+    };
+
+    await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(resolver).toHaveBeenCalledExactlyOnceWith(cdnUrl, {
+      uuid: 'uuid-1234',
+      cdnUrlModifiers: '-/crop/100x100/100,100/-/preview/300x300/',
+      fileName: 'photo.jpg',
+    });
+  });
+
+  it('on resolver throw: logs console.error, invokes onResolverError with the context string, and falls back to the passthrough url', async () => {
+    const failure = new Error('network down');
+    const resolver = vi.fn().mockRejectedValue(failure);
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: '',
+      secureDeliveryProxyUrlResolver: resolver,
+    };
+
+    const result = await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(result).toBe(cdnUrl);
+    expect(errorSpy).toHaveBeenCalledExactlyOnceWith(
+      'Failed to resolve secure delivery proxy URL. Falling back to the default URL.',
+      failure,
+    );
+    expect(onResolverError).toHaveBeenCalledExactlyOnceWith(
+      failure,
+      'secureDeliveryProxyUrlResolver. Failed to resolve secure delivery proxy URL. Falling back to the default URL.',
+    );
+  });
+
+  it('applies the secureDeliveryProxy template with an encoded previewUrl when no resolver is set', async () => {
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: 'https://proxy.example.com/?url={{previewUrl}}',
+      secureDeliveryProxyUrlResolver: null,
+    };
+
+    const result = await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(result).toBe(`https://proxy.example.com/?url=${window.encodeURIComponent(cdnUrl)}`);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns the url unchanged when neither secureDeliveryProxy nor the resolver is set', async () => {
+    const config: SecureDeliveryProxyConfig = {
+      secureDeliveryProxy: '',
+      secureDeliveryProxyUrlResolver: null,
+    };
+
+    const result = await resolveSecureDeliveryProxyUrl(config, onResolverError, cdnUrl);
+
+    expect(result).toBe(cdnUrl);
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+    expect(onResolverError).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/secureDeliveryProxyUrl.ts
+++ b/src/abstract/secureDeliveryProxyUrl.ts
@@ -1,0 +1,46 @@
+import type { ConfigType } from '../types';
+import { extractCdnUrlModifiers, extractFilename, extractUuid } from '../utils/cdn-utils';
+import { applyTemplateData } from '../utils/template-utils';
+
+export type SecureDeliveryProxyConfig = Pick<ConfigType, 'secureDeliveryProxy' | 'secureDeliveryProxyUrlResolver'>;
+
+/**
+ * Resolve a CDN url through the configured secure-delivery proxy, if any.
+ * Extracted verbatim from `LitBlock.proxyUrl` so both the v1 and v2 element
+ * bases can delegate to the same DOM-free logic.
+ */
+export async function resolveSecureDeliveryProxyUrl(
+  config: SecureDeliveryProxyConfig,
+  onResolverError: (error: unknown, context: string) => void,
+  url: string,
+): Promise<string> {
+  if (config.secureDeliveryProxy && config.secureDeliveryProxyUrlResolver) {
+    console.warn(
+      'Both secureDeliveryProxy and secureDeliveryProxyUrlResolver are set. The secureDeliveryProxyUrlResolver will be used.',
+    );
+  }
+  if (config.secureDeliveryProxyUrlResolver) {
+    try {
+      return await config.secureDeliveryProxyUrlResolver(url, {
+        uuid: extractUuid(url),
+        cdnUrlModifiers: extractCdnUrlModifiers(url),
+        fileName: extractFilename(url),
+      });
+    } catch (err) {
+      console.error('Failed to resolve secure delivery proxy URL. Falling back to the default URL.', err);
+      onResolverError(
+        err,
+        'secureDeliveryProxyUrlResolver. Failed to resolve secure delivery proxy URL. Falling back to the default URL.',
+      );
+      return url;
+    }
+  }
+  if (config.secureDeliveryProxy) {
+    return applyTemplateData(
+      config.secureDeliveryProxy,
+      { previewUrl: url },
+      { transform: (value) => window.encodeURIComponent(value) },
+    );
+  }
+  return url;
+}

--- a/src/abstract/secureDeliveryProxyUrl.ts
+++ b/src/abstract/secureDeliveryProxyUrl.ts
@@ -39,7 +39,7 @@ export async function resolveSecureDeliveryProxyUrl(
     return applyTemplateData(
       config.secureDeliveryProxy,
       { previewUrl: url },
-      { transform: (value) => window.encodeURIComponent(value) },
+      { transform: (value) => encodeURIComponent(value) },
     );
   }
   return url;

--- a/src/blocks/FileItem/FileActionButton.ts
+++ b/src/blocks/FileItem/FileActionButton.ts
@@ -1,6 +1,7 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import { ChildBlock } from '../../lit/ChildBlock';
 
 import '../Icon/Icon';
@@ -33,6 +34,10 @@ export class FileActionButton extends ChildBlock {
 
   private get _normalizedProgress(): number {
     return Math.min(Math.max(this.progress || 0, 0), 100);
+  }
+
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
   }
 
   private _handleAction() {

--- a/src/blocks/FileItem/FileActionButton.ts
+++ b/src/blocks/FileItem/FileActionButton.ts
@@ -1,7 +1,7 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 
 import '../Icon/Icon';
 
@@ -10,7 +10,7 @@ import { classMap } from 'lit/directives/class-map.js';
 
 const L10N_REMOVE_KEY = 'file-item-remove-button';
 
-export class FileActionButton extends LitUploaderBlock {
+export class FileActionButton extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-file-action-button'];
 
   @property({ type: Boolean })

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -202,7 +202,8 @@ export class FileItem extends FileItemConfig {
   private _handleEntryId(id: Uid): void {
     this.reset();
 
-    const entry = this.bag.uploadCollection.read(id);
+    // The uploader-scope shared instances exist only once an uploader block initializes this ctx.
+    const entry = this.bag.ctx.has('*uploadCollection') ? this.bag.uploadCollection.read(id) : null;
     this.entry = entry;
 
     if (!entry) {

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -93,7 +93,7 @@ export class FileItem extends FileItemConfig {
       },
     });
 
-    if (this.uid && this.bag.uploadCollection.hasItem(this.uid)) {
+    if (this.uid && this.bag.ctx.has('*uploadCollection') && this.bag.uploadCollection.hasItem(this.uid)) {
       this.entry?.getValue('abortController')?.abort();
       this.bag.uploadCollection.remove(this.uid);
     }
@@ -276,6 +276,12 @@ export class FileItem extends FileItemConfig {
   private _updatePluginFileActions(): void {
     const pluginManager = this._pluginManager;
     if (!pluginManager || !this.uid) {
+      this._pluginFileActions = [];
+      return;
+    }
+
+    // The uploader-scope shared instances exist only once an uploader block initializes this ctx.
+    if (!this.bag.ctx.has('*publicApi')) {
       this._pluginFileActions = [];
       return;
     }

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -1,6 +1,7 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import type { PluginFileActionRegistration } from '../../abstract/managers/plugin';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import type { PluginController, PluginFileActionRegistration } from '../../abstract/managers/plugin';
 import type { Owned } from '../../abstract/managers/plugin/PluginTypes';
 import type { UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
 import { debounce } from '../../utils/debounce';
@@ -80,10 +81,10 @@ export class FileItem extends FileItemConfig {
 
   private _renderedOnce = false;
   private _observer?: IntersectionObserver;
-  private _unsubscribePlugins?: () => void;
+  private _pluginManager: PluginController | null = null;
 
   private _handleRemove = (): void => {
-    this.telemetryManager.sendEvent({
+    this.bag.telemetryManager.sendEvent({
       payload: {
         metadata: {
           event: 'remove-file',
@@ -92,9 +93,9 @@ export class FileItem extends FileItemConfig {
       },
     });
 
-    if (this.uid && this.uploadCollection.hasItem(this.uid)) {
+    if (this.uid && this.bag.uploadCollection.hasItem(this.uid)) {
       this.entry?.getValue('abortController')?.abort();
-      this.uploadCollection.remove(this.uid);
+      this.bag.uploadCollection.remove(this.uid);
     }
   };
 
@@ -201,7 +202,7 @@ export class FileItem extends FileItemConfig {
   private _handleEntryId(id: Uid): void {
     this.reset();
 
-    const entry = this.uploadCollection?.read(id);
+    const entry = this.bag.uploadCollection.read(id);
     this.entry = entry;
 
     if (!entry) {
@@ -254,7 +255,7 @@ export class FileItem extends FileItemConfig {
   }
 
   private _updateShowFileNames(value: boolean): void {
-    const isListMode = this.cfg.filesViewMode === 'list';
+    const isListMode = this.uploader.config.get('filesViewMode') === 'list';
     if (isListMode) {
       this._showFileNames = true;
       return;
@@ -272,14 +273,14 @@ export class FileItem extends FileItemConfig {
   }
 
   private _updatePluginFileActions(): void {
-    const pluginManager = this._sharedInstancesBag.pluginManager;
+    const pluginManager = this._pluginManager;
     if (!pluginManager || !this.uid) {
       this._pluginFileActions = [];
       return;
     }
 
     const allFileActions = pluginManager.snapshot().fileActions;
-    const outputFileEntry = this.api.getOutputItem(this.uid);
+    const outputFileEntry = this.bag.api.getOutputItem(this.uid);
 
     if (!outputFileEntry) {
       this._pluginFileActions = [];
@@ -301,12 +302,12 @@ export class FileItem extends FileItemConfig {
       return;
     }
 
-    const outputFileEntry = this.api.getOutputItem(this.uid);
+    const outputFileEntry = this.bag.api.getOutputItem(this.uid);
     if (!outputFileEntry) {
       return;
     }
 
-    this.telemetryManager.sendEvent({
+    this.bag.telemetryManager.sendEvent({
       payload: {
         metadata: {
           event: action.id,
@@ -323,13 +324,11 @@ export class FileItem extends FileItemConfig {
     }
   }
 
-  public override initCallback(): void {
-    super.initCallback();
-
+  protected override controllerReady(): void {
     this._handleEntryId(this.uid);
 
     this.subConfigValue('filesViewMode', (mode) => {
-      this._updateShowFileNames(this.cfg.gridShowFileNames);
+      this._updateShowFileNames(this.uploader.config.get('gridShowFileNames'));
 
       this.setAttribute('mode', mode);
     });
@@ -348,20 +347,32 @@ export class FileItem extends FileItemConfig {
       });
     };
 
-    this.sub('*uploadTrigger', (itemsToUpload) => {
-      if (this.entry && !itemsToUpload.has(this.entry.uid)) {
-        return;
-      }
-      setTimeout(() => this.isConnected && this._upload());
-    });
+    this.trackSub(
+      this.bag.ctx.sub('*uploadTrigger', (itemsToUpload) => {
+        if (this.entry && !itemsToUpload.has(this.entry.uid)) {
+          return;
+        }
+        setTimeout(() => this.isConnected && this._upload());
+      }),
+    );
 
-    const pluginManager = this._sharedInstancesBag.pluginManager;
-    if (pluginManager?.onPluginsChange) {
-      this._unsubscribePlugins = pluginManager.onPluginsChange(() => this._updatePluginFileActions());
-    }
-    this._updatePluginFileActions();
+    this.trackSub(
+      this.bag.when('pluginManager', (pm) => {
+        this._pluginManager = pm;
+        this.trackSub(pm.onPluginsChange(() => this._updatePluginFileActions()));
+        this._updatePluginFileActions();
+      }),
+    );
 
     FileItem.activeInstances.add(this);
+  }
+
+  protected override controllerReleased(): void {
+    this._pluginManager = null;
+  }
+
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
   }
 
   public override connectedCallback(): void {
@@ -374,8 +385,6 @@ export class FileItem extends FileItemConfig {
   }
 
   public override disconnectedCallback(): void {
-    this._unsubscribePlugins?.();
-    this._unsubscribePlugins = undefined;
     super.disconnectedCallback();
 
     this._observer?.disconnect();
@@ -390,7 +399,7 @@ export class FileItem extends FileItemConfig {
   // trigger; it reacts to the resulting entry mutations through its existing
   // per-entry subscriptions (`isUploading`/`errors`/… → `_debouncedCalculateState`).
   private _upload = this.withEntry(async (entry) => {
-    await this.uploadController.uploadEntry(entry.uid);
+    await this.bag.uploadController.uploadEntry(entry.uid);
   });
 
   public static activeInstances: Set<FileItem> = new Set<FileItem>();

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -1,9 +1,9 @@
 import type { UploadEntryData, UploadEntryKeys, UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 
 type EntrySubscription = ReturnType<UploadEntryTypedData['subscribe']>;
 
-export class FileItemConfig extends LitUploaderBlock {
+export class FileItemConfig extends ChildBlock {
   private _entrySubs: Set<EntrySubscription> = new Set<EntrySubscription>();
 
   protected entry: UploadEntryTypedData | null = null;

--- a/src/blocks/Icon/Icon.ts
+++ b/src/blocks/Icon/Icon.ts
@@ -45,6 +45,12 @@ export class Icon extends ChildBlock {
     this._pluginManager = null;
   }
 
+  // Pre-adoption safety: unlike `willUpdate`-gated derivations, a `name` set
+  // before adoption is not lost here — `controllerReady`'s `subConfigValue`/
+  // `bag.when` subscriptions above both call `_updateResolvedHref()` when
+  // they first fire on adoption. If this restructures, keep one of those
+  // subscriptions calling it (or add an explicit re-derive here) so a
+  // pre-adoption `name` write still resolves.
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
     super.willUpdate(changedProperties);
     if (changedProperties.has('name')) {

--- a/src/blocks/ProgressBar/ProgressBar.ts
+++ b/src/blocks/ProgressBar/ProgressBar.ts
@@ -38,12 +38,12 @@ export class ProgressBar extends ChildBlock {
   protected override controllerReady(): void {
     // Pre-adoption property writes never reach `updated` (gated cycles clear
     // changed-properties) — re-derive the visibility class and progress state
-    // from current values on adoption.
+    // from current values on adoption, mirroring `firstUpdated` (which only
+    // fires once ever, so re-adoptions must re-sync here).
     this.classList.toggle('uc-progress-bar--hidden', !this.visible);
+    this._progressValue = this._normalizeProgressValue(this.value);
     if (this.visible) {
       this._updateProgressValueStyle();
-    } else {
-      this._progressValue = this._normalizeProgressValue(this.value);
     }
   }
 

--- a/src/blocks/ProgressBar/ProgressBar.ts
+++ b/src/blocks/ProgressBar/ProgressBar.ts
@@ -35,6 +35,18 @@ export class ProgressBar extends ChildBlock {
     }
   };
 
+  protected override controllerReady(): void {
+    // Pre-adoption property writes never reach `updated` (gated cycles clear
+    // changed-properties) — re-derive the visibility class and progress state
+    // from current values on adoption.
+    this.classList.toggle('uc-progress-bar--hidden', !this.visible);
+    if (this.visible) {
+      this._updateProgressValueStyle();
+    } else {
+      this._progressValue = this._normalizeProgressValue(this.value);
+    }
+  }
+
   protected override firstUpdated(changedProperties: PropertyValues<this>): void {
     super.firstUpdated(changedProperties);
 

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -310,7 +310,16 @@ export class Thumb extends FileItemConfig {
     // isolated composition) has no collection and therefore no entry.
     const collection = this.bag.ctx.has('*uploadCollection') ? this.bag.uploadCollection : null;
     const entry = collection?.read(id);
-    if (!entry || entry === this.entry) {
+    if (!entry) {
+      // The uid no longer resolves (entry removed, scope lost, or uid swapped
+      // to an unknown id) — drop the previous entry's subscriptions and image
+      // instead of keeping a stale thumb alive.
+      if (this.entry) {
+        this.reset();
+      }
+      return;
+    }
+    if (entry === this.entry) {
       return;
     }
 

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -305,7 +305,11 @@ export class Thumb extends FileItemConfig {
       return;
     }
 
-    const entry = this.bag.uploadCollection.read(id);
+    // The uploader-scope shared instances exist only once an uploader block
+    // initializes this ctx — a thumb rendered outside that scope (e.g. an
+    // isolated composition) has no collection and therefore no entry.
+    const collection = this.bag.ctx.has('*uploadCollection') ? this.bag.uploadCollection : null;
+    const entry = collection?.read(id);
     if (!entry || entry === this.entry) {
       return;
     }

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -7,7 +7,9 @@ import { generateThumb } from '../../utils/resizeImage';
 import { FileItemConfig } from '../FileItem/FileItemConfig';
 import { fileCssBg } from '../svg-backgrounds/svg-backgrounds';
 import './thumb.css';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { Uid } from '../../lit/Uid';
+import type { ConfigType } from '../../types';
 import { TRANSPARENT_PIXEL_SRC } from '../../utils/transparentPixelSrc';
 
 import '../Icon/Icon';
@@ -38,7 +40,7 @@ export class Thumb extends FileItemConfig {
 
   private _isIntersecting = false;
 
-  private _firstViewMode = this.cfg.filesViewMode;
+  private _firstViewMode: ConfigType['filesViewMode'] | undefined;
 
   private _observer?: IntersectionObserver;
 
@@ -52,7 +54,7 @@ export class Thumb extends FileItemConfig {
     let size = Math.max(
       parseInt(String(this?._thumbRect?.height || 0), 10),
       parseInt(String(this?._thumbRect?.width || 0), 10),
-      this.cfg.thumbSize,
+      this.uploader.config.get('thumbSize'),
     );
 
     if (window.devicePixelRatio > 1) {
@@ -74,7 +76,7 @@ export class Thumb extends FileItemConfig {
     if (fileInfo && isImage && uuid) {
       const thumbUrl = await this.proxyUrl(
         createCdnUrl(
-          createOriginalUrl(this.cfg.cdnCname, uuid),
+          createOriginalUrl(this.uploader.config.get('cdnCname'), uuid),
           createCdnUrlModifiers(entry.getValue('cdnUrlModifiers'), `stretch/off`, `scale_crop/${size}x${size}/center`),
         ),
       );
@@ -98,7 +100,7 @@ export class Thumb extends FileItemConfig {
             const blobThumbUrl = await generateThumb(file, size);
             entry.setValue('thumbUrl', blobThumbUrl);
           } catch (err) {
-            this.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
+            this.bag.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
             const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
             entry.setValue('thumbUrl', fileCssBg(color));
           }
@@ -117,7 +119,7 @@ export class Thumb extends FileItemConfig {
         const thumbUrl = await generateThumb(file, size);
         entry.setValue('thumbUrl', thumbUrl);
       } catch (err) {
-        this.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
+        this.bag.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
         const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
         entry.setValue('thumbUrl', fileCssBg(color));
       }
@@ -303,7 +305,7 @@ export class Thumb extends FileItemConfig {
       return;
     }
 
-    const entry = this.uploadCollection?.read(id);
+    const entry = this.bag.uploadCollection.read(id);
     if (!entry || entry === this.entry) {
       return;
     }
@@ -330,8 +332,8 @@ export class Thumb extends FileItemConfig {
     this._requestThumbGeneration(true);
   }
 
-  public override initCallback(): void {
-    super.initCallback();
+  protected override controllerReady(ctrl: UploaderController): void {
+    this._firstViewMode ??= ctrl.config.get('filesViewMode');
 
     this.subConfigValue('filesViewMode', (viewMode) => {
       if (viewMode === 'grid' && !this._renderedGridOnce) {
@@ -341,6 +343,8 @@ export class Thumb extends FileItemConfig {
         this._renderedGridOnce = true;
       }
     });
+
+    this._bindToEntry();
   }
 
   public override connectedCallback(): void {

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -2,6 +2,7 @@ import { ContextConsumer, ContextProvider } from '@lit/context';
 import { LitElement, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { UploaderController } from '../abstract/controllers/UploaderController';
+import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import type { ConfigType } from '../types';
 import { LightDomMixin } from './LightDomMixin';
@@ -248,4 +249,13 @@ export abstract class ChildBlock extends ChildBlockBase {
 
   /** Called after the controller is released (disconnect or re-adoption). */
   protected controllerReleased(_ctrl: UploaderController): void {}
+
+  /** Resolve a CDN url through the configured secure-delivery proxy, if any. */
+  protected async proxyUrl(url: string): Promise<string> {
+    return resolveSecureDeliveryProxyUrl(
+      this.uploader.config.values,
+      (error, context) => this.bag.telemetryManager.sendEventError(error, context),
+      url,
+    );
+  }
 }

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -9,14 +9,13 @@ import { PluginController } from '../abstract/managers/plugin';
 import { buildPluginApi } from '../abstract/managers/plugin/buildPluginApi';
 import { LazyPluginLoader } from '../abstract/managers/plugin/LazyPluginLoader';
 import { TelemetryManager } from '../abstract/managers/TelemetryManager';
+import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { sharedConfigKey } from '../abstract/sharedConfigKey';
 import { initialConfig } from '../blocks/Config/initialConfig';
 import { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
 import { PubSub } from '../lit/PubSubCompat';
 import type { ConfigType } from '../types';
-import { extractCdnUrlModifiers, extractFilename, extractUuid } from '../utils/cdn-utils';
 import { getLocaleDirection } from '../utils/getLocaleDirection';
-import { applyTemplateData } from '../utils/template-utils';
 import { WindowHeightTracker } from '../utils/WindowHeightTracker';
 import type { ActivityId } from './activity-constants';
 import { CssDataMixin } from './CssDataMixin';
@@ -332,35 +331,11 @@ export class LitBlock extends LitBlockBase {
   }
 
   protected async proxyUrl(url: string): Promise<string> {
-    if (this.cfg.secureDeliveryProxy && this.cfg.secureDeliveryProxyUrlResolver) {
-      console.warn(
-        'Both secureDeliveryProxy and secureDeliveryProxyUrlResolver are set. The secureDeliveryProxyUrlResolver will be used.',
-      );
-    }
-    if (this.cfg.secureDeliveryProxyUrlResolver) {
-      try {
-        return await this.cfg.secureDeliveryProxyUrlResolver(url, {
-          uuid: extractUuid(url),
-          cdnUrlModifiers: extractCdnUrlModifiers(url),
-          fileName: extractFilename(url),
-        });
-      } catch (err) {
-        console.error('Failed to resolve secure delivery proxy URL. Falling back to the default URL.', err);
-        this.telemetryManager.sendEventError(
-          err,
-          'secureDeliveryProxyUrlResolver. Failed to resolve secure delivery proxy URL. Falling back to the default URL.',
-        );
-        return url;
-      }
-    }
-    if (this.cfg.secureDeliveryProxy) {
-      return applyTemplateData(
-        this.cfg.secureDeliveryProxy,
-        { previewUrl: url },
-        { transform: (value) => window.encodeURIComponent(value) },
-      );
-    }
-    return url;
+    return resolveSecureDeliveryProxyUrl(
+      this.cfg,
+      (error, context) => this.telemetryManager.sendEventError(error, context),
+      url,
+    );
   }
 
   public get cfg(): ConfigType {

--- a/tests/blocks/file-item.e2e.test.tsx
+++ b/tests/blocks/file-item.e2e.test.tsx
@@ -1,0 +1,134 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, FileItem, OutputFileEntry, UploadCtxProvider, UploaderPlugin } from '@/index.ts';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+// M9e Task 2 — additive parity e2e pinning current v1 `uc-file-item` behavior
+// ahead of the FileItem/Thumb family port. Mounts the full regular solution +
+// `<uc-upload-ctx-provider>` (same composition as tests/blocks/upload-events-wiring.e2e.test.tsx),
+// drives real uploads through the public api, and asserts only against the
+// rendered DOM / documented api surface.
+const TEST_IMAGE_NAME = 'prithiviraj-a-fa7Stge3YXs-unsplash.jpg';
+
+const renderFileItemHost = (plugins: UploaderPlugin[] = []) => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  config.plugins = plugins;
+  const provider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+  return { ctxName, config, api: provider.api };
+};
+
+const fileItemEl = () => document.querySelector('uc-file-item') as FileItem | null;
+
+describe('uc-file-item (parity, real upload flow)', () => {
+  it('renders with the file name visible in list mode and a "mode" attribute reflecting the view mode', async () => {
+    const { api } = renderFileItemHost();
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    // `onFileAdd` only auto-navigates to `upload-list` once an upload actually
+    // starts; adding via the api alone leaves the modal closed, so the item
+    // exists in the DOM but is not visible/rendered (its IntersectionObserver
+    // never reports intersecting while the dialog is closed). `initFlow()` is
+    // the same call the "Upload files" button issues to open the modal.
+    api.initFlow();
+
+    await expect.element(page.getByTestId('uc-file-item')).toBeVisible();
+    await expect.element(page.getByText(TEST_IMAGE_NAME)).toBeVisible();
+    // `filesViewMode` defaults to `'list'` (src/blocks/Config/initialConfig.ts).
+    await expect.poll(() => fileItemEl()?.getAttribute('mode')).toBe('list');
+  });
+
+  it('shows the badge-success icon and marks .uc-inner data-finished on upload success', async () => {
+    const { api } = renderFileItemHost();
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+
+    await expect
+      .poll(() => document.querySelector('uc-file-item uc-thumb uc-icon[name="badge-success"]'), { timeout: 20_000 })
+      .toBeTruthy();
+    await expect
+      .poll(() => document.querySelector('uc-file-item .uc-inner')?.hasAttribute('data-finished'), { timeout: 20_000 })
+      .toBe(true);
+  }, 30_000);
+
+  it('removes the entry when the remove action is clicked: totalCount drops to 0 and the item unmounts', async () => {
+    const { api } = renderFileItemHost();
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+    await expect.element(page.getByTestId('uc-file-item')).toBeVisible();
+
+    const removeBtn = page.getByRole('button', { name: 'Remove', exact: true });
+    await expect.element(removeBtn).toBeVisible();
+    await removeBtn.click();
+
+    await expect.poll(() => api.getOutputCollectionState().totalCount).toBe(0);
+    await expect.poll(() => fileItemEl()).toBeNull();
+  }, 30_000);
+
+  it('hides the file name in grid mode by default, and shows it when gridShowFileNames is true', async () => {
+    const { config, api } = renderFileItemHost();
+    config.filesViewMode = 'grid';
+    config.gridShowFileNames = false;
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+
+    await expect.element(page.getByTestId('uc-file-item')).toBeVisible();
+    await expect.poll(() => fileItemEl()?.getAttribute('mode')).toBe('grid');
+    await expect.poll(() => document.querySelector('uc-file-item .uc-file-name')?.hasAttribute('hidden')).toBe(true);
+
+    config.gridShowFileNames = true;
+    await expect.poll(() => document.querySelector('uc-file-item .uc-file-name')?.hasAttribute('hidden')).toBe(false);
+    await expect.element(page.getByText(TEST_IMAGE_NAME)).toBeVisible();
+  });
+
+  it('renders a plugin-registered file action and passes the output entry to onClick', async () => {
+    const onClick = vi.fn<(entry: OutputFileEntry) => void>();
+    const plugin: UploaderPlugin = {
+      id: 'fa-file-item-parity',
+      setup: ({ pluginApi }) => {
+        pluginApi.registry.registerFileAction({
+          id: 'file-item-parity-action',
+          icon: 'default',
+          label: 'Parity Action',
+          shouldRender: () => true,
+          onClick,
+        });
+      },
+    };
+
+    const { api } = renderFileItemHost([plugin]);
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+
+    const actionBtnSelector = 'uc-file-item [data-plugin-action-id="file-item-parity-action"]';
+    await expect.poll(() => document.querySelector(actionBtnSelector), { timeout: 20_000 }).toBeTruthy();
+
+    (document.querySelector(actionBtnSelector) as HTMLButtonElement).click();
+
+    await vi.waitFor(() => {
+      expect(onClick).toHaveBeenCalledOnce();
+      const entry = onClick.mock.calls[0][0];
+      expect(entry).toHaveProperty('internalId');
+      expect(entry).toHaveProperty('status');
+    });
+  }, 30_000);
+});

--- a/tests/blocks/file-item.e2e.test.tsx
+++ b/tests/blocks/file-item.e2e.test.tsx
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { Config, FileItem, OutputFileEntry, UploadCtxProvider, UploaderPlugin } from '@/index.ts';
+import type { Uid } from '../../src/lit/Uid';
 import { TEST_IMAGE_URL } from '../utils/constants';
 import { getCtxName } from '../utils/getCtxName';
 import '../../types/jsx';
@@ -33,6 +34,21 @@ const renderFileItemHost = (plugins: UploaderPlugin[] = []) => {
 };
 
 const fileItemEl = () => document.querySelector('uc-file-item') as FileItem | null;
+
+// Standalone-block composition (same shape as tests/blocks/thumb.e2e.test.tsx)
+// for the uploader-scope-free regression case, which needs no upload
+// collection / uploader block at all.
+const renderStandaloneFileItem = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-item ctx-name={ctxName}></uc-file-item>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const fileItem = document.querySelector('uc-file-item')! as FileItem;
+  return { ctxName, fileItem };
+};
 
 describe('uc-file-item (parity, real upload flow)', () => {
   it('renders with the file name visible in list mode and a "mode" attribute reflecting the view mode', async () => {
@@ -131,4 +147,40 @@ describe('uc-file-item (parity, real upload flow)', () => {
       expect(entry).toHaveProperty('status');
     });
   }, 30_000);
+
+  // M9e regression — `*pluginManager` is registered by any LitBlock, so
+  // `bag.when('pluginManager', ...)` fires synchronously during
+  // `controllerReady`, driving `_updatePluginFileActions()` →
+  // `this.bag.api.getOutputItem(this.uid)`. `*publicApi` is uploader-scope-only
+  // (registered by an uploader block), so a `<uc-file-item>` rendered outside
+  // that scope (e.g. alongside a bare `<uc-config>`, no uploader block) must
+  // fall back gracefully instead of throwing an unhandled error from the
+  // required-getter read.
+  it('renders without unhandled errors when given a uid outside an uploader scope', async () => {
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+
+    try {
+      const { fileItem } = renderStandaloneFileItem();
+      // Let the IntersectionObserver-gated render open before assigning `uid` —
+      // a uid write while the gate is still closed doesn't surface in the next
+      // `willUpdate`'s changedProperties (see ChildBlock's render-gate note).
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      fileItem.uid = 'some-uid' as Uid;
+
+      await fileItem.updateComplete;
+      // Give any async/microtask-scheduled throw a moment to surface as an
+      // unhandled window error before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 200));
+      expect(fileItem.isConnected).toBe(true);
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+
+    expect(errors).toEqual([]);
+  });
 });

--- a/tests/blocks/primary-action.e2e.test.tsx
+++ b/tests/blocks/primary-action.e2e.test.tsx
@@ -93,6 +93,17 @@ describe('uc-primary-action', () => {
     await expect.poll(buttonText).toBe('3 files uploaded');
   });
 
+  it('renders the header-total text for idle entries with totalCount > 0 (not uploading/failed/success)', async () => {
+    // `_headerTextDependentOnEntries` (src/blocks/DynamicBtn/PrimaryAction.ts)
+    // only special-cases `status` 'uploading' | 'failed' | 'success'; any
+    // other status (e.g. 'idle') with `totalCount > 0` falls through to the
+    // `header-total` l10n key: '{{count}} {{plural:file(count)}} selected'.
+    const { btn } = renderPrimaryAction();
+    btn.entries = { status: 'idle', totalCount: 2, allEntries: [{}, {}] } as unknown as Entries;
+
+    await expect.poll(buttonText).toBe('2 files selected');
+  });
+
   it('renders the source icon when dynamicButtonShowFirstIcon is truthy and there are no entries', async () => {
     const { config, btn } = renderPrimaryAction();
     config.dynamicButtonShowFirstIcon = true;

--- a/tests/blocks/primary-action.e2e.test.tsx
+++ b/tests/blocks/primary-action.e2e.test.tsx
@@ -19,6 +19,21 @@ beforeAll(async () => {
 // cast is narrowed to the public `OutputCollectionState` shape (not `any`).
 type Entries = OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
 
+// Fixture helper: every call site above only ever sets the subset of
+// `Entries` fields `PrimaryAction` reads (see comment above), with
+// `allEntries` items shaped as plain `{}` / partial objects rather than full
+// `OutputFileEntry`s — so `Partial<Pick<...>>` still can't satisfy the full
+// discriminated-union `Entries` type. The single narrow cast lives here
+// instead of being repeated (as `as unknown as Entries`) at every call site.
+const makeEntries = (
+  partial: Partial<
+    Pick<
+      Entries,
+      'status' | 'totalCount' | 'allEntries' | 'uploadingCount' | 'failedCount' | 'successCount' | 'isSuccess'
+    >
+  >,
+): Entries => partial as Entries;
+
 // Booleans are driven as JS properties on `config` after render (same pattern
 // as tests/blocks/simple-btn.e2e.test.tsx's `config.multiple = false`), not as
 // JSX attributes: the render-jsx `CommonDOMRenderer` maps a `false`-valued JSX
@@ -60,7 +75,7 @@ describe('uc-primary-action', () => {
     const onClick = vi.fn();
     const source: SourceButtonConfig = { id: 'local', label: 'src-type-local', onClick };
     btn.source = source;
-    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+    btn.entries = makeEntries({ totalCount: 0, allEntries: [] });
 
     await expect.poll(buttonText).toBe('Upload from device');
     expect(ariaLabel()).toBe('Upload from device');
@@ -68,27 +83,27 @@ describe('uc-primary-action', () => {
 
   it('renders the header-uploading text with count while uploading', async () => {
     const { btn } = renderPrimaryAction();
-    btn.entries = { status: 'uploading', uploadingCount: 2, allEntries: [{}], totalCount: 2 } as unknown as Entries;
+    btn.entries = makeEntries({ status: 'uploading', uploadingCount: 2, allEntries: [{}], totalCount: 2 });
 
     await expect.poll(buttonText).toBe('Uploading 2 files');
   });
 
   it('renders the header-failed text with count when failed', async () => {
     const { btn } = renderPrimaryAction();
-    btn.entries = { status: 'failed', failedCount: 1, allEntries: [{}], totalCount: 1 } as unknown as Entries;
+    btn.entries = makeEntries({ status: 'failed', failedCount: 1, allEntries: [{}], totalCount: 1 });
 
     await expect.poll(buttonText).toBe('1 error');
   });
 
   it('renders the header-succeed text with count on success', async () => {
     const { btn } = renderPrimaryAction();
-    btn.entries = {
+    btn.entries = makeEntries({
       status: 'success',
       successCount: 3,
       allEntries: [{}, {}, {}],
       isSuccess: true,
       totalCount: 3,
-    } as unknown as Entries;
+    });
 
     await expect.poll(buttonText).toBe('3 files uploaded');
   });
@@ -99,7 +114,7 @@ describe('uc-primary-action', () => {
     // other status (e.g. 'idle') with `totalCount > 0` falls through to the
     // `header-total` l10n key: '{{count}} {{plural:file(count)}} selected'.
     const { btn } = renderPrimaryAction();
-    btn.entries = { status: 'idle', totalCount: 2, allEntries: [{}, {}] } as unknown as Entries;
+    btn.entries = makeEntries({ status: 'idle', totalCount: 2, allEntries: [{}, {}] });
 
     await expect.poll(buttonText).toBe('2 files selected');
   });
@@ -108,7 +123,7 @@ describe('uc-primary-action', () => {
     const { config, btn } = renderPrimaryAction();
     config.dynamicButtonShowFirstIcon = true;
     btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
-    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+    btn.entries = makeEntries({ totalCount: 0, allEntries: [] });
 
     await expect.poll(iconName).toBe('my-icon');
   });
@@ -117,7 +132,7 @@ describe('uc-primary-action', () => {
     const { config, btn } = renderPrimaryAction();
     config.dynamicButtonShowFirstIcon = false;
     btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
-    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+    btn.entries = makeEntries({ totalCount: 0, allEntries: [] });
 
     await expect.poll(buttonText).toBe('Upload from device');
     expect(iconEl()).toBeNull();
@@ -127,13 +142,13 @@ describe('uc-primary-action', () => {
     const { config, btn } = renderPrimaryAction();
     config.multiple = false;
     await expect.poll(() => config.multiple).toBe(false);
-    btn.entries = {
+    btn.entries = makeEntries({
       status: 'success',
       successCount: 1,
       isSuccess: true,
       totalCount: 1,
       allEntries: [{ isImage: true, internalId: 'test-uid' }],
-    } as unknown as Entries;
+    });
 
     await expect.poll(() => thumbEl()).toBeTruthy();
   });
@@ -143,13 +158,13 @@ describe('uc-primary-action', () => {
     config.multiple = true;
     config.dynamicButtonShowFirstIcon = true;
     btn.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
-    btn.entries = {
+    btn.entries = makeEntries({
       status: 'success',
       successCount: 1,
       isSuccess: true,
       totalCount: 1,
       allEntries: [{ isImage: true, internalId: 'test-uid' }],
-    } as unknown as Entries;
+    });
 
     await expect.poll(buttonText).toBe('1 file uploaded');
     expect(thumbEl()).toBeNull();
@@ -160,7 +175,7 @@ describe('uc-primary-action', () => {
     const { btn } = renderPrimaryAction();
     const onClick = vi.fn();
     btn.source = { id: 'local', label: 'src-type-local', onClick };
-    btn.entries = { totalCount: 0, allEntries: [] } as unknown as Entries;
+    btn.entries = makeEntries({ totalCount: 0, allEntries: [] });
     await expect.poll(buttonText).toBe('Upload from device');
 
     (document.querySelector('uc-primary-action button') as HTMLButtonElement).click();
@@ -171,13 +186,13 @@ describe('uc-primary-action', () => {
     const { btn } = renderPrimaryAction();
     const onClick = vi.fn();
     btn.source = { id: 'local', label: 'src-type-local', onClick };
-    btn.entries = {
+    btn.entries = makeEntries({
       status: 'success',
       successCount: 1,
       isSuccess: true,
       totalCount: 1,
       allEntries: [{ isImage: false, internalId: 'test-uid' }],
-    } as unknown as Entries;
+    });
     await expect.poll(buttonText).toBe('1 file uploaded');
 
     // `_handleClick` is synchronous and branches on `hasEntries` before ever

--- a/tests/blocks/primary-action.e2e.test.tsx
+++ b/tests/blocks/primary-action.e2e.test.tsx
@@ -27,11 +27,8 @@ type Entries = OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
 // instead of being repeated (as `as unknown as Entries`) at every call site.
 const makeEntries = (
   partial: Partial<
-    Pick<
-      Entries,
-      'status' | 'totalCount' | 'allEntries' | 'uploadingCount' | 'failedCount' | 'successCount' | 'isSuccess'
-    >
-  >,
+    Pick<Entries, 'status' | 'totalCount' | 'uploadingCount' | 'failedCount' | 'successCount' | 'isSuccess'>
+  > & { allEntries?: Array<Partial<Entries['allEntries'][number]>> },
 ): Entries => partial as Entries;
 
 // Booleans are driven as JS properties on `config` after render (same pattern

--- a/tests/blocks/progress-bar.e2e.test.tsx
+++ b/tests/blocks/progress-bar.e2e.test.tsx
@@ -104,4 +104,24 @@ describe('uc-progress-bar', () => {
     fakeLine().dispatchEvent(new Event('animationiteration'));
     await expect.poll(() => fakeLine().classList.contains('uc-fake-progress--hidden')).toBe(true);
   });
+
+  it('applies visibility while the render gate was still closed', async () => {
+    const ctxName = getCtxName();
+    // Mount the bar BEFORE any ctx exists, then set properties — the
+    // scheduled update flushes gated, so Lit clears changedProperties.
+    const bar = document.createElement('uc-progress-bar');
+    bar.setAttribute('ctx-name', ctxName);
+    document.body.append(bar);
+    await bar.updateComplete;
+    bar.visible = false;
+    bar.value = 30;
+    await bar.updateComplete;
+
+    // Now create the ctx; the bar adopts and must reflect the hidden state
+    // it was given pre-adoption, not the stale defaults.
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    await expect.poll(() => bar.classList.contains('uc-progress-bar--hidden')).toBe(true);
+    await expect.poll(() => progressVar(bar)).toBe('');
+    bar.remove();
+  });
 });

--- a/tests/blocks/thumb.e2e.test.tsx
+++ b/tests/blocks/thumb.e2e.test.tsx
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 import { page } from 'vitest/browser';
 import type { Config, Thumb, UploadCtxProvider } from '@/index.ts';
+import type { Uid } from '../../src/lit/Uid';
 import { TRANSPARENT_PIXEL_SRC } from '../../src/utils/transparentPixelSrc';
 import { TEST_IMAGE_URL } from '../utils/constants';
 import { getCtxName } from '../utils/getCtxName';
@@ -92,6 +93,36 @@ describe('uc-thumb (parity, real upload flow)', () => {
       renderStandaloneThumb();
       await expect.element(page.getByTestId('uc-thumb')).toBeInTheDocument();
       await expect.poll(() => thumbImg()?.getAttribute('src')).toBe(TRANSPARENT_PIXEL_SRC);
+      expect(thumbImg()?.hasAttribute('hidden')).toBe(true);
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+
+    expect(errors).toEqual([]);
+  });
+
+  // M9e regression — the ChildBlock port made `*uploadCollection` a required
+  // getter; a thumb rendered outside any uploader-block scope (e.g. the
+  // primary-action parity suite, which mounts a bare `<uc-thumb>` alongside
+  // `<uc-config>` with no uploader/ctx-provider) has no collection registered,
+  // so a truthy `uid` must fall back gracefully instead of throwing from
+  // `_bindToEntry`.
+  it('renders the fallback without unhandled errors when given a uid outside an uploader scope', async () => {
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+
+    try {
+      const { thumb } = renderStandaloneThumb();
+      thumb.uid = 'some-uid' as Uid;
+
+      await thumb.updateComplete;
+      // Give any async/microtask-scheduled throw a moment to surface as an
+      // unhandled window error before asserting.
+      await expect.poll(() => thumbImg()?.getAttribute('src'), { timeout: 2_000 }).toBe(TRANSPARENT_PIXEL_SRC);
       expect(thumbImg()?.hasAttribute('hidden')).toBe(true);
     } finally {
       window.removeEventListener('error', onError);

--- a/tests/blocks/thumb.e2e.test.tsx
+++ b/tests/blocks/thumb.e2e.test.tsx
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, Thumb, UploadCtxProvider } from '@/index.ts';
+import { TRANSPARENT_PIXEL_SRC } from '../../src/utils/transparentPixelSrc';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+// M9e Task 2 — additive parity e2e pinning current v1 `uc-thumb` behavior
+// ahead of the FileItem/Thumb family port.
+
+const renderUploadHost = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const provider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+  return { ctxName, config, api: provider.api };
+};
+
+// Standalone-block composition (same shape as tests/blocks/progress-bar.e2e.test.tsx
+// / spinner.e2e.test.tsx) for the entry-less Thumb cases, which need no upload
+// collection at all.
+const renderStandaloneThumb = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-thumb ctx-name={ctxName}></uc-thumb>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+    </>,
+  );
+  const thumb = document.querySelector('uc-thumb')! as Thumb;
+  return { ctxName, thumb };
+};
+
+const thumbImg = () => document.querySelector('uc-thumb img.uc-thumb__img') as HTMLImageElement | null;
+
+describe('uc-thumb (parity, real upload flow)', () => {
+  it('gains a non-transparent img src and un-hides after a successful image upload', async () => {
+    const { api } = renderUploadHost();
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    // `initFlow()` opens the modal (same call the "Upload files" button
+    // issues); without it the item exists in the DOM but its
+    // IntersectionObserver never reports intersecting while the dialog is
+    // closed, so the thumb never renders.
+    api.initFlow();
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+
+    await expect
+      .poll(
+        () => (thumbImg()?.hasAttribute('src') ? thumbImg()!.getAttribute('src') !== TRANSPARENT_PIXEL_SRC : false),
+        {
+          timeout: 20_000,
+        },
+      )
+      .toBe(true);
+    await expect.poll(() => thumbImg()?.hasAttribute('hidden'), { timeout: 20_000 }).toBe(false);
+  }, 30_000);
+
+  it('reflects the badgeIcon property into the badge uc-icon name', async () => {
+    const { thumb } = renderStandaloneThumb();
+
+    await expect.poll(() => document.querySelector('uc-thumb .uc-badge uc-icon')).toBeTruthy();
+    thumb.badgeIcon = 'badge-success';
+
+    await expect
+      .poll(() => document.querySelector('uc-thumb .uc-badge uc-icon')?.getAttribute('name'))
+      .toBe('badge-success');
+  });
+
+  it('renders the transparent-pixel img without errors when mounted standalone with no entry', async () => {
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+
+    try {
+      renderStandaloneThumb();
+      await expect.element(page.getByTestId('uc-thumb')).toBeInTheDocument();
+      await expect.poll(() => thumbImg()?.getAttribute('src')).toBe(TRANSPARENT_PIXEL_SRC);
+      expect(thumbImg()?.hasAttribute('hidden')).toBe(true);
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+
+    expect(errors).toEqual([]);
+  });
+});

--- a/types/jsx.d.ts
+++ b/types/jsx.d.ts
@@ -4,6 +4,7 @@ type LitElement = import('lit').LitElement;
 type UploadCtxProvider = import('../dist/index.ts').UploadCtxProvider;
 type Config = import('../dist/index.ts').Config;
 type Copyright = import('../dist/index.ts').Copyright;
+type Thumb = import('../dist/index.ts').Thumb;
 type FileUploaderInline = import('../dist/index.ts').FileUploaderInline;
 type FileUploaderRegular = import('../dist/index.ts').FileUploaderRegular;
 type FileUploaderMinimal = import('../dist/index.ts').FileUploaderMinimal;
@@ -80,6 +81,7 @@ declare namespace JSX {
     'uc-source-btn': CustomElement<SourceBtn>;
     'uc-source-list': CustomElement<SourceList>;
     'uc-file-item': CustomElement<FileItem>;
+    'uc-thumb': CustomElement<Thumb>;
     'uc-modal': CustomElement<Modal>;
     'uc-upload-list': CustomElement<UploadList>;
     'uc-url-source': CustomElement<UrlSource>;


### PR DESCRIPTION
Fifth slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7). The entry-coupled family moves atomically (both leaves extend `FileItemConfig`), bringing the count to **13 blocks on `ChildBlock`**.

## Coverage first (AGENTS.md #1)
- `proxyUrl` (secure-delivery resolution) extracted verbatim to DOM-free `src/abstract/secureDeliveryProxyUrl.ts` (100% unit coverage); `LitBlock` and `ChildBlock` both delegate — signatures unchanged.
- New parity e2e for FileItem (5) and Thumb (3) via real upload flows, plus the `header-total` case — written pre-port, kept green unchanged.

## Ports
- **FileItemConfig** — base swap only (entry-subscription plumbing byte-identical). **FileActionButton** — swap + locale re-render subscription.
- **FileItem** — 8 bag rewires, plugin actions via `bag.when('pluginManager')`, `*uploadTrigger` via the ctx facade sub, uid re-derive in `controllerReady` (port-checklist rule); `shouldUpdate`/IntersectionObserver render pause untouched.
- **Thumb** — bag rewires + inherited `proxyUrl`; **disclosed intentional fix:** `_firstViewMode` now captures on adoption (v1's construction-time read was accidentally `undefined` in the common template-rendered path — order-dependent, same class as M8's `*solution` finding).

## Hardenings (M9d carry-overs + review-driven)
- ProgressBar `visible` pre-adoption re-derive (TDD; plus an unconditional `_progressValue` re-sync covering re-adoption, caught in review of the plan's own prescribed code).
- **Two review/gate-caught regressions fixed with RED-confirmed tests:** as `LitUploaderBlock`s, Thumb/FileItem used to self-register the uploader-scope shared instances; as `ChildBlock`s in uploader-block-free compositions, required bag getters (`*uploadCollection`, then `*publicApi` one review later) threw as unhandled errors. Both reads now tolerate a missing scope (v1's `?.` intent): no scope → fallback render / no actions. Standalone regression tests for both blocks.
- Icon safety comment; `makeEntries` fixture helper retiring the `as unknown as` casts.

Follow-up queued (M9f): systematize the scope-guard seam (`bag.*OrNull` getters / `hasUploaderScope`), isolate-and-warn around `controllerReady` in `_adoptController`, and the has-true/value-null teardown window the review noted on the guard idiom.

## Gate
tsc:app ✅ build ✅ specs 584 ✅ locales ✅ e2e 273/273, exit 0 ✅ lint ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added secure delivery proxy support for CDN URLs, including configurable resolver-based URL resolution and template-based proxying.
* **Bug Fixes**
  * Improved component resilience and state synchronization when adopted or rendered outside an uploader context (including progress bar, thumbs, and file items).
  * Enhanced error reporting/telemetry when URL proxy resolution fails.
  * Improved uploader-scope handling for plugin file actions and entry removal flow.
* **Tests**
  * Added and expanded end-to-end coverage for file items, thumbnails, progress bar hidden/visible state, and primary action entry rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->