### PR TITLE
feat(m9f): ChildBlock hardening + activity foundation + StartFrom/ActivityHeader ports

### DIFF
--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -450,7 +450,12 @@ export class UploaderPublicApi extends SharedInstance {
         {
           onTimeout: () => console.warn(`Activity block "${activityType}" not found in the context`),
         },
-      ).then(() => {
+      ).then((found) => {
+        if (!found) {
+          // Timeout — the activity's block never appeared; keep the modal
+          // closed (same observable behavior as before the promise settled).
+          return;
+        }
         router.openModal(activityType);
       });
     });

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -5,9 +5,7 @@ import { CameraSourceTypes, type ModeCameraType } from '../blocks/CameraSource/c
 import { type EventKey, type EventPayload, EventType } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { ActivityParamsMap, ActivityType } from '../lit/activity-constants';
 import { ACTIVITY_TYPES } from '../lit/activity-constants';
-import { waitForBlockInCtx } from '../lit/hasBlockInCtx';
-import type { LitActivityBlock } from '../lit/LitActivityBlock';
-import type { LitBlock } from '../lit/LitBlock';
+import { waitForActivityBlock } from '../lit/hasBlockInCtx';
 import { createL10n } from '../lit/l10n';
 import { SharedInstance } from '../lit/shared-instances';
 import type { Uid } from '../lit/Uid';
@@ -38,13 +36,6 @@ export type ApiAddFileCommonOptions = {
   fileName?: string;
   source?: string;
 };
-
-/**
- * Narrows a registry block to a {@link LitActivityBlock}. Non-activity blocks
- * (config, form-input, sources, …) carry no `activityType`, so this filters
- * them out instead of blindly casting and reading `undefined`.
- */
-const isActivityBlock = (block: LitBlock): block is LitActivityBlock => 'activityType' in block;
 
 export class UploaderPublicApi extends SharedInstance {
   private _l10n = createL10n(() => this._ctx);
@@ -378,14 +369,10 @@ export class UploaderPublicApi extends SharedInstance {
     void this._pluginsReady().then(() => {
       this._sharedInstancesBag.router.navigate(activityType, params[0] ?? {});
       if (activityType !== null) {
-        waitForBlockInCtx(
-          this._sharedInstancesBag.blocksRegistry,
-          (b) => isActivityBlock(b) && b.activityType === activityType,
-          {
-            onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
-            timeout: 100,
-          },
-        );
+        waitForActivityBlock(this._sharedInstancesBag.blocksRegistry, this._sharedInstancesBag.router, activityType, {
+          onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
+          timeout: 100,
+        });
       }
     });
   };
@@ -413,14 +400,10 @@ export class UploaderPublicApi extends SharedInstance {
         return;
       }
       this._sharedInstancesBag.router.setActivity(activityType, params[0]);
-      waitForBlockInCtx(
-        this._sharedInstancesBag.blocksRegistry,
-        (b) => isActivityBlock(b) && b.activityType === activityType,
-        {
-          onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
-          timeout: 100,
-        },
-      );
+      waitForActivityBlock(this._sharedInstancesBag.blocksRegistry, this._sharedInstancesBag.router, activityType, {
+        onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
+        timeout: 100,
+      });
     });
   };
 
@@ -460,9 +443,10 @@ export class UploaderPublicApi extends SharedInstance {
         return;
       }
 
-      return waitForBlockInCtx(
+      return waitForActivityBlock(
         this._sharedInstancesBag.blocksRegistry,
-        (b) => isActivityBlock(b) && b.activityType === activityType,
+        this._sharedInstancesBag.router,
+        activityType,
         {
           onTimeout: () => console.warn(`Activity block "${activityType}" not found in the context`),
         },

--- a/src/abstract/controllers/RouterController.test.ts
+++ b/src/abstract/controllers/RouterController.test.ts
@@ -627,6 +627,54 @@ describe('RouterController (v2)', () => {
     });
   });
 
+  describe('mounted activities', () => {
+    it('reports a mounted activity as present', () => {
+      const { router } = setup();
+
+      router.activityBlockMounted('start-from');
+
+      expect(router.hasMountedActivity('start-from')).toBe(true);
+      expect(router.hasMountedActivity('camera')).toBe(false);
+    });
+
+    it('notifies subscribers on mount and on unmount', () => {
+      const { router } = setup();
+      const onChange = vi.fn();
+      router.subscribe(onChange);
+
+      const release = router.activityBlockMounted('start-from');
+      expect(onChange).toHaveBeenCalledTimes(1);
+
+      release();
+      expect(onChange).toHaveBeenCalledTimes(2);
+    });
+
+    it('refcounts — stays mounted while any slot still holds it, clears once all release', () => {
+      const { router } = setup();
+
+      const releaseA = router.activityBlockMounted('start-from');
+      const releaseB = router.activityBlockMounted('start-from');
+      expect(router.hasMountedActivity('start-from')).toBe(true);
+
+      releaseA();
+      expect(router.hasMountedActivity('start-from')).toBe(true); // second slot still mounted
+
+      releaseB();
+      expect(router.hasMountedActivity('start-from')).toBe(false);
+    });
+
+    it('releasing is idempotent — calling the same release fn twice does not under-count', () => {
+      const { router } = setup();
+
+      const releaseA = router.activityBlockMounted('start-from');
+      router.activityBlockMounted('start-from');
+
+      releaseA();
+      releaseA(); // double-release must not double-decrement
+      expect(router.hasMountedActivity('start-from')).toBe(true);
+    });
+  });
+
   describe('destroy', () => {
     it('clears registered guards', () => {
       const { router } = setup();

--- a/src/abstract/controllers/RouterController.ts
+++ b/src/abstract/controllers/RouterController.ts
@@ -163,6 +163,34 @@ export class RouterController {
     }
   }
 
+  // ─── Mounted activities ───
+
+  // Mounted-activity signal: ported activity blocks (ActivityChildBlock)
+  // report themselves here on adoption/release, replacing their former
+  // membership in the v1 `*blocksRegistry` for "is this activity's block
+  // mounted?" waits. Refcounted — the same activityType can be mounted in
+  // several slots at once (e.g. minimal's two <uc-start-from>).
+  private _mountedActivities = new Map<string, number>();
+
+  /** Report a mounted activity block. Returns the matching un-mount call. */
+  public activityBlockMounted(activityType: string): () => void {
+    this._mountedActivities.set(activityType, (this._mountedActivities.get(activityType) ?? 0) + 1);
+    this._listeners.notify();
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      const next = (this._mountedActivities.get(activityType) ?? 1) - 1;
+      if (next <= 0) this._mountedActivities.delete(activityType);
+      else this._mountedActivities.set(activityType, next);
+      this._listeners.notify();
+    };
+  }
+
+  public hasMountedActivity(activityType: string): boolean {
+    return this._mountedActivities.has(activityType);
+  }
+
   // ─── Hooks ───
   /**
    * Register interceptors for navigation intents. A hook may redirect (return
@@ -445,6 +473,7 @@ export class RouterController {
   public destroy(): void {
     this._listeners.clear();
     this._guards.clear();
+    this._mountedActivities.clear();
     this._hooks = { beforeChange: [], onFileAdd: [], onBack: [], onCancel: [], onClose: [], onDone: [] };
   }
 }

--- a/src/blocks/ActivityHeader/ActivityHeader.ts
+++ b/src/blocks/ActivityHeader/ActivityHeader.ts
@@ -1,7 +1,7 @@
-import { LitActivityBlock } from '../../lit/LitActivityBlock';
+import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import './activity-header.css';
 
-export class ActivityHeader extends LitActivityBlock {}
+export class ActivityHeader extends ActivityChildBlock {}
 
 declare global {
   interface HTMLElementTagNameMap {

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -93,9 +93,10 @@ export class FileItem extends FileItemConfig {
       },
     });
 
-    if (this.uid && this.bag.uploadCollectionOrNull?.hasItem(this.uid)) {
+    const collection = this.bag.uploadCollectionOrNull;
+    if (this.uid && collection?.hasItem(this.uid)) {
       this.entry?.getValue('abortController')?.abort();
-      this.bag.uploadCollectionOrNull.remove(this.uid);
+      collection.remove(this.uid);
     }
   };
 

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -93,9 +93,9 @@ export class FileItem extends FileItemConfig {
       },
     });
 
-    if (this.uid && this.bag.ctx.has('*uploadCollection') && this.bag.uploadCollection.hasItem(this.uid)) {
+    if (this.uid && this.bag.uploadCollectionOrNull?.hasItem(this.uid)) {
       this.entry?.getValue('abortController')?.abort();
-      this.bag.uploadCollection.remove(this.uid);
+      this.bag.uploadCollectionOrNull.remove(this.uid);
     }
   };
 
@@ -203,7 +203,7 @@ export class FileItem extends FileItemConfig {
     this.reset();
 
     // The uploader-scope shared instances exist only once an uploader block initializes this ctx.
-    const entry = this.bag.ctx.has('*uploadCollection') ? this.bag.uploadCollection.read(id) : null;
+    const entry = this.bag.uploadCollectionOrNull?.read(id) ?? null;
     this.entry = entry;
 
     if (!entry) {
@@ -281,13 +281,14 @@ export class FileItem extends FileItemConfig {
     }
 
     // The uploader-scope shared instances exist only once an uploader block initializes this ctx.
-    if (!this.bag.ctx.has('*publicApi')) {
+    const api = this.bag.apiOrNull;
+    if (!api) {
       this._pluginFileActions = [];
       return;
     }
 
     const allFileActions = pluginManager.snapshot().fileActions;
-    const outputFileEntry = this.bag.api.getOutputItem(this.uid);
+    const outputFileEntry = api.getOutputItem(this.uid);
 
     if (!outputFileEntry) {
       this._pluginFileActions = [];
@@ -309,7 +310,12 @@ export class FileItem extends FileItemConfig {
       return;
     }
 
-    const outputFileEntry = this.bag.api.getOutputItem(this.uid);
+    const api = this.bag.apiOrNull;
+    if (!api) {
+      return;
+    }
+
+    const outputFileEntry = api.getOutputItem(this.uid);
     if (!outputFileEntry) {
       return;
     }

--- a/src/blocks/StartFrom/StartFrom.ts
+++ b/src/blocks/StartFrom/StartFrom.ts
@@ -1,9 +1,9 @@
 import './start-from.css';
 import { html } from 'lit';
+import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import { ACTIVITY_TYPES, type ActivityType } from '../../lit/activity-constants';
-import { LitActivityBlock } from '../../lit/LitActivityBlock';
 
-export class StartFrom extends LitActivityBlock {
+export class StartFrom extends ActivityChildBlock {
   public override activityType: ActivityType = ACTIVITY_TYPES.START_FROM;
 
   public override render() {

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -308,8 +308,7 @@ export class Thumb extends FileItemConfig {
     // The uploader-scope shared instances exist only once an uploader block
     // initializes this ctx — a thumb rendered outside that scope (e.g. an
     // isolated composition) has no collection and therefore no entry.
-    const collection = this.bag.ctx.has('*uploadCollection') ? this.bag.uploadCollection : null;
-    const entry = collection?.read(id);
+    const entry = this.bag.uploadCollectionOrNull?.read(id);
     if (!entry) {
       // The uid no longer resolves (entry removed, scope lost, or uid swapped
       // to an unknown id) — drop the previous entry's subscriptions and image

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -27,6 +27,9 @@ export class ActivityChildBlock extends ChildBlock {
     }
     // Re-render on every router transition so `updated()` re-evaluates the slot.
     this.subRouter(() => this.requestUpdate());
+    // Report this activity as mounted so API waits (navigate/setModalState)
+    // can find it now that ported blocks are not in `*blocksRegistry`.
+    this.trackSub(this.bag.router.activityBlockMounted(this.activityType));
   }
 
   /** Whether this block's activity currently owns its slot. */

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -1,0 +1,53 @@
+import type { PropertyValues } from 'lit';
+import type { UploaderController } from '../abstract/controllers/UploaderController';
+import { ACTIVITY_TYPES, type ActivityParamsMap, type ActivityType } from './activity-constants';
+import { ChildBlock } from './ChildBlock';
+
+const ACTIVE_ATTR = 'active';
+
+/**
+ * Base for activity blocks ported off `LitActivityBlock` (M9). A subclass
+ * declares its `activityType`; the base reflects the `activity` attribute and
+ * toggles `[active]` whenever the block's slot owns the current transition.
+ * Slot is chosen by DOM location: inside `<uc-modal>` tracks the foreground
+ * slot (`router.modal`), otherwise the background slot (`router.activity`).
+ * Subclasses overriding `controllerReady` MUST call `super.controllerReady(ctrl)`.
+ */
+export class ActivityChildBlock extends ChildBlock {
+  public activityType: ActivityType = null;
+
+  public static activities = ACTIVITY_TYPES;
+
+  protected override controllerReady(_ctrl: UploaderController): void {
+    if (!this.activityType) {
+      return;
+    }
+    if (!this.hasAttribute('activity')) {
+      this.setAttribute('activity', this.activityType);
+    }
+    // Re-render on every router transition so `updated()` re-evaluates the slot.
+    this.subRouter(() => this.requestUpdate());
+  }
+
+  /** Whether this block's activity currently owns its slot. */
+  protected get isActivityActive(): boolean {
+    if (!this.activityType) {
+      return false;
+    }
+    const router = this.bag.router;
+    const isInModal = this.closest('uc-modal') !== null;
+    const slot = isInModal ? router.modal : router.activity;
+    return slot === this.activityType;
+  }
+
+  protected override updated(changed: PropertyValues<this>): void {
+    super.updated(changed);
+    if (this.activityType) {
+      this.toggleAttribute(ACTIVE_ATTR, this.isActivityActive);
+    }
+  }
+
+  public get activityParams(): ActivityParamsMap[keyof ActivityParamsMap] {
+    return this.bag.router.params as ActivityParamsMap[keyof ActivityParamsMap];
+  }
+}

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -178,7 +178,14 @@ export abstract class ChildBlock extends ChildBlockBase {
     }
     this._subs.push(ctrl.config.subscribe(() => this._syncTestId(ctrl)));
     this._syncTestId(ctrl);
-    this.controllerReady(ctrl);
+    try {
+      this.controllerReady(ctrl);
+    } catch (err) {
+      // One block's adoption hook must not break the adoption cycle or escape
+      // the registry callback as an unhandled error (isolate-and-warn, as in
+      // teardown and EventBus fan-out).
+      console.warn(`[uc] ${this.tagName.toLowerCase()}: controllerReady threw during adoption`, err);
+    }
     this.requestUpdate();
   }
 

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -5,6 +5,7 @@ import type { UploaderController } from '../abstract/controllers/UploaderControl
 import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import type { ConfigType } from '../types';
+import type { ActivityId } from './activity-constants';
 import { LightDomMixin } from './LightDomMixin';
 import { createL10n } from './l10n';
 import { PubSub } from './PubSubCompat';
@@ -234,6 +235,38 @@ export abstract class ChildBlock extends ChildBlockBase {
     const unsub = config.subscribe(() => {
       const next = config.get(key);
       if (!Object.is(next, last)) {
+        last = next;
+        callback(next);
+      }
+    });
+    this.trackSub(unsub);
+    return unsub;
+  }
+
+  /**
+   * Subscribe to *any* router change. Fires immediately, then on every
+   * notification — no value dedup. Auto-tracked. Call from `controllerReady`
+   * or later (`bag.router` requires the ctx).
+   */
+  protected subRouter(callback: () => void): () => void {
+    callback();
+    const unsub = this.bag.router.subscribe(callback);
+    this.trackSub(unsub);
+    return unsub;
+  }
+
+  /**
+   * Subscribe to the effective current activity (foreground modal, else
+   * background). Fires immediately with the current value, then on change
+   * (reference dedup). Auto-tracked.
+   */
+  protected subActivity(callback: (activity: ActivityId | null) => void): () => void {
+    const router = this.bag.router;
+    let last: ActivityId | null = router.currentActivity;
+    callback(last);
+    const unsub = router.subscribe(() => {
+      const next: ActivityId | null = router.currentActivity;
+      if (next !== last) {
         last = next;
         callback(next);
       }

--- a/src/lit/hasBlockInCtx.ts
+++ b/src/lit/hasBlockInCtx.ts
@@ -66,10 +66,12 @@ export const waitForActivityBlock = (
 
     const timer = setTimeout(() => {
       cancelAnimationFrame(rafId);
-      onTimeout?.();
       // Settle instead of leaving the promise pending forever (unlike the
       // legacy `waitForBlockInCtx`): callers gate on the resolved value.
+      // Resolve BEFORE the callback so a throwing `onTimeout` can't leave
+      // the promise pending.
       resolve(false);
+      onTimeout?.();
     }, timeout);
 
     const check = () => {

--- a/src/lit/hasBlockInCtx.ts
+++ b/src/lit/hasBlockInCtx.ts
@@ -1,5 +1,14 @@
+import type { RouterController } from '../abstract/controllers/RouterController';
+import type { LitActivityBlock } from './LitActivityBlock';
 import type { LitBlock } from './LitBlock';
 import type { BlocksRegistry } from './SharedState';
+
+/**
+ * Narrows a registry block to a {@link LitActivityBlock}. Non-activity blocks
+ * (config, form-input, sources, …) carry no `activityType`, so this filters
+ * them out instead of blindly casting and reading `undefined`.
+ */
+const isActivityBlock = (block: LitBlock): block is LitActivityBlock => 'activityType' in block;
 
 export const hasBlockInCtx = (blocksRegistry: BlocksRegistry, callback: (block: LitBlock) => boolean): boolean => {
   for (const block of blocksRegistry) {
@@ -30,6 +39,44 @@ export const waitForBlockInCtx = (
           resolve(block);
           return;
         }
+      }
+      rafId = requestAnimationFrame(check);
+    };
+
+    check();
+  });
+};
+
+/**
+ * Wait for an activity to be "mounted" — either as a ported
+ * `ActivityChildBlock` (reported through the router's mounted-activity
+ * signal, see `RouterController.activityBlockMounted`) or as a v1 block still
+ * living in `*blocksRegistry`. Replaces the `waitForBlockInCtx` + `isActivityBlock`
+ * pairing at the API's activity-wait call sites now that ported blocks are no
+ * longer registry members.
+ */
+export const waitForActivityBlock = (
+  blocksRegistry: BlocksRegistry,
+  router: RouterController,
+  activityType: string,
+  { timeout = 1000, onTimeout }: { timeout?: number; onTimeout?: () => void } = {},
+): Promise<void> => {
+  return new Promise((resolve) => {
+    let rafId: ReturnType<typeof requestAnimationFrame>;
+
+    const timer = setTimeout(() => {
+      cancelAnimationFrame(rafId);
+      onTimeout?.();
+    }, timeout);
+
+    const check = () => {
+      const found =
+        router.hasMountedActivity(activityType) ||
+        hasBlockInCtx(blocksRegistry, (b) => isActivityBlock(b) && b.activityType === activityType);
+      if (found) {
+        clearTimeout(timer);
+        resolve();
+        return;
       }
       rafId = requestAnimationFrame(check);
     };

--- a/src/lit/hasBlockInCtx.ts
+++ b/src/lit/hasBlockInCtx.ts
@@ -60,13 +60,16 @@ export const waitForActivityBlock = (
   router: RouterController,
   activityType: string,
   { timeout = 1000, onTimeout }: { timeout?: number; onTimeout?: () => void } = {},
-): Promise<void> => {
+): Promise<boolean> => {
   return new Promise((resolve) => {
     let rafId: ReturnType<typeof requestAnimationFrame>;
 
     const timer = setTimeout(() => {
       cancelAnimationFrame(rafId);
       onTimeout?.();
+      // Settle instead of leaving the promise pending forever (unlike the
+      // legacy `waitForBlockInCtx`): callers gate on the resolved value.
+      resolve(false);
     }, timeout);
 
     const check = () => {
@@ -75,7 +78,7 @@ export const waitForActivityBlock = (
         hasBlockInCtx(blocksRegistry, (b) => isActivityBlock(b) && b.activityType === activityType);
       if (found) {
         clearTimeout(timer);
-        resolve();
+        resolve(true);
         return;
       }
       rafId = requestAnimationFrame(check);

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -164,6 +164,19 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
       return getSharedInstance(getCtx(), '*validationManager');
     },
 
+    /**
+     * Null-tolerant reads for the uploader-scope instances (registered only
+     * once an uploader block initializes the ctx, and pubbed `null` again at
+     * teardown — `ctx.has()` alone reports stale keys as present). Use these
+     * from blocks that may render outside an uploader scope.
+     */
+    get uploadCollectionOrNull(): UploadCollectionController | null {
+      return getSharedInstance(getCtx(), '*uploadCollection', false) ?? null;
+    },
+    get apiOrNull(): UploaderPublicApi | null {
+      return getSharedInstance(getCtx(), '*publicApi', false) ?? null;
+    },
+
     when<TName extends InstanceName>(
       name: TName,
       callback: (instance: NonNullable<InstanceTypeMap[TName]>) => void,

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -171,10 +171,20 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
      * from blocks that may render outside an uploader scope.
      */
     get uploadCollectionOrNull(): UploadCollectionController | null {
-      return getSharedInstance(getCtx(), '*uploadCollection', false) ?? null;
+      // `getCtx` itself may throw when no ctx exists at all (bare block,
+      // post-teardown callback) — OrNull means never throwing, either way.
+      try {
+        return getSharedInstance(getCtx(), '*uploadCollection', false) ?? null;
+      } catch {
+        return null;
+      }
     },
     get apiOrNull(): UploaderPublicApi | null {
-      return getSharedInstance(getCtx(), '*publicApi', false) ?? null;
+      try {
+        return getSharedInstance(getCtx(), '*publicApi', false) ?? null;
+      } catch {
+        return null;
+      }
     },
 
     when<TName extends InstanceName>(

--- a/tests/blocks/activity-child-block.e2e.test.tsx
+++ b/tests/blocks/activity-child-block.e2e.test.tsx
@@ -1,0 +1,119 @@
+import { html } from 'lit';
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { RouterController } from '@/abstract/controllers/RouterController';
+import { ActivityChildBlock } from '@/lit/ActivityChildBlock';
+import type { ChildBlock } from '@/lit/ChildBlock';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+class TestActivityBlock extends ActivityChildBlock {
+  public override activityType: ActivityChildBlock['activityType'] = 'start-from';
+
+  public override render() {
+    return html`<span class="marker">activity</span>`;
+  }
+}
+
+class TestNoActivityBlock extends ActivityChildBlock {
+  public override render() {
+    return html`<span class="marker">no-activity</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'test-activity-block': TestActivityBlock;
+    'test-no-activity-block': TestNoActivityBlock;
+  }
+}
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+  if (!customElements.get('test-activity-block')) customElements.define('test-activity-block', TestActivityBlock);
+  if (!customElements.get('test-no-activity-block')) {
+    customElements.define('test-no-activity-block', TestNoActivityBlock);
+  }
+});
+
+const appended: HTMLElement[] = [];
+const append = <K extends keyof HTMLElementTagNameMap>(tag: K, attrs: Record<string, string> = {}) => {
+  const el = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  document.body.append(el);
+  appended.push(el);
+  return el;
+};
+
+afterEach(() => {
+  for (const el of appended) el.remove();
+  appended.length = 0;
+});
+
+// biome-ignore lint/suspicious/noExplicitAny: reaching into the protected `bag` to drive the router directly, same pattern as child-block.e2e.test.tsx
+const routerOf = (block: ChildBlock): RouterController => (block as any).bag.router;
+
+describe('ActivityChildBlock', () => {
+  it('sets the activity attribute on adoption', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-activity-block', { 'ctx-name': ctxName });
+
+    await expect.poll(() => child.getAttribute('activity')).toBe('start-from');
+  });
+
+  it('toggles [active] as the router background activity moves to/from its activityType', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-activity-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.getAttribute('activity')).toBe('start-from');
+
+    const router = routerOf(child);
+    expect(child.hasAttribute('active')).toBe(false);
+
+    router.setActivity('start-from');
+    await expect.poll(() => child.hasAttribute('active')).toBe(true);
+
+    router.setActivity(null);
+    await expect.poll(() => child.hasAttribute('active')).toBe(false);
+  });
+
+  it('does not set activity or active for blocks without an activityType', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-no-activity-block', { 'ctx-name': ctxName });
+    await child.updateComplete;
+
+    const router = routerOf(child);
+    router.setActivity('start-from');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(child.hasAttribute('activity')).toBe(false);
+    expect(child.hasAttribute('active')).toBe(false);
+  });
+
+  it('tracks the foreground modal slot instead of the background slot when nested in a uc-modal', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const modal = append('uc-modal', { 'ctx-name': ctxName });
+    const child = document.createElement('test-activity-block');
+    child.setAttribute('ctx-name', ctxName);
+    modal.append(child);
+
+    await expect.poll(() => child.getAttribute('activity')).toBe('start-from');
+
+    const router = routerOf(child);
+
+    // Background activity alone must not activate a modal-nested block.
+    router.setActivity('start-from');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(child.hasAttribute('active')).toBe(false);
+
+    router.openModal('start-from');
+    await expect.poll(() => child.hasAttribute('active')).toBe(true);
+
+    router.closeModal();
+    await expect.poll(() => child.hasAttribute('active')).toBe(false);
+  });
+});

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -13,6 +13,7 @@ class TestChildBlock extends ChildBlock {
   public readyCount = 0;
   public releasedCount = 0;
   public throwOnRelease = false;
+  public throwInReady = false;
   public cleanupRanAfterThrow = false;
 
   protected override subscriptionsFor(ctrl: UploaderController) {
@@ -23,6 +24,9 @@ class TestChildBlock extends ChildBlock {
   }
 
   protected override controllerReady(): void {
+    if (this.throwInReady) {
+      throw new Error('boom in controllerReady');
+    }
     this.readyCount += 1;
     if (this.throwOnRelease) {
       this.trackSub(() => {
@@ -233,5 +237,30 @@ describe('ChildBlock', () => {
     await expect.poll(() => child.readyCount).toBe(1);
     // biome-ignore lint/suspicious/noExplicitAny: reaching into the helper directly
     expect((child as any).l10n('definitely-not-a-key')).toBe('definitely-not-a-key');
+  });
+
+  it('isolates a throwing controllerReady during adoption, warns, and finishes the update', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = document.createElement('test-child-block');
+    child.throwInReady = true;
+    child.setAttribute('ctx-name', ctxName);
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      document.body.append(child);
+      appended.push(child);
+
+      // Adoption must still complete (post-hook requestUpdate ran) even though
+      // controllerReady threw.
+      await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+      expect(child.readyCount).toBe(0);
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('controllerReady threw during adoption'),
+        expect.any(Error),
+      );
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/tests/blocks/start-from.e2e.test.tsx
+++ b/tests/blocks/start-from.e2e.test.tsx
@@ -1,0 +1,134 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, UploadCtxProvider } from '@/index.ts';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+// M9f Task 3 — additive parity e2e pinning current v1 behavior of
+// `uc-start-from` (activity reflection via `LitActivityBlock`) and
+// `uc-activity-header` (an inert `LitActivityBlock` subclass with no
+// `activityType` — see src/blocks/ActivityHeader/ActivityHeader.ts) ahead of
+// the `LitActivityBlock` -> `ActivityChildBlock` swap. Mounts the regular
+// solution + `<uc-upload-ctx-provider>` (same composition as
+// tests/blocks/file-item.e2e.test.tsx / upload-events-wiring.e2e.test.tsx)
+// and drives real navigation through the public api, asserting only against
+// rendered DOM / documented api surface.
+//
+// Disclosure: the brief's case-2 driver as described — "with the modal open,
+// api.addFileFromUrl(TEST_IMAGE_URL) triggers onFileAdd navigation to
+// upload-list" — does not hold: `addFileFromUrl` only mutates the upload
+// collection (src/abstract/UploaderPublicApi.ts) and never itself calls
+// `router.traverse('onFileAdd')`; that traversal is wired only from
+// UI-driven source flows (DropArea drop, UrlSource/ExternalSource/
+// CameraSource submit) and the public api's `openSystemDialog` change
+// handler (see grep for `traverse('onFileAdd')` across src/blocks +
+// src/abstract/UploaderPublicApi.ts). A bare `addFileFromUrl()` call left
+// `uc-start-from` active with no navigation (verified empirically). The
+// actual v1 driver that navigates away from `start-from` once a file exists
+// is `UploaderPublicApi.initFlow()` (src/abstract/UploaderPublicApi.ts:312),
+// which — when the upload collection is non-empty — calls
+// `router.navigate(ACTIVITY_TYPES.UPLOAD_LIST)` directly; this is the same
+// call the "Upload files" button issues (see file-item.e2e.test.tsx's
+// comment on `api.initFlow()`). Case 2 below uses
+// `api.addFileFromUrl(...)` followed by `api.initFlow()` as the real,
+// non-timed navigation driver.
+
+const renderRegularHost = () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+    </>,
+  );
+  const config = page.getByTestId('uc-config').query()! as Config;
+  const provider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+  return { ctxName, config, api: provider.api };
+};
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+describe('uc-start-from (parity, activity reflection)', () => {
+  it('becomes visible with activity="start-from" and [active] when the modal opens', async () => {
+    renderRegularHost();
+
+    await page.getByText('Upload files', { exact: true }).click();
+
+    const startFrom = page.getByTestId('uc-start-from');
+    await expect.element(startFrom).toBeVisible();
+    await expect.poll(() => document.querySelector('uc-start-from')?.getAttribute('activity')).toBe('start-from');
+    await expect.poll(() => document.querySelector('uc-start-from')?.hasAttribute('active')).toBe(true);
+  });
+
+  it('loses [active] but stays in the DOM once navigation moves to upload-list', async () => {
+    const { api } = renderRegularHost();
+
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    await expect.poll(() => document.querySelector('uc-start-from')?.hasAttribute('active')).toBe(true);
+
+    // Real navigation driver — see file-level disclosure comment above.
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+
+    await expect.poll(() => document.querySelector('uc-start-from')?.hasAttribute('active')).toBe(false);
+    // Still owns its slot attribute — only [active] is toggled off.
+    expect(document.querySelector('uc-start-from')?.getAttribute('activity')).toBe('start-from');
+    // Remains mounted, just not the active/foreground activity.
+    expect(document.querySelector('uc-start-from')).toBeTruthy();
+
+    await expect.poll(() => document.querySelector('uc-upload-list')?.hasAttribute('active')).toBe(true);
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    renderRegularHost();
+
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+    expect(document.querySelector('uc-start-from')?.getAttribute('data-testid')).toBe('uc-start-from');
+  });
+});
+
+describe('uc-activity-header (parity, inert passthrough)', () => {
+  it('carries no activity/active attributes and preserves its light-DOM children', async () => {
+    const { api } = renderRegularHost();
+
+    await page.getByText('Upload files', { exact: true }).click();
+    // `uc-activity-header` is only rendered inside upload-list/url/external/
+    // camera source activities (see FileUploaderRegular.ts + grep for
+    // `uc-activity-header` — `uc-start-from` itself does not render one), so
+    // navigate there via the same real driver as the case above.
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+    await expect.poll(() => document.querySelector('uc-upload-list')?.hasAttribute('active')).toBe(true);
+
+    const header = document.querySelector('uc-upload-list uc-activity-header');
+    expect(header).toBeTruthy();
+    expect(header?.hasAttribute('activity')).toBe(false);
+    expect(header?.hasAttribute('active')).toBe(false);
+
+    // Light-DOM children (header text span + close button) are preserved,
+    // per UploadList.ts's `<uc-activity-header>` template.
+    expect(header?.querySelector('.uc-header-text')).toBeTruthy();
+    expect(header?.querySelector('.uc-close-btn')).toBeTruthy();
+  });
+
+  it('reflects data-testid under testMode', async () => {
+    const { api } = renderRegularHost();
+
+    await page.getByText('Upload files', { exact: true }).click();
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+    await expect.poll(() => document.querySelector('uc-upload-list')?.hasAttribute('active')).toBe(true);
+
+    await expect
+      .poll(() => document.querySelector('uc-upload-list uc-activity-header')?.getAttribute('data-testid'))
+      .toBe('uc-activity-header');
+  });
+});


### PR DESCRIPTION
Sixth slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7): the systemic hardenings M9e's reviews demanded, plus the foundation that unlocks the activity-block group. **15 blocks on `ChildBlock`.**

## Hardening (TDD)
- **OrNull scope-guard seam:** `bag.uploadCollectionOrNull`/`apiOrNull` (over `getSharedInstance(..., false)`) replace the M9e ad-hoc `ctx.has(...)` guards in Thumb/FileItem — also closing the has-true/value-null teardown window (`ctx.has` reports null-pubbed keys as present).
- **`controllerReady` isolate-and-warn** in `_adoptController`: one block's adoption throw no longer escapes the registry callback as an unhandled window error (RED-confirmed).

## Activity foundation
- `subRouter`/`subActivity` on `ChildBlock` (auto-tracked, line-for-line parity with `LitBlock`'s helpers).
- `ActivityChildBlock` — post-M7 `LitActivityBlock` semantics on the v2 base: `activity` attribute, modal-aware `[active]` slot reflection, `activityParams`, dual-slot support (minimal's two `uc-start-from`). Opus-audited parity, no first-render gap.
- **Real gap found by the port and fixed:** `setModalState(true)` gated `openModal` on a `*blocksRegistry` lookup that ported activity blocks no longer satisfy (the deprecated-pair path hung; `navigate`/`setCurrentActivity` would false-warn on every future activity port). Fix: a refcounted **mounted-activity signal on `RouterController`** (`activityBlockMounted`/`hasMountedActivity`), reported by `ActivityChildBlock` on adoption/release, with `waitForActivityBlock` checking both the registry (v1 + plugin activities, unchanged) and the signal (ported). Timeout/warn semantics preserved exactly.

## Ports
StartFrom + ActivityHeader — two-line swaps onto `ActivityChildBlock`, parity suite (pinned before the port, corrected against real navigation behavior) kept green unchanged.

## Gate (now includes the full `npm run tsc` stage, per #1009's CI lesson)
tsc:app ✅ build ✅ tsc ✅ specs 588 ✅ locales ✅ e2e 283/283 exit 0 ✅ lint ✅

Follow-ups queued (M9g): UrlSource/CameraSource/ExternalSource ports (registry arm stays load-bearing until then), `ActivityId` typing on the signal, first `subActivity` consumer + dedup test, `findBlockInCtx.ts` dead-code deletion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced activity-aware child blocks that automatically set the `activity` attribute and toggle `[active]`, including correct foreground modal vs background behavior and activity parameters.
  * Navigation now waits for the target activity to be mounted before proceeding.

* **Bug Fixes**
  * Router activity mounting now uses refcounted tracking, ensuring mounts persist until all releases.
  * Modal opening is skipped when the required activity block can’t be found, preventing premature modal state changes.

* **Tests**
  * Added/expanded end-to-end coverage for activity mounting lifecycle, modal activation logic, and controller-ready error isolation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->