### PR TITLE
feat(m9h): star-key block ports (DynamicBtn family, ProgressBarCommon, FormInput) + queue items

### DIFF
--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -2,7 +2,7 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { SourceListController } from '../../abstract/controllers';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import type { Uid } from '../../lit/Uid';
 import type { SourceButtonConfig } from '../SourceBtn/SourceBtn';
 
@@ -51,10 +51,8 @@ const iconsBasedOnMode: Record<Exclude<DynamicButtonMode, 'toolbar'>, string> = 
 
 const AUTO_MODE_INLINE_THRESHOLD = 3;
 
-export class DynamicBtn extends LitUploaderBlock {
+export class DynamicBtn extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-dynamic-btn'];
-
-  private _unregisterOnFileAddHook?: () => void;
 
   @property({ attribute: 'dropzone', type: Boolean })
   public dropzone = true;
@@ -140,7 +138,7 @@ export class DynamicBtn extends LitUploaderBlock {
   }, 300);
 
   private _updateButtonBasedOnCollectionState() {
-    const collectionState = this.api?.getOutputCollectionState();
+    const collectionState = this.bag.api?.getOutputCollectionState();
 
     if (!collectionState) {
       console.warn('Collection state is undefined');
@@ -155,9 +153,7 @@ export class DynamicBtn extends LitUploaderBlock {
     this._mainAndRemainSources = adjustSourceBasedOnMode(this._sources, this._mode);
   }
 
-  public override initCallback(): void {
-    super.initCallback();
-
+  protected override controllerReady(): void {
     this.subConfigValue('dynamicButtonViewMode', (value) => {
       if (this._mode === value) return;
 
@@ -165,42 +161,54 @@ export class DynamicBtn extends LitUploaderBlock {
       this._updateSourceSplit();
     });
 
-    this.sub('*commonProgress', (progress: number) => {
-      this._progress = progress;
-    });
+    this.trackSub(
+      this.bag.ctx.sub('*commonProgress', (progress: number) => {
+        this._progress = progress;
+      }),
+    );
 
     new SourceListController(this, {
-      ctx: this._sharedInstancesBag.ctx,
-      sharedInstancesBag: this._sharedInstancesBag,
+      ctx: this.bag.ctx,
+      sharedInstancesBag: this.bag,
       onSourcesChange: (sources) => {
         this._sources = sources;
         this._updateSourceSplit();
       },
     });
 
-    this.uploadCollection.observeProperties(this._throttledHandleCollectionUpdate);
-    this.uploadCollection.observeCollection(this._throttledHandleCollectionUpdate);
+    // The uploader-scope `*uploadCollection` instance may not have registered
+    // yet when this block's controller adopts (it's published once the
+    // uploader/solution block finishes its own init, which can race this
+    // block's adoption) — go through `bag.when` rather than the throwing
+    // `bag.uploadCollection` getter (FileItem precedent for `pluginManager`).
+    this.trackSub(
+      this.bag.when('uploadCollection', (collection) => {
+        collection.observeProperties(this._throttledHandleCollectionUpdate);
+        collection.observeCollection(this._throttledHandleCollectionUpdate);
+      }),
+    );
 
-    this._unregisterOnFileAddHook = this.router.hooks.onFileAdd(() => {
-      // With confirmUpload, always land on the upload list.
-      if (this.cfg.confirmUpload) {
-        return ACTIVITY_TYPES.UPLOAD_LIST;
-      }
-      // If the user navigated somewhere to add the file, fall through to the
-      // default (upload list); otherwise close everything so the dynamic button
-      // just shows inline status.
-      if (this.router.canGoBack) {
-        return undefined;
-      }
-      return null;
-    });
+    this.trackSub(
+      this.bag.router.hooks.onFileAdd(() => {
+        // With confirmUpload, always land on the upload list.
+        if (this.uploader.config.get('confirmUpload')) {
+          return ACTIVITY_TYPES.UPLOAD_LIST;
+        }
+        // If the user navigated somewhere to add the file, fall through to the
+        // default (upload list); otherwise close everything so the dynamic button
+        // just shows inline status.
+        if (this.bag.router.canGoBack) {
+          return undefined;
+        }
+        return null;
+      }),
+    );
   }
 
   public override disconnectedCallback(): void {
     if (typeof this._throttledHandleCollectionUpdate.cancel === 'function') {
       this._throttledHandleCollectionUpdate.cancel();
     }
-    this._unregisterOnFileAddHook?.();
     super.disconnectedCallback();
   }
 
@@ -219,18 +227,18 @@ export class DynamicBtn extends LitUploaderBlock {
   }
 
   private _clearAllEntries() {
-    this.uploadCollection.clearAll();
+    this.bag.uploadCollection.clearAll();
   }
 
   private _clearAllFailedEntries() {
     this._collection.failedEntries.forEach((it) => {
-      if (it && this.uploadCollection.hasItem(it.internalId as Uid)) {
-        this.uploadCollection.remove(it.internalId as Uid);
+      if (it && this.bag.uploadCollection.hasItem(it.internalId as Uid)) {
+        this.bag.uploadCollection.remove(it.internalId as Uid);
       }
     });
   }
   private _abortAllEntries() {
-    this.uploadCollection.abortAll();
+    this.bag.uploadCollection.abortAll();
   }
 
   private _handleRemove() {

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -183,8 +183,11 @@ export class DynamicBtn extends ChildBlock {
     // `bag.uploadCollection` getter (FileItem precedent for `pluginManager`).
     this.trackSub(
       this.bag.when('uploadCollection', (collection) => {
-        collection.observeProperties(this._throttledHandleCollectionUpdate);
-        collection.observeCollection(this._throttledHandleCollectionUpdate);
+        // Deliberate post-parity improvement (v1 never unobserved these):
+        // track the unsubscribers so a release/re-adoption cycle can't stack
+        // duplicate observers (same shape as ProgressBarCommon).
+        this.trackSub(collection.observeProperties(this._throttledHandleCollectionUpdate));
+        this.trackSub(collection.observeCollection(this._throttledHandleCollectionUpdate));
       }),
     );
 

--- a/src/blocks/DynamicBtn/NoWrapModeDynamicBtn.ts
+++ b/src/blocks/DynamicBtn/NoWrapModeDynamicBtn.ts
@@ -1,6 +1,6 @@
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 
-export class NoWrapModeDynamicBtn extends LitUploaderBlock {
+export class NoWrapModeDynamicBtn extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-no-wrap-mode-dynamic-btn'];
 }
 

--- a/src/blocks/ExternalSource/ExternalSource.ts
+++ b/src/blocks/ExternalSource/ExternalSource.ts
@@ -202,6 +202,9 @@ export class ExternalSource extends ChildBlock {
     const socialBaseUrl = this.uploader.config.get('socialBaseUrl');
     const multiple = this.uploader.config.get('multiple');
     const { externalSourceType } = this.bag.router.params as ActivityParams;
+    if (!externalSourceType) {
+      throw new Error(`Param "externalSourceType" is required for external source activity`);
+    }
     const sourceName = SOCIAL_SOURCE_MAPPING[externalSourceType] ?? externalSourceType;
     const lang = this.l10n('social-source-lang')?.split('-')?.[0] || 'en';
     const params = {
@@ -224,6 +227,9 @@ export class ExternalSource extends ChildBlock {
       const url = this._extractUrlFromSelectedFile(message);
       const { filename } = message;
       const { externalSourceType } = this.bag.router.params as ActivityParams;
+      if (!externalSourceType) {
+        throw new Error(`Param "externalSourceType" is required for external source activity`);
+      }
       this.bag.api.addFileFromUrl(url, {
         fileName: filename,
         source: externalSourceType,

--- a/src/blocks/FormInput/FormInput.ts
+++ b/src/blocks/FormInput/FormInput.ts
@@ -1,9 +1,9 @@
 import { property } from 'lit/decorators.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import type { OutputCollectionState } from '../../types/index';
 import { applyStyles } from '../../utils/applyStyles';
 
-export class FormInput extends LitUploaderBlock {
+export class FormInput extends ChildBlock {
   public declare attributesMeta: {
     'ctx-name': string;
     name?: string;
@@ -15,14 +15,14 @@ export class FormInput extends LitUploaderBlock {
   public nameAttrValue?: string;
 
   private get _inputName(): string {
-    return this.nameAttrValue ?? this.ctxName;
+    return this.nameAttrValue ?? this.effectiveCtxName ?? '';
   }
 
   private _createValidationInput(): HTMLInputElement {
     const validationInput = document.createElement('input');
     validationInput.type = 'text';
     validationInput.name = this._inputName;
-    validationInput.required = this.cfg.multipleMin > 0;
+    validationInput.required = this.uploader.config.get('multipleMin') > 0;
     validationInput.tabIndex = -1;
     applyStyles(validationInput, {
       opacity: 0,
@@ -32,78 +32,78 @@ export class FormInput extends LitUploaderBlock {
     return validationInput;
   }
 
-  public override initCallback(): void {
-    super.initCallback();
-
+  protected override controllerReady(): void {
     this._validationInputElement = this._createValidationInput();
     this.appendChild(this._validationInputElement);
 
-    this.sub(
-      '*collectionState',
-      (collectionState: OutputCollectionState | null) => {
-        if (!collectionState) {
-          return;
-        }
-        if (!this._dynamicInputsContainer) {
-          const dynamicInputsContainer = document.createElement('div');
-          this.appendChild(dynamicInputsContainer);
-          this._dynamicInputsContainer = dynamicInputsContainer;
-        }
-        if (!this._validationInputElement) {
-          const input = this._createValidationInput();
-          this.appendChild(input);
-          this._validationInputElement = input;
-        }
+    this.trackSub(
+      this.bag.ctx.sub(
+        '*collectionState',
+        (collectionState: OutputCollectionState | null) => {
+          if (!collectionState) {
+            return;
+          }
+          if (!this._dynamicInputsContainer) {
+            const dynamicInputsContainer = document.createElement('div');
+            this.appendChild(dynamicInputsContainer);
+            this._dynamicInputsContainer = dynamicInputsContainer;
+          }
+          if (!this._validationInputElement) {
+            const input = this._createValidationInput();
+            this.appendChild(input);
+            this._validationInputElement = input;
+          }
 
-        this._dynamicInputsContainer.innerHTML = '';
+          this._dynamicInputsContainer.innerHTML = '';
 
-        if (collectionState.status === 'uploading' || collectionState.status === 'idle') {
-          this._validationInputElement.value = '';
-          this._validationInputElement.setCustomValidity('');
-          return;
-        }
+          if (collectionState.status === 'uploading' || collectionState.status === 'idle') {
+            this._validationInputElement.value = '';
+            this._validationInputElement.setCustomValidity('');
+            return;
+          }
 
-        if (collectionState.status === 'failed') {
-          const errorMsg = collectionState.errors[0]?.message;
-          this._validationInputElement.value = '';
-          this._validationInputElement.setCustomValidity(errorMsg ?? '');
-          return;
-        }
+          if (collectionState.status === 'failed') {
+            const errorMsg = collectionState.errors[0]?.message;
+            this._validationInputElement.value = '';
+            this._validationInputElement.setCustomValidity(errorMsg ?? '');
+            return;
+          }
 
-        const group = collectionState.group ? collectionState.group : null;
-        if (group) {
-          this._validationInputElement.value = group.cdnUrl ?? '';
-          this._validationInputElement.setCustomValidity('');
-          return;
-        }
+          const group = collectionState.group ? collectionState.group : null;
+          if (group) {
+            this._validationInputElement.value = group.cdnUrl ?? '';
+            this._validationInputElement.setCustomValidity('');
+            return;
+          }
 
-        const cdnUrls = collectionState.allEntries
-          .map((entry) => entry.cdnUrl)
-          .filter((url): url is string => typeof url === 'string');
+          const cdnUrls = collectionState.allEntries
+            .map((entry) => entry.cdnUrl)
+            .filter((url): url is string => typeof url === 'string');
 
-        if (!this.cfg.multiple && cdnUrls.length === 1 && cdnUrls[0]) {
-          this._validationInputElement.value = cdnUrls[0];
-          this._validationInputElement.setCustomValidity('');
-          return;
-        }
+          if (!this.uploader.config.get('multiple') && cdnUrls.length === 1 && cdnUrls[0]) {
+            this._validationInputElement.value = cdnUrls[0];
+            this._validationInputElement.setCustomValidity('');
+            return;
+          }
 
-        // Remove validation input to prevent it from being submitted
-        this._validationInputElement.remove();
-        this._validationInputElement = null;
+          // Remove validation input to prevent it from being submitted
+          this._validationInputElement.remove();
+          this._validationInputElement = null;
 
-        const fr = new DocumentFragment();
+          const fr = new DocumentFragment();
 
-        for (const value of cdnUrls) {
-          const input = document.createElement('input');
-          input.type = 'hidden';
-          input.name = `${this._inputName}[]`;
-          input.value = value;
-          fr.appendChild(input);
-        }
+          for (const value of cdnUrls) {
+            const input = document.createElement('input');
+            input.type = 'hidden';
+            input.name = `${this._inputName}[]`;
+            input.value = value;
+            fr.appendChild(input);
+          }
 
-        this._dynamicInputsContainer.replaceChildren(fr);
-      },
-      false,
+          this._dynamicInputsContainer.replaceChildren(fr);
+        },
+        false,
+      ),
     );
   }
 }

--- a/src/blocks/FormInput/FormInput.ts
+++ b/src/blocks/FormInput/FormInput.ts
@@ -33,8 +33,13 @@ export class FormInput extends ChildBlock {
   }
 
   protected override controllerReady(): void {
-    this._validationInputElement = this._createValidationInput();
-    this.appendChild(this._validationInputElement);
+    // `controllerReady` re-runs on controller re-adoption — guard the append
+    // so duplicate hidden inputs can't stack (same guard as the subscription
+    // callback below).
+    if (!this._validationInputElement) {
+      this._validationInputElement = this._createValidationInput();
+      this.appendChild(this._validationInputElement);
+    }
 
     this.trackSub(
       this.bag.ctx.sub(

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
@@ -1,52 +1,54 @@
 import { html, type PropertyValues } from 'lit';
 import { state } from 'lit/decorators.js';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './progress-bar-common.css';
 
 import '../ProgressBar/ProgressBar';
 
-type BaseInitState = InstanceType<typeof LitUploaderBlock>['init$'];
-
-interface ProgressBarCommonInitState extends BaseInitState {
-  '*commonProgress': number;
-}
-
-export class ProgressBarCommon extends LitUploaderBlock {
-  private _unobserveCollectionCb?: () => void;
-
+export class ProgressBarCommon extends ChildBlock {
   @state()
   private _visible = false;
 
   @state()
   private _value = 0;
 
-  public constructor() {
-    super();
-    this.init$ = {
-      ...this.init$,
-      '*commonProgress': 0,
-    } as ProgressBarCommonInitState;
-  }
+  // No `init$` here: `*commonProgress` is a ctx-scope key seeded by v1
+  // uploader blocks (`UploaderController`/solution wiring), not by this
+  // block — `ChildBlock` has no `init$` seam to declare it in.
+  protected override controllerReady(): void {
+    this.trackSub(
+      this.bag.ctx.sub('*commonProgress', (progress: number) => {
+        this._value = progress;
+      }),
+    );
 
-  public override initCallback(): void {
-    super.initCallback();
-    this._unobserveCollectionCb = this.uploadCollection.observeProperties(() => {
-      const anyUploading = this.uploadCollection.items().some((id) => {
-        const item = this.uploadCollection.read(id);
-        return item?.getValue('isUploading') ?? false;
-      });
+    // The uploader-scope `*uploadCollection` instance may not have registered
+    // yet when this block's controller adopts — go through `bag.when` rather
+    // than the throwing `bag.uploadCollection` getter (DynamicBtn precedent).
+    this.trackSub(
+      this.bag.when('uploadCollection', (collection) => {
+        this.trackSub(
+          collection.observeProperties(() => {
+            const anyUploading = collection.items().some((id) => {
+              const item = collection.read(id);
+              return item?.getValue('isUploading') ?? false;
+            });
 
-      this._visible = anyUploading;
-    });
-
-    this.sub('*commonProgress', (progress: number) => {
-      this._value = progress;
-    });
+            this._visible = anyUploading;
+          }),
+        );
+      }),
+    );
   }
 
   protected override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
 
+    // Known-dead code, preserved bug-for-bug from v1: this checks
+    // `changedProperties.has('visible')` but the backing field is `_visible`,
+    // so this branch never fires and the host `active` attribute is never
+    // toggled. Not fixed here — activating it would change CSS-visible
+    // behavior that v1 never exercised (see M9h task-3 brief / progress.md).
     if (changedProperties.has('visible' as keyof ProgressBarCommon)) {
       if (this._visible) {
         this.setAttribute('active', '');
@@ -54,12 +56,6 @@ export class ProgressBarCommon extends LitUploaderBlock {
         this.removeAttribute('active');
       }
     }
-  }
-
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._unobserveCollectionCb?.();
-    this._unobserveCollectionCb = undefined;
   }
 
   public override render() {

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -216,11 +216,6 @@ export class LitBlock extends LitBlockBase {
     return this._subRouterDerived(() => this.router.currentActivity, cb);
   }
 
-  /** Subscribe to the current activity params. Fires immediately + on change. */
-  protected subActivityParams(cb: (params: Readonly<Record<string, unknown>>) => void): () => void {
-    return this._subRouterDerived(() => this.router.params, cb);
-  }
-
   /**
    * Subscribe to *any* router change (slot or params). Fires immediately, then
    * on every notification — no value dedup. Use when a reader depends on a slot

--- a/tests/blocks/dynamic-btn.e2e.test.tsx
+++ b/tests/blocks/dynamic-btn.e2e.test.tsx
@@ -47,6 +47,11 @@ describe('DynamicBtn remove/abort action', () => {
     api.addFileFromUrl(TEST_IMAGE_URL);
     api.uploadAll();
 
+    // Pin the branch precondition: the collection must actually be in the
+    // uploading state before clicking, or this could silently exercise the
+    // failed/finished branches instead.
+    await expect.poll(() => api.getOutputCollectionState().status).toBe('uploading');
+
     const abortBtn = dynamicBtn.getByLabelText('Remove');
     await expect.element(abortBtn).toBeVisible();
     // Still mid-flight: the upload has not resolved yet.

--- a/tests/blocks/dynamic-btn.e2e.test.tsx
+++ b/tests/blocks/dynamic-btn.e2e.test.tsx
@@ -1,0 +1,102 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { commands, page } from 'vitest/browser';
+import type { Config, UploadCtxProvider } from '@/index.js';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+/**
+ * M9h Task 1 — gap-fill ahead of the ChildBlock port of DynamicBtn.
+ *
+ * `tests/dynamic-btn-upload-list.e2e.test.tsx` deeply pins DynamicBtn's
+ * navigation behavior (upload list open/closed across confirmUpload and
+ * compact-mode branches) but never exercises `DynamicBtn#_handleRemove` —
+ * the three-way `switch (this._status)` that the abort/remove action
+ * (`uc-file-action-button`'s `@uc:remove`) dispatches into:
+ *   - 'uploading' -> `_abortAllEntries()` (aborts in-flight uploads)
+ *   - 'failed'    -> `_clearAllFailedEntries()` (clears only failed entries)
+ *   - default     -> `_clearAllEntries()` (clears everything, e.g. on success)
+ * None of these branches has any existing pin. A ChildBlock rewrite of this
+ * switch (or of `shouldShowAbortAction`) could silently break any of them.
+ */
+describe('DynamicBtn remove/abort action', () => {
+  const renderDynamicBtn = () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular dynamic-button ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    const dynamicBtn = page.getByTestId('uc-dynamic-btn');
+    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = ctxProvider.getAPI();
+    return { dynamicBtn, api };
+  };
+
+  it('aborts in-flight uploads when the abort action is clicked while uploading', async () => {
+    const { dynamicBtn, api } = renderDynamicBtn();
+    await expect.element(dynamicBtn).toBeVisible();
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    const abortBtn = dynamicBtn.getByLabelText('Remove');
+    await expect.element(abortBtn).toBeVisible();
+    // Still mid-flight: the upload has not resolved yet.
+    expect(api.getOutputCollectionState().successCount).toBe(0);
+
+    await abortBtn.click();
+
+    await expect.poll(() => api.getOutputCollectionState().totalCount).toBe(0);
+    // The aborted upload must never resolve as a success afterwards.
+    expect(api.getOutputCollectionState().successCount).toBe(0);
+  }, 30_000);
+
+  it('clears only failed entries when the abort action is clicked in the failed state', async () => {
+    const { dynamicBtn, api } = renderDynamicBtn();
+    const config = page.getByTestId('uc-config').query()! as Config;
+    config.fileValidators = [() => ({ message: 'Bad file' })];
+
+    await expect.element(dynamicBtn).toBeVisible();
+
+    // Go through the file chooser (not `api.initFlow()`, which navigates
+    // straight to the upload-list modal once the collection is non-empty)
+    // so DynamicBtn's own `onFileAdd` hook stays in control and the modal
+    // never opens over the abort button — matching the non-confirm flow
+    // already pinned in tests/dynamic-btn-upload-list.e2e.test.tsx.
+    commands.waitFileChooserAndUpload(['../fixtures/test_image.jpeg']);
+    await dynamicBtn.click();
+
+    await expect.poll(() => api.getOutputCollectionState().status).toBe('failed');
+
+    const abortBtn = dynamicBtn.getByLabelText('Remove');
+    await expect.element(abortBtn).toBeVisible();
+    await abortBtn.click();
+
+    await expect.poll(() => api.getOutputCollectionState().totalCount).toBe(0);
+  });
+
+  it('clears all entries when the remove action is clicked after a successful upload', async () => {
+    const { dynamicBtn, api } = renderDynamicBtn();
+    await expect.element(dynamicBtn).toBeVisible();
+
+    commands.waitFileChooserAndUpload(['../fixtures/test_image.jpeg']);
+    await dynamicBtn.click();
+
+    await expect.element(dynamicBtn.getByText('1 file uploaded')).toBeVisible();
+    await expect.poll(() => api.getOutputCollectionState().successCount).toBe(1);
+
+    const removeBtn = dynamicBtn.getByLabelText('Remove');
+    await expect.element(removeBtn).toBeVisible();
+    await removeBtn.click();
+
+    await expect.poll(() => api.getOutputCollectionState().totalCount).toBe(0);
+  });
+});

--- a/tests/blocks/progress-bar-common.e2e.test.tsx
+++ b/tests/blocks/progress-bar-common.e2e.test.tsx
@@ -1,0 +1,72 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { ProgressBar, UploadCtxProvider } from '@/index.js';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+/**
+ * M9h Task 1 — gap-fill ahead of the ChildBlock port of ProgressBarCommon.
+ *
+ * `uc-progress-bar-common` is a documented standalone public element
+ * (exported from `src/index.ts`) whose entire behavior is bridging real
+ * upload state — `uploadCollection` (any item `isUploading`) and the shared
+ * `*commonProgress` value — into the inner `<uc-progress-bar>`'s
+ * `.visible`/`.value`. Before this suite, it had zero dedicated coverage:
+ * `tests/blocks/progress-bar.e2e.test.tsx` only drives the inner
+ * `<uc-progress-bar>` directly via its own properties, never through
+ * ProgressBarCommon's real upload-driven wiring. A ChildBlock rewrite of
+ * `initCallback`'s `uploadCollection.observeProperties` / `sub('*commonProgress', ...)`
+ * subscriptions could silently break this visibility lifecycle with nothing
+ * to catch it.
+ */
+describe('uc-progress-bar-common', () => {
+  const render = () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-progress-bar-common ctx-name={ctxName}></uc-progress-bar-common>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = ctxProvider.getAPI();
+    const innerBar = () => document.querySelector('uc-progress-bar-common uc-progress-bar') as ProgressBar | null;
+    return { api, innerBar };
+  };
+
+  it('keeps the inner progress bar hidden before any upload starts', async () => {
+    const { innerBar } = render();
+    await expect.poll(() => innerBar()).toBeTruthy();
+    expect(innerBar()!.visible).toBe(false);
+  });
+
+  it('shows the inner progress bar while uploading and hides it again on completion', async () => {
+    const { api, innerBar } = render();
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    await expect.poll(() => innerBar()?.visible, { timeout: 20_000 }).toBe(true);
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+    await expect.poll(() => innerBar()?.visible, { timeout: 20_000 }).toBe(false);
+  }, 30_000);
+
+  it('syncs the inner progress bar value from *commonProgress up to completion', async () => {
+    const { api, innerBar } = render();
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    await expect.poll(() => api.getOutputCollectionState().successCount, { timeout: 20_000 }).toBe(1);
+    await expect.poll(() => innerBar()?.value, { timeout: 20_000 }).toBe(100);
+  }, 30_000);
+});


### PR DESCRIPTION
Eighth slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7). **22 blocks on `ChildBlock`** — the `*`-shared-state subscribers move via the facade-sub precedent (`trackSub(bag.ctx.sub('*commonProgress'/'*collectionState', ...))`; the keys themselves migrate to controllers in a later milestone).

## Coverage first (gap-fill discipline)
Existing deep suites are the primary nets; this slice added only genuine gaps: 6 tests (ProgressBarCommon had zero coverage; DynamicBtn's remove-button switch branches were unexercised), with justified zero-gaps for FormInput and NoWrapModeDynamicBtn. The analysis also **confirmed a pre-existing v1 bug**: ProgressBarCommon's host `active` toggle keys `changedProperties.has('visible')` while the field is `_visible` — dead code since inception. Preserved bug-for-bug with a marker comment (activating it would change untested CSS-visible behavior); tracked for a deliberate decision.

## Real gap found by the port: adoption-reentrancy
`ChildBlock` adoption fires **inside** the `*uploadCollection` resolver during LUB init, so uploader-scope required bag getters throw in `controllerReady` for blocks that adopt mid-init (DynamicBtn's `onFileAdd` hook registration silently died). Fixed via `bag.when('uploadCollection', ...)`, and the final review swept all 20 ported classes — **zero other live instances** — and produced the exact checklist partition: ctx-scope instances (`router`, `pluginManager`, …) + `bag.ctx` + `uploader.config` are safe in `controllerReady`; everything uploader-scope **and `telemetryManager`** (registration fires inside its own resolver) must use `bag.when`/`*OrNull`.

## Ports
- **DynamicBtn** + **NoWrapModeDynamicBtn** — star-key sub, 6 collection rewires, router/api/config.
- **ProgressBarCommon** — `init$` dropped (keys seeded by v1 uploader blocks), observers inner-trackSub'd (v1 parity — its v1 did unobserve).
- **FormInput** — `*collectionState` sub converted (no-dedup flag preserved); ElementInternals/validation byte-identical; one disclosed narrow widening: the name fallback now also accepts an inherited ctx-name per the ChildBlock contract (benign; own attribute still wins).

## Queue items
Dead `LitBlock.subActivityParams` deleted (zero consumers). ExternalSource `externalSourceType` fail-fast restored at the two v1-getter sites (deferred-mount soft path kept; slightly stricter falsy check + clearer message — both verified inert).

## Gate
tsc:app ✅ build ✅ tsc ✅ specs 588 ✅ locales ✅ e2e 300/300 exit 0 ✅ lint ✅

Follow-up batch queued (small): `apiOrNull` in DynamicBtn's throttled tick; deliberate post-parity unobserve for its collection observers; mixed-collection strengthening of the failed-entries test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dynamic Button “Remove” behavior across in-flight, failed, and completed upload states (abort, clear failed entries, or clear all).
  * Added validation to external-source flows to prevent missing source-type values from breaking URL generation or completion.
  * Refined Form Input upload state/hidden input handling and validation updates; improved common progress bar visibility and value synchronization.
* **Tests**
  * Added end-to-end coverage for Dynamic Button remove/abort behavior across upload states.
  * Added end-to-end coverage for common progress bar visibility and completion/value updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->