### PR TITLE
feat(m9i): container ports (Modal, UploadList, SourceList) + ChildBlock.emit + registry unregistration signal

### DIFF
--- a/src/abstract/UploaderRegistry.test.ts
+++ b/src/abstract/UploaderRegistry.test.ts
@@ -101,6 +101,84 @@ describe('UploaderRegistry', () => {
     expect(UploaderRegistry.get(name)).toBeUndefined();
   });
 
+  it('unregister notifies consumers with null', () => {
+    const name = uniqueName();
+    const controller = new UploaderController();
+    UploaderRegistry.register(name, controller);
+
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    cb.mockClear();
+
+    UploaderRegistry.unregister(name, controller);
+
+    expect(cb).toHaveBeenCalledWith(null);
+    off();
+  });
+
+  it('unregister of a stale controller does not notify consumers', () => {
+    const name = uniqueName();
+    const current = new UploaderController();
+    const stale = new UploaderController();
+    UploaderRegistry.register(name, current);
+
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    cb.mockClear();
+
+    UploaderRegistry.unregister(name, stale);
+
+    expect(cb).not.toHaveBeenCalled();
+
+    off();
+    UploaderRegistry.unregister(name, current);
+  });
+
+  it('re-registering after an unregister fires the new controller', () => {
+    const name = uniqueName();
+    const first = new UploaderController();
+    UploaderRegistry.register(name, first);
+
+    const cb = vi.fn();
+    const off = UploaderRegistry.whenAvailable(name, cb);
+    cb.mockClear();
+
+    UploaderRegistry.unregister(name, first);
+    expect(cb).toHaveBeenCalledWith(null);
+    cb.mockClear();
+
+    const second = new UploaderController();
+    UploaderRegistry.register(name, second);
+    expect(cb).toHaveBeenCalledWith(second);
+
+    off();
+    UploaderRegistry.unregister(name, second);
+  });
+
+  it('isolates a throwing consumer so other consumers are still notified on unregister', () => {
+    const name = uniqueName();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const controller = new UploaderController();
+
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    const offBad = UploaderRegistry.whenAvailable(name, bad);
+    const offGood = UploaderRegistry.whenAvailable(name, good);
+    UploaderRegistry.register(name, controller);
+    bad.mockClear();
+    good.mockClear();
+
+    expect(() => UploaderRegistry.unregister(name, controller)).not.toThrow();
+    expect(good).toHaveBeenCalledWith(null);
+    expect(warn).toHaveBeenCalled();
+
+    offBad();
+    offGood();
+    warn.mockRestore();
+  });
+
   it('unsubscribe stops further notifications', () => {
     const name = uniqueName();
     const cb = vi.fn();

--- a/src/abstract/UploaderRegistry.ts
+++ b/src/abstract/UploaderRegistry.ts
@@ -9,13 +9,17 @@ import type { UploaderController } from './controllers/UploaderController';
  * if a controller is already registered, immediately when one registers, and
  * AGAIN whenever the registration changes (e.g. the owning element is removed
  * and a new one with the same `ctx-name` is rendered). This lets consumers
- * re-adopt across a remount without losing their bindings.
+ * re-adopt across a remount without losing their bindings. It also fires with
+ * `null` when the registered controller for that `ctxName` is actually
+ * unregistered (the owning element disconnected and nothing has taken its
+ * place yet) — consumers must release the controller, not just ignore the
+ * notification, so they don't outlive the ctx they were reading from.
  *
  * Introduced as a standalone primitive in M0; wired to nothing yet.
  */
 class UploaderRegistryImpl {
   private _map = new Map<string, UploaderController>();
-  private _consumers = new Map<string, Set<(c: UploaderController) => void>>();
+  private _consumers = new Map<string, Set<(c: UploaderController | null) => void>>();
 
   public register(ctxName: string, controller: UploaderController): void {
     const existing = this._map.get(ctxName);
@@ -46,8 +50,23 @@ class UploaderRegistryImpl {
   }
 
   public unregister(ctxName: string, controller: UploaderController): void {
-    if (this._map.get(ctxName) === controller) {
-      this._map.delete(ctxName);
+    if (this._map.get(ctxName) !== controller) {
+      // Stale unregister (e.g. deferred from a disconnected element already
+      // replaced by a new registration) — the current owner is unaffected.
+      return;
+    }
+    this._map.delete(ctxName);
+    const set = this._consumers.get(ctxName);
+    if (set) {
+      // Isolate each consumer: a single throwing callback must not abort
+      // notification of the others or bubble out of `unregister()`.
+      for (const cb of set) {
+        try {
+          cb(null);
+        } catch (err) {
+          console.warn(`[uc] a whenAvailable consumer for ctx-name="${ctxName}" threw`, err);
+        }
+      }
     }
   }
 
@@ -58,9 +77,11 @@ class UploaderRegistryImpl {
   /**
    * Subscribe to the controller under `ctxName`. Fires synchronously with the
    * current controller (if registered), then again each time a new controller
-   * registers under the same name. Returns an unsubscribe.
+   * registers under the same name, and with `null` when that controller is
+   * unregistered (its ctx is gone — consumers must release, not just wait for
+   * a replacement that may never come). Returns an unsubscribe.
    */
-  public whenAvailable(ctxName: string, cb: (c: UploaderController) => void): () => void {
+  public whenAvailable(ctxName: string, cb: (c: UploaderController | null) => void): () => void {
     let set = this._consumers.get(ctxName);
     if (!set) {
       set = new Set();

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -138,7 +138,7 @@ export class DynamicBtn extends ChildBlock {
   }, 300);
 
   private _updateButtonBasedOnCollectionState() {
-    const collectionState = this.bag.api?.getOutputCollectionState();
+    const collectionState = this.bag.apiOrNull?.getOutputCollectionState();
 
     if (!collectionState) {
       console.warn('Collection state is undefined');

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -60,6 +60,8 @@ export class DynamicBtn extends ChildBlock {
   @state()
   private _mode: DynamicButtonMode = 'auto';
 
+  private _sourceListController: SourceListController | null = null;
+
   @state()
   private _sources: SourceButtonConfig[] = [];
 
@@ -167,7 +169,10 @@ export class DynamicBtn extends ChildBlock {
       }),
     );
 
-    new SourceListController(this, {
+    // Re-adoption would otherwise stack a new SourceListController per
+    // adoption without removing the previous one (same shape as SourceList).
+    this._teardownSourceListController();
+    this._sourceListController = new SourceListController(this, {
       ctx: this.bag.ctx,
       sharedInstancesBag: this.bag,
       onSourcesChange: (sources) => {
@@ -312,6 +317,19 @@ export class DynamicBtn extends ChildBlock {
         <uc-icon name="arrow-down"></uc-icon>
       </div>
     `;
+  }
+
+  protected override controllerReleased(): void {
+    this._teardownSourceListController();
+  }
+
+  private _teardownSourceListController(): void {
+    if (!this._sourceListController) {
+      return;
+    }
+    this._sourceListController.hostDisconnected();
+    this.removeController(this._sourceListController);
+    this._sourceListController = null;
   }
 
   public override render() {

--- a/src/blocks/Modal/Modal.ts
+++ b/src/blocks/Modal/Modal.ts
@@ -1,12 +1,12 @@
 import { html } from 'lit';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import './modal.css';
 import { property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import type { RegisteredActivityType } from '../../lit/activity-constants';
 import { getScrollLock } from '../../utils/scroll-lock';
 
-export class Modal extends LitBlock {
+export class Modal extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-modal'];
 
   private _mouseDownTarget: EventTarget | null | undefined;
@@ -35,7 +35,7 @@ export class Modal extends LitBlock {
     // can land after this block's ctx was torn down (deferred destroyCtx once
     // the last block disconnects) — there is no router to notify then, and
     // nothing left to close.
-    const router = this._getSharedContextInstance('*router', false);
+    const router = this.bag.routerOrNull;
     if (!router) {
       return;
     }
@@ -96,9 +96,7 @@ export class Modal extends LitBlock {
     }
   }
 
-  public override initCallback(): void {
-    super.initCallback();
-
+  protected override controllerReady(): void {
     this.subConfigValue('modalBackdropStrokes', (val: boolean) => {
       if (val) {
         this.setAttribute('strokes', '');
@@ -118,8 +116,8 @@ export class Modal extends LitBlock {
     // refcount keeps the body locked across modal-to-modal swaps and across
     // other uploader instances on the same page.
     this.subRouter(() => {
-      const isForeground = this.router.modal === (this.id as RegisteredActivityType);
-      if (isForeground && this.cfg.modalScrollLock) {
+      const isForeground = this.bag.router.modal === (this.id as RegisteredActivityType);
+      if (isForeground && this.uploader.config.get('modalScrollLock')) {
         this._releaseScrollLock ??= getScrollLock(document).acquire();
       } else {
         this._releaseScrollLock?.();

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
@@ -1,4 +1,4 @@
-import { html, type PropertyValues } from 'lit';
+import { html } from 'lit';
 import { state } from 'lit/decorators.js';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './progress-bar-common.css';
@@ -39,23 +39,6 @@ export class ProgressBarCommon extends ChildBlock {
         );
       }),
     );
-  }
-
-  protected override updated(changedProperties: PropertyValues<this>): void {
-    super.updated(changedProperties);
-
-    // Known-dead code, preserved bug-for-bug from v1: this checks
-    // `changedProperties.has('visible')` but the backing field is `_visible`,
-    // so this branch never fires and the host `active` attribute is never
-    // toggled. Not fixed here — activating it would change CSS-visible
-    // behavior that v1 never exercised (see M9h task-3 brief / progress.md).
-    if (changedProperties.has('visible' as keyof ProgressBarCommon)) {
-      if (this._visible) {
-        this.setAttribute('active', '');
-      } else {
-        this.removeAttribute('active');
-      }
-    }
   }
 
   public override render() {

--- a/src/blocks/SourceList/SourceList.ts
+++ b/src/blocks/SourceList/SourceList.ts
@@ -5,9 +5,9 @@ import { SourceListController } from '../../abstract/controllers';
 import type { SourceButtonConfig } from '../SourceBtn/SourceBtn';
 
 import '../SourceBtn/SourceBtn';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 
-export class SourceList extends LitUploaderBlock {
+export class SourceList extends ChildBlock {
   @state()
   private _sources: SourceButtonConfig[] = [];
 
@@ -17,12 +17,10 @@ export class SourceList extends LitUploaderBlock {
   @property({ type: Boolean, attribute: 'wrap', noAccessor: true })
   public wrap = false;
 
-  public override initCallback(): void {
-    super.initCallback();
-
+  protected override controllerReady(): void {
     new SourceListController(this, {
-      ctx: this._sharedInstancesBag.ctx,
-      sharedInstancesBag: this._sharedInstancesBag,
+      ctx: this.bag.ctx,
+      sharedInstancesBag: this.bag,
       onSourcesChange: (sources) => {
         this._sources = sources;
       },
@@ -32,7 +30,7 @@ export class SourceList extends LitUploaderBlock {
   protected override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
 
-    if (this.cfg.sourceListWrap) {
+    if (this.uploader.config.get('sourceListWrap')) {
       this.style.removeProperty('display');
     } else {
       this.style.display = 'contents';

--- a/src/blocks/SourceList/SourceList.ts
+++ b/src/blocks/SourceList/SourceList.ts
@@ -17,14 +17,34 @@ export class SourceList extends ChildBlock {
   @property({ type: Boolean, attribute: 'wrap', noAccessor: true })
   public wrap = false;
 
+  private _sourceListController: SourceListController | null = null;
+
   protected override controllerReady(): void {
-    new SourceListController(this, {
+    // Re-adoption (release-while-connected followed by re-adopt) would otherwise
+    // stack a new SourceListController per adoption without ever removing the
+    // previous one — tear down the old instance's subscriptions first.
+    this._teardownSourceListController();
+
+    this._sourceListController = new SourceListController(this, {
       ctx: this.bag.ctx,
       sharedInstancesBag: this.bag,
       onSourcesChange: (sources) => {
         this._sources = sources;
       },
     });
+  }
+
+  protected override controllerReleased(): void {
+    this._teardownSourceListController();
+  }
+
+  private _teardownSourceListController(): void {
+    if (!this._sourceListController) {
+      return;
+    }
+    this._sourceListController.hostDisconnected();
+    this.removeController(this._sourceListController);
+    this._sourceListController = null;
   }
 
   protected override updated(changedProperties: PropertyValues<this>): void {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -174,8 +174,6 @@ export class UploadList extends ActivityChildBlock {
     return localizedText('total');
   }
 
-  private _unregisterGuard?: () => void;
-
   protected override controllerReady(ctrl: UploaderController): void {
     super.controllerReady(ctrl);
 
@@ -184,10 +182,17 @@ export class UploadList extends ActivityChildBlock {
     // `revalidate()` (called on collection changes) leaves it once it empties.
     // `uploadCollection` may not have registered yet when this guard is later
     // invoked by the router (FileItem/DynamicBtn `bag.when`/`OrNull` precedent
-    // for the adoption-reentrancy race) — read it null-tolerantly.
-    this._unregisterGuard = this.bag.router.guard(
-      this.activityType,
-      () => this.uploader.config.get('showEmptyList') || (this.bag.uploadCollectionOrNull?.size ?? 0) > 0,
+    // for the adoption-reentrancy race) — read it null-tolerantly. Tracked
+    // like the other subscriptions below so teardown is uniform (release-time,
+    // not just disconnect) and the predicate itself reads the controller
+    // non-throwingly so a teardown-time navigation can't warn spuriously.
+    this.trackSub(
+      this.bag.router.guard(
+        this.activityType,
+        () =>
+          (this.uploaderOrNull?.config.get('showEmptyList') ?? false) ||
+          (this.bag.uploadCollectionOrNull?.size ?? 0) > 0,
+      ),
     );
 
     this.subConfigValue('multiple', this._throttledHandleCollectionUpdate);
@@ -230,12 +235,6 @@ export class UploadList extends ActivityChildBlock {
         this._commonErrorMessage = firstError.message;
       }),
     );
-  }
-
-  public override disconnectedCallback(): void {
-    super.disconnectedCallback();
-    this._unregisterGuard?.();
-    this._unregisterGuard = undefined;
   }
 
   protected override subscriptionsFor(ctrl: UploaderController) {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -1,7 +1,8 @@
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import { ACTIVITY_TYPES } from '../../lit/activity-constants';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
 import type { OutputCollectionErrorType, OutputError } from '../../types';
 import { throttle } from '../../utils/throttle';
 import { EventType, InternalEventType } from '../UploadCtxProvider/EventEmitter';
@@ -23,7 +24,7 @@ export type Summary = {
   validatingBeforeUploading: number;
 };
 
-export class UploadList extends LitUploaderBlock {
+export class UploadList extends ActivityChildBlock {
   public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
 
   @state()
@@ -58,7 +59,7 @@ export class UploadList extends LitUploaderBlock {
   }
 
   private _handleAdd = (): void => {
-    this.telemetryManager.sendEvent({
+    this.bag.telemetryManager.sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -67,22 +68,22 @@ export class UploadList extends LitUploaderBlock {
         },
       },
     });
-    this.api.initFlow(true);
+    this.bag.api.initFlow(true);
   };
 
   private _handleUpload = (): void => {
     this.emit(EventType.UPLOAD_CLICK);
-    this.api.uploadAll();
+    this.bag.api.uploadAll();
     this._throttledHandleCollectionUpdate();
   };
 
   private _handleDone = (): void => {
-    this.emit(EventType.DONE_CLICK, this.api.getOutputCollectionState());
-    this.api.doneFlow();
+    this.emit(EventType.DONE_CLICK, this.bag.api.getOutputCollectionState());
+    this.bag.api.doneFlow();
   };
 
   private _handleCancel = (): void => {
-    this.telemetryManager.sendEvent({
+    this.bag.telemetryManager.sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -92,7 +93,7 @@ export class UploadList extends LitUploaderBlock {
       },
     });
 
-    this.uploadCollection.clearAll();
+    this.bag.uploadCollection.clearAll();
   };
 
   private _throttledHandleCollectionUpdate = throttle(() => {
@@ -101,17 +102,17 @@ export class UploadList extends LitUploaderBlock {
     }
     this._updateUploadsState();
 
-    // The router guard (registered in initCallback) decides whether the empty
+    // The router guard (registered in controllerReady) decides whether the empty
     // list may stay open; ask it to re-check now that the collection changed.
-    this.router.revalidate();
+    this.bag.router.revalidate();
 
-    if (!this.cfg.confirmUpload) {
-      this.api.uploadAll();
+    if (!this.uploader.config.get('confirmUpload')) {
+      this.bag.api.uploadAll();
     }
   }, 300);
 
   private _updateUploadsState(): void {
-    const collectionState = this.api.getOutputCollectionState();
+    const collectionState = this.bag.api.getOutputCollectionState();
     const summary: Summary = {
       total: collectionState.totalCount,
       succeed: collectionState.successCount,
@@ -123,7 +124,8 @@ export class UploadList extends LitUploaderBlock {
       (err) => err.type === 'TOO_MANY_FILES' || err.type === 'TOO_FEW_FILES',
     );
     const tooMany = collectionState.errors.some((err) => err.type === 'TOO_MANY_FILES');
-    const exact = collectionState.totalCount === (this.cfg.multiple ? this.cfg.multipleMax : 1);
+    const multiple = this.uploader.config.get('multiple');
+    const exact = collectionState.totalCount === (multiple ? this.uploader.config.get('multipleMax') : 1);
     const isValidationPending = collectionState.allEntries.some((entry) => entry.isValidationPending);
     const validationOk = summary.failed === 0 && collectionState.errors.length === 0 && !isValidationPending;
     let uploadBtnVisible = false;
@@ -131,11 +133,11 @@ export class UploadList extends LitUploaderBlock {
     let doneBtnEnabled = false;
 
     const readyToUpload = summary.total - summary.succeed - summary.uploading - summary.failed;
-    if (readyToUpload > 0 && fitCountRestrictions && validationOk && this.cfg.confirmUpload) {
+    if (readyToUpload > 0 && fitCountRestrictions && validationOk && this.uploader.config.get('confirmUpload')) {
       uploadBtnVisible = true;
     } else {
       allDone = true;
-      const groupOk = this.cfg.groupOutput ? !!collectionState.group : true;
+      const groupOk = this.uploader.config.get('groupOutput') ? !!collectionState.group : true;
       doneBtnEnabled = summary.total === summary.succeed && fitCountRestrictions && validationOk && groupOk;
     }
 
@@ -143,7 +145,7 @@ export class UploadList extends LitUploaderBlock {
     this._doneBtnEnabled = doneBtnEnabled;
     this._uploadBtnVisible = uploadBtnVisible;
     this._addMoreBtnEnabled = summary.total === 0 || (!tooMany && !exact);
-    this._addMoreBtnVisible = !exact || this.cfg.multiple;
+    this._addMoreBtnVisible = !exact || multiple;
     this._hasFiles = summary.total > 0;
 
     this._latestSummary = summary;
@@ -174,25 +176,30 @@ export class UploadList extends LitUploaderBlock {
 
   private _unregisterGuard?: () => void;
 
-  public override initCallback() {
-    super.initCallback();
+  protected override controllerReady(ctrl: UploaderController): void {
+    super.controllerReady(ctrl);
 
     // Guard: the upload list may only be open while it has files (or
     // `showEmptyList`). The router blocks navigating into it otherwise and
     // `revalidate()` (called on collection changes) leaves it once it empties.
-    this._unregisterGuard = this.router.guard(
+    // `uploadCollection` may not have registered yet when this guard is later
+    // invoked by the router (FileItem/DynamicBtn `bag.when`/`OrNull` precedent
+    // for the adoption-reentrancy race) — read it null-tolerantly.
+    this._unregisterGuard = this.bag.router.guard(
       this.activityType,
-      () => this.cfg.showEmptyList || this.uploadCollection.size > 0,
+      () => this.uploader.config.get('showEmptyList') || (this.bag.uploadCollectionOrNull?.size ?? 0) > 0,
     );
 
     this.subConfigValue('multiple', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMin', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMax', this._throttledHandleCollectionUpdate);
-    this.sub('*groupInfo', (groupInfo) => {
-      if (groupInfo) {
-        this._throttledHandleCollectionUpdate();
-      }
-    });
+    this.trackSub(
+      this.bag.ctx.sub('*groupInfo', (groupInfo) => {
+        if (groupInfo) {
+          this._throttledHandleCollectionUpdate();
+        }
+      }),
+    );
 
     this.subConfigValue('filesViewMode', (mode: FilesViewMode) => {
       this.setAttribute('mode', mode);
@@ -200,27 +207,39 @@ export class UploadList extends LitUploaderBlock {
 
     // TODO: could be performance issue on many files
     // there is no need to update buttons state on every progress tick
-    this.uploadCollection.observeProperties(this._throttledHandleCollectionUpdate);
-    this.uploadCollection.observeCollection(this._throttledHandleCollectionUpdate);
+    //
+    // The uploader-scope `*uploadCollection` instance may not have registered
+    // yet when this block's controller adopts — go through `bag.when` rather
+    // than the throwing `bag.uploadCollection` getter (FileItem/DynamicBtn
+    // precedent), and track the observer unsubscribers so release/re-adoption
+    // can't stack duplicate observers.
+    this.trackSub(
+      this.bag.when('uploadCollection', (collection) => {
+        this.trackSub(collection.observeProperties(this._throttledHandleCollectionUpdate));
+        this.trackSub(collection.observeCollection(this._throttledHandleCollectionUpdate));
+      }),
+    );
 
-    this.sub('*collectionErrors', (errors: OutputError<OutputCollectionErrorType>[]) => {
-      const firstError = errors.filter((err) => err.type !== 'SOME_FILES_HAS_ERRORS')[0];
-      if (!firstError) {
-        this._commonErrorMessage = null;
-        return;
-      }
-      this._commonErrorMessage = firstError.message;
-    });
+    this.trackSub(
+      this.bag.ctx.sub('*collectionErrors', (errors: OutputError<OutputCollectionErrorType>[]) => {
+        const firstError = errors.filter((err) => err.type !== 'SOME_FILES_HAS_ERRORS')[0];
+        if (!firstError) {
+          this._commonErrorMessage = null;
+          return;
+        }
+        this._commonErrorMessage = firstError.message;
+      }),
+    );
   }
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
     this._unregisterGuard?.();
     this._unregisterGuard = undefined;
-    if (this.has('*uploadCollection')) {
-      this.uploadCollection.unobserveProperties(this._throttledHandleCollectionUpdate);
-      this.uploadCollection.unobserveCollection(this._throttledHandleCollectionUpdate);
-    }
+  }
+
+  protected override subscriptionsFor(ctrl: UploaderController) {
+    return [(listener: () => void) => ctrl.locale.subscribe(listener)];
   }
 
   public override render() {
@@ -230,7 +249,7 @@ export class UploadList extends LitUploaderBlock {
     <button
       type="button"
       class="uc-mini-btn uc-close-btn"
-      @click=${() => this.router.traverse('onClose')}
+      @click=${() => this.bag.router.traverse('onClose')}
       title=${this.l10n('a11y-activity-header-button-close')}
       aria-label=${this.l10n('a11y-activity-header-button-close')}
     >
@@ -245,7 +264,7 @@ export class UploadList extends LitUploaderBlock {
   <div class="uc-files">
     <div class="uc-files-wrapper">
     ${repeat(
-      this.$['*uploadList'] ?? [],
+      this.bag.ctx.read('*uploadList') ?? [],
       ({ uid }) => uid,
       ({ uid }) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
     )}

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -96,18 +96,22 @@ export class UploadList extends ActivityChildBlock {
     this.bag.uploadCollection.clearAll();
   };
 
+  // A trailing tick can fire after the block is released while still connected
+  // (registry unregistration race) — read the controller null-tolerantly and
+  // bail rather than throwing uncaught in the timeout (DynamicBtn precedent).
   private _throttledHandleCollectionUpdate = throttle(() => {
-    if (!this.isConnected) {
+    const uploader = this.uploaderOrNull;
+    if (!this.isConnected || !uploader) {
       return;
     }
     this._updateUploadsState();
 
     // The router guard (registered in controllerReady) decides whether the empty
     // list may stay open; ask it to re-check now that the collection changed.
-    this.bag.router.revalidate();
+    this.bag.routerOrNull?.revalidate();
 
-    if (!this.uploader.config.get('confirmUpload')) {
-      this.bag.api.uploadAll();
+    if (!uploader.config.get('confirmUpload')) {
+      this.bag.apiOrNull?.uploadAll();
     }
   }, 300);
 

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -24,7 +24,11 @@ const ChildBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
  * `ctx-name` attribute or, when absent, from the nearest v1 ancestor's
  * `ctxNameContext` provider — via `UploaderRegistry.whenAvailable`, which
  * fires synchronously when a controller is already registered and again
- * across a remount, so subclasses re-adopt without losing bindings.
+ * across a remount, so subclasses re-adopt without losing bindings. If the
+ * ctx dies while this block stays connected (the last v1 block elsewhere
+ * disconnected and tore the ctx down), the registry notifies with `null` and
+ * the block releases its controller — closing the render gate — rather than
+ * outliving the ctx it was reading from.
  *
  * Subclasses read controllers directly: no `$` proxy, no `init$`, no
  * nanostores. Rendering is gated until a controller is adopted (matching
@@ -205,7 +209,13 @@ export abstract class ChildBlock extends ChildBlockBase {
     if (!ctxName) {
       return;
     }
-    this._registryUnsub = UploaderRegistry.whenAvailable(ctxName, (ctrl) => this._adoptController(ctrl));
+    this._registryUnsub = UploaderRegistry.whenAvailable(ctxName, (ctrl) => {
+      if (ctrl) {
+        this._adoptController(ctrl);
+      } else {
+        this._releaseController();
+      }
+    });
   }
 
   private _adoptController(ctrl: UploaderController): void {

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -4,6 +4,7 @@ import { property, state } from 'lit/decorators.js';
 import type { UploaderController } from '../abstract/controllers/UploaderController';
 import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
+import type { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { ConfigType } from '../types';
 import type { ActivityId } from './activity-constants';
 import { LightDomMixin } from './LightDomMixin';
@@ -113,6 +114,34 @@ export abstract class ChildBlock extends ChildBlockBase {
    * text re-renders when the dictionary loads or the locale switches.
    */
   public l10n = createL10n(() => this._requireCtx());
+
+  /**
+   * Emit a documented uploader event with the telemetry mirror — same
+   * contract as v1 `LitBlock.emit`. Guarded for teardown: emissions can race
+   * ctx destruction (queued events), so a missing emitter is a no-op and a
+   * telemetry failure is contained.
+   */
+  public emit(
+    type: Parameters<EventEmitter['emit']>[0],
+    payload?: Parameters<EventEmitter['emit']>[1],
+    options?: Parameters<EventEmitter['emit']>[2],
+  ): void {
+    const ctx = this.effectiveCtxName ? PubSub.getCtx<SharedState>(this.effectiveCtxName) : null;
+    const eventEmitter = ctx?.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
+    if (!eventEmitter) {
+      return;
+    }
+    eventEmitter.emit(type, payload, options);
+    const resolvedPayload = typeof payload === 'function' ? payload() : payload;
+    try {
+      this.bag.telemetryManager.sendEvent({
+        eventType: type,
+        payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
+      });
+    } catch {
+      // Telemetry may already be torn down — reporting must never throw.
+    }
+  }
 
   public override connectedCallback(): void {
     super.connectedCallback();

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -186,6 +186,13 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
         return null;
       }
     },
+    get routerOrNull(): RouterController | null {
+      try {
+        return getSharedInstance(getCtx(), '*router', false) ?? null;
+      } catch {
+        return null;
+      }
+    },
 
     when<TName extends InstanceName>(
       name: TName,

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -2,10 +2,11 @@ import { html } from 'lit';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { UploaderController } from '@/abstract/controllers/UploaderController';
-import type { Config } from '@/index.ts';
+import type { Config, UploadCtxProvider } from '@/index.ts';
 import { ChildBlock } from '@/lit/ChildBlock';
 import { LitBlock } from '@/lit/LitBlock';
 import { getCtxName } from '../utils/getCtxName';
+import { cleanup } from '../utils/test-renderer';
 import '../../types/jsx';
 
 class TestChildBlock extends ChildBlock {
@@ -15,6 +16,14 @@ class TestChildBlock extends ChildBlock {
   public throwOnRelease = false;
   public throwInReady = false;
   public cleanupRanAfterThrow = false;
+
+  public fireDocumentedEvent(): void {
+    this.emit('upload-click', undefined);
+  }
+
+  public routerOrNull() {
+    return this.bag.routerOrNull;
+  }
 
   protected override subscriptionsFor(ctrl: UploaderController) {
     return [
@@ -275,5 +284,76 @@ describe('ChildBlock', () => {
     } finally {
       warnSpy.mockRestore();
     }
+  });
+
+  it('bag.routerOrNull is null (no throw) before adoption and resolves once a controller is adopted', async () => {
+    const child = document.createElement('test-child-block');
+    // No ctx-name at all: `_requireCtx` throws internally; `routerOrNull` must
+    // swallow that and report `null`, same contract as `uploadCollectionOrNull`/`apiOrNull`.
+    expect(child.routerOrNull()).toBeNull();
+
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    child.setAttribute('ctx-name', ctxName);
+    document.body.append(child);
+    appended.push(child);
+
+    await expect.poll(() => child.readyCount).toBe(1);
+    expect(child.routerOrNull()).not.toBeNull();
+  });
+
+  it('emit dispatches the documented event on the same-ctx uc-upload-ctx-provider', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+
+    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const handler = vi.fn<(e: CustomEvent<unknown>) => void>();
+    ctxProvider.addEventListener('upload-click', handler);
+
+    child.fireDocumentedEvent();
+
+    await expect.poll(() => handler.mock.calls.length).toBe(1);
+  });
+
+  it('emit is a silent no-op once the ctx has been torn down', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      </>,
+    );
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+
+    // Disconnect the child (releasing its controller/subscriptions, same as
+    // any real unmount) and unmount the rest of the uploader; the ctx
+    // destroys via a deferred task once the last block disconnects. The
+    // child's `ctx-name` attribute is untouched by `remove()` — same as a
+    // queued event callback holding a reference to an unmounted block.
+    child.remove();
+    cleanup();
+    const { PubSub } = await import('@/lit/PubSubCompat.js');
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      expect(() => child.fireDocumentedEvent()).not.toThrow();
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
   });
 });

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -356,4 +356,39 @@ describe('ChildBlock', () => {
     }
     expect(errors).toEqual([]);
   });
+
+  it('releases the controller when its ctx is destroyed while still connected, and a later render throws no window errors', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-child-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.querySelector('.pk')?.textContent).toBe('demopublickey');
+    expect(child.releasedCount).toBe(0);
+
+    // Tear down the ctx while the fixture stays connected: only the
+    // uc-config (a v1 LitBlock) unmounts, so the ctx is destroyed via the
+    // deferred blocksRegistry-empty task, exactly as when the last v1 block
+    // elsewhere in the tree disconnects.
+    cleanup();
+    const { PubSub } = await import('@/lit/PubSubCompat.js');
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+    expect(child.isConnected).toBe(true);
+    await expect.poll(() => child.releasedCount).toBe(1);
+    // biome-ignore lint/suspicious/noExplicitAny: reaching into a protected getter
+    expect((child as any).uploaderOrNull).toBeNull();
+
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      child.requestUpdate();
+      await child.updateComplete;
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
+  });
 });

--- a/tests/blocks/dynamic-btn.e2e.test.tsx
+++ b/tests/blocks/dynamic-btn.e2e.test.tsx
@@ -64,29 +64,51 @@ describe('DynamicBtn remove/abort action', () => {
     expect(api.getOutputCollectionState().successCount).toBe(0);
   }, 30_000);
 
-  it('clears only failed entries when the abort action is clicked in the failed state', async () => {
+  it('clears only the failed entry when the abort action is clicked over a mixed failed/uploading collection', async () => {
     const { dynamicBtn, api } = renderDynamicBtn();
     const config = page.getByTestId('uc-config').query()! as Config;
-    config.fileValidators = [() => ({ message: 'Bad file' })];
+    // Only the entry named 'bad.jpg' is destined to fail — the valid entry
+    // added alongside it must survive `_clearAllFailedEntries` untouched.
+    config.fileValidators = [(entry) => (entry.name === 'bad.jpg' ? { message: 'Bad file' } : undefined)];
 
     await expect.element(dynamicBtn).toBeVisible();
 
-    // Go through the file chooser (not `api.initFlow()`, which navigates
-    // straight to the upload-list modal once the collection is non-empty)
-    // so DynamicBtn's own `onFileAdd` hook stays in control and the modal
-    // never opens over the abort button — matching the non-confirm flow
-    // already pinned in tests/dynamic-btn-upload-list.e2e.test.tsx.
-    commands.waitFileChooserAndUpload(['../fixtures/test_image.jpeg']);
-    await dynamicBtn.click();
+    const badFile = new File(['(⌐□_□)'], 'bad.jpg', { type: 'image/jpeg' });
+    api.addFileFromObject(badFile);
 
-    await expect.poll(() => api.getOutputCollectionState().status).toBe('failed');
+    // Validation runs asynchronously (`ValidationController`'s debounced
+    // queue) — let the bad entry actually fail *before* adding the valid one
+    // and calling `uploadAll()`, or `uploadAll()` (which only skips entries
+    // that already carry errors) could race the validator and upload it too.
+    await expect.poll(() => api.getOutputCollectionState().failedCount, { timeout: 10_000 }).toBe(1);
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.uploadAll();
+
+    // `buildOutputCollectionState`'s status resolves `isFailed` before
+    // `isUploading` (see `src/abstract/buildOutputCollectionState.ts`), so the
+    // collection reaches 'failed' even while the valid entry is still
+    // mid-upload — pinning that `_handleRemove`'s switch takes the 'failed'
+    // branch (`_clearAllFailedEntries`), not the 'uploading' one, in a mix.
+    await expect.poll(() => api.getOutputCollectionState().status, { timeout: 10_000 }).toBe('failed');
+    expect(api.getOutputCollectionState().failedCount).toBe(1);
+    expect(api.getOutputCollectionState().totalCount).toBe(2);
 
     const abortBtn = dynamicBtn.getByLabelText('Remove');
     await expect.element(abortBtn).toBeVisible();
+    // `_handleRemove`'s branch is keyed off DynamicBtn's own throttled
+    // `_status` (not the raw collection state polled above), so wait for the
+    // button's `uc-failed` class — its render is driven by that same
+    // `_status` — before clicking, or a race could still catch the button in
+    // an earlier ('uploading'/'idle') branch and abort/clear everything.
+    await expect.poll(() => abortBtn.element().classList.contains('uc-failed'), { timeout: 10_000 }).toBe(true);
     await abortBtn.click();
 
-    await expect.poll(() => api.getOutputCollectionState().totalCount).toBe(0);
-  });
+    await expect.poll(() => api.getOutputCollectionState().failedCount, { timeout: 10_000 }).toBe(0);
+    // The valid, still in-flight entry must not be swept up by the clear.
+    expect(api.getOutputCollectionState().totalCount).toBe(1);
+    expect(api.getOutputCollectionState().allEntries[0]?.externalUrl).toBe(TEST_IMAGE_URL);
+  }, 30_000);
 
   it('clears all entries when the remove action is clicked after a successful upload', async () => {
     const { dynamicBtn, api } = renderDynamicBtn();

--- a/tests/blocks/modal.e2e.test.tsx
+++ b/tests/blocks/modal.e2e.test.tsx
@@ -1,5 +1,6 @@
-import { beforeAll, describe, expect, it } from 'vitest';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import type { EventPayload, UploadCtxProvider } from '@/index.js';
 import { PubSub } from '@/lit/PubSubCompat';
 import { getCtxName } from '../utils/getCtxName';
 import { cleanup } from '../utils/test-renderer';
@@ -8,6 +9,40 @@ import '../../types/jsx';
 beforeAll(async () => {
   const UC = await import('@/index.js');
   UC.defineComponents(UC);
+});
+
+describe('uc-modal native close routing', () => {
+  it('a native dialog "close" event (Esc / native close) routes through the router as modal-close', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const modalCloseHandler = vi.fn<(e: CustomEvent<EventPayload['modal-close']>) => void>();
+    ctxProvider.addEventListener('modal-close', modalCloseHandler);
+
+    const dialog = document.querySelector('uc-modal dialog') as HTMLDialogElement;
+    expect(dialog).toBeTruthy();
+
+    // Simulate the browser's native close (Esc key / native dialog dismissal):
+    // the <dialog> fires its own "close" event, which `Modal._handleDialogClose`
+    // routes to `router.closeModal()` — this must reach the documented
+    // `modal-close` event, not just flip an internal flag.
+    dialog.dispatchEvent(new Event('close'));
+
+    await expect.poll(() => modalCloseHandler.mock.calls.length).toBe(1);
+    expect(modalCloseHandler.mock.calls[0][0].detail).toMatchObject({ hasActiveModals: false });
+    // The router's foreground modal slot cleared: the Modal block reflects
+    // that back onto the dialog's a11y state.
+    await expect.poll(() => document.querySelector('uc-modal')?.getAttribute('aria-modal')).toBe('false');
+  });
 });
 
 describe('uc-modal teardown', () => {

--- a/tests/blocks/upload-list.e2e.test.tsx
+++ b/tests/blocks/upload-list.e2e.test.tsx
@@ -1,0 +1,68 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { UploadCtxProvider } from '@/index.js';
+import { TEST_IMAGE_URL } from '../utils/constants';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+/**
+ * M9i Task 1 gap-fill — `UploadList` has no dedicated suite; the
+ * `.uc-common-error` rendering driven by `*collectionErrors` (UploadList.ts)
+ * was entirely untested ahead of the container's v2 port.
+ */
+describe('uc-upload-list common error rendering', () => {
+  it('shows .uc-common-error once a collection-level validation error is set, and hides it again once resolved', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config
+          qualityInsights={false}
+          ctx-name={ctxName}
+          pubkey="demopublickey"
+          testMode
+          multiple
+          multipleMax={1}
+          confirmUpload
+        ></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+    // Two idle files against `multipleMax: 1` trips the collection-level
+    // TOO_MANY_FILES validator, which UploadList surfaces as a common error.
+    // `initFlow()` is the real navigation driver into upload-list (v1 parity
+    // with the start-from suite) — `addFileFromUrl` alone only adds to the
+    // collection, it doesn't navigate.
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.addFileFromUrl(TEST_IMAGE_URL);
+    api.initFlow();
+
+    const uploadList = page.getByTestId('uc-upload-list');
+    await expect.element(uploadList).toBeVisible();
+
+    const commonError = () => document.querySelector('uc-upload-list .uc-common-error');
+    await expect.poll(() => commonError()?.hasAttribute('hidden')).toBe(false);
+    await expect
+      .poll(() => commonError()?.textContent?.trim())
+      .toBe('You’ve chosen too many files. 1 file is maximum.');
+
+    // Raising the limit clears the collection-level error and the message
+    // hides again — same `*collectionErrors` sub, opposite direction.
+    const config = document.querySelector('uc-config') as HTMLElement & { multipleMax: number };
+    config.multipleMax = 2;
+
+    await expect.poll(() => commonError()?.hasAttribute('hidden')).toBe(true);
+  });
+});


### PR DESCRIPTION
Ninth slice of M9 ([MIGRATION-PLAN.md](./MIGRATION-PLAN.md) §7). **25 blocks on `ChildBlock`** — the container layer is ported.

## Base additions (TDD)
- **`ChildBlock.emit`** — v1 `LitBlock.emit` parity (same emitter guard, payload resolution, cast) plus the plan-mandated teardown-safe telemetry containment.
- **`bag.routerOrNull`** — so Modal's #1005 teardown tolerance survives the port.
- **Registry unregistration signal** (inserted slice — a Task 1 teardown test surfaced a REAL infra gap, opus-verified): a connected cross-DOM `ChildBlock` could outlive its destroyed ctx (`_controller` never nulled → later async render threw through `_requireCtx`). `whenAvailable` consumers now receive `null` on unregistration; the block releases while staying connected (gate closes, `controllerReleased` fires) and re-adopts on re-registration. Replace-registration race, stale-unregister no-op, and throw isolation all pinned by new specs. This closes the long-queued "UploaderRegistry unregistration signal" item.

## Ports
- **Modal** — dashboard-coupled `dialogEl`/`closeDialog` names/signatures untouched (diff-verified); `closeDialog` keeps the #1005 guard via `routerOrNull`; show/hide/scroll-lock byte-identical.
- **UploadList** — first ActivityChildBlock container (mounted-activity signal + `[active]` from the base); adoption-reentrancy partition applied strictly; router guard now `trackSub`-tracked with a non-throwing predicate.
- **SourceList** — near-trivial swap.

## Cleanup batch
`apiOrNull` in DynamicBtn's throttled tick; mixed-collection abort test (discriminates `_clearAllFailedEntries` from `_clearAllEntries`; throttle-aware condition wait); **ProgressBarCommon's confirmed-dead `active` toggle DELETED** — its CSS `:not([active])` applies constantly today, so deletion is provably zero-behavior-change; *activating* the toggle (the apparent original design intent) is a separate product-visual decision, flagged for review.

## Gate
tsc:app ✅ build ✅ tsc ✅ specs 592 ✅ locales ✅ e2e 306/306 exit 0 ✅ lint ✅

M9j queue (from the final review, all Minor): `*uploadList` render subscription restoring v1's next-tick item latency; SourceListController re-adoption accumulation (new checklist rule: controllerReady must be re-entrant-safe); OrNull sweep for async callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added controller availability notifications that update consumers when controllers are unregistered or replaced.
  - Added safe event dispatching and null-tolerant router access for child components.

- **Bug Fixes**
  - Improved modal close routing and accessibility state updates during teardown.
  - Strengthened lifecycle teardown to prevent errors after context/controller release.
  - Made DynamicBtn output-state handling null-safe and prevented controller stacking.

- **Tests**
  - Added/expanded e2e coverage for router adoption, event behavior after teardown, and UploadList collection-level validation (“common error”) rendering updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->