### PR TITLE
feat(m9j): activity-host ports + registry-arm retirement

### DIFF
--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -369,7 +369,7 @@ export class UploaderPublicApi extends SharedInstance {
     void this._pluginsReady().then(() => {
       this._sharedInstancesBag.router.navigate(activityType, params[0] ?? {});
       if (activityType !== null) {
-        waitForActivityBlock(this._sharedInstancesBag.blocksRegistry, this._sharedInstancesBag.router, activityType, {
+        waitForActivityBlock(this._sharedInstancesBag.router, activityType, {
           onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
           timeout: 100,
         });
@@ -400,7 +400,7 @@ export class UploaderPublicApi extends SharedInstance {
         return;
       }
       this._sharedInstancesBag.router.setActivity(activityType, params[0]);
-      waitForActivityBlock(this._sharedInstancesBag.blocksRegistry, this._sharedInstancesBag.router, activityType, {
+      waitForActivityBlock(this._sharedInstancesBag.router, activityType, {
         onTimeout: () => console.warn(`Activity type "${activityType}" not found in the context`),
         timeout: 100,
       });
@@ -443,14 +443,9 @@ export class UploaderPublicApi extends SharedInstance {
         return;
       }
 
-      return waitForActivityBlock(
-        this._sharedInstancesBag.blocksRegistry,
-        this._sharedInstancesBag.router,
-        activityType,
-        {
-          onTimeout: () => console.warn(`Activity block "${activityType}" not found in the context`),
-        },
-      ).then((found) => {
+      return waitForActivityBlock(this._sharedInstancesBag.router, activityType, {
+        onTimeout: () => console.warn(`Activity block "${activityType}" not found in the context`),
+      }).then((found) => {
         if (!found) {
           // Timeout — the activity's block never appeared; keep the modal
           // closed (same observable behavior as before the promise settled).

--- a/src/abstract/UploaderRegistry.test.ts
+++ b/src/abstract/UploaderRegistry.test.ts
@@ -169,6 +169,7 @@ describe('UploaderRegistry', () => {
     UploaderRegistry.register(name, controller);
     bad.mockClear();
     good.mockClear();
+    warn.mockClear();
 
     expect(() => UploaderRegistry.unregister(name, controller)).not.toThrow();
     expect(good).toHaveBeenCalledWith(null);

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
@@ -1,8 +1,10 @@
 import { html, nothing } from 'lit';
 import { state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { TypedData } from '../../abstract/TypedData';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
+import { createDebugPrinter } from '../../lit/createDebugPrinter';
 import type { ApplyResult, ChangeResult } from '../CloudImageEditor/src/types';
 import './cloud-image-editor-activity.css';
 import type { UploadEntryData } from '../../abstract/uploadEntrySchema';
@@ -18,23 +20,17 @@ type EditorTemplateConfig = {
   tabs: string;
 };
 
-export class CloudImageEditorActivity extends LitUploaderBlock {
+export class CloudImageEditorActivity extends ActivityChildBlock {
   private _entry?: TypedData<UploadEntryData>;
 
   @state()
   private _editorConfig: EditorTemplateConfig | null = null;
 
-  public override get activityParams(): ActivityParams {
-    const params = super.activityParams;
+  /** Same contract as v1 `LitBlock.debugPrint` (`createDebugPrinter`), scoped to this ctx. */
+  private _debugPrint = createDebugPrinter(() => this.bag.ctx, this.constructor.name);
 
-    if ('internalId' in params) {
-      return params as ActivityParams;
-    }
-    throw new Error(`Cloud Image Editor activity params not found`);
-  }
-
-  public override initCallback(): void {
-    super.initCallback();
+  protected override controllerReady(ctrl: UploaderController): void {
+    super.controllerReady(ctrl);
 
     this.subConfigValue('cropPreset', (cropPreset) => {
       if (!this._editorConfig) {
@@ -74,7 +70,7 @@ export class CloudImageEditorActivity extends LitUploaderBlock {
     if (!this._entry) {
       return;
     }
-    this.debugPrint(`editor event "apply"`, e.detail);
+    this._debugPrint(`editor event "apply"`, e.detail);
     const result = e.detail;
     this._entry.setMultipleValues({
       cdnUrl: result.cdnUrl,
@@ -82,31 +78,42 @@ export class CloudImageEditorActivity extends LitUploaderBlock {
     });
     // The back intent closes the cloud-editor activity and returns to the
     // previous one.
-    this.router.traverse('onBack');
+    this.bag.router.traverse('onBack');
   }
 
   private _handleCancel(event?: Event): void {
     const detail = event instanceof CustomEvent ? event.detail : undefined;
-    this.debugPrint(`editor event "cancel"`, detail);
-    this.router.traverse('onBack');
+    this._debugPrint(`editor event "cancel"`, detail);
+    this.bag.router.traverse('onBack');
   }
 
   public handleChange(event: CustomEvent<ChangeResult>): void {
-    this.debugPrint(`editor event "change"`, event.detail);
+    this._debugPrint(`editor event "change"`, event.detail);
   }
 
   private _mountEditor(): void {
-    const { internalId } = this.activityParams;
-    const entry = this.uploadCollection.read(internalId as Uid);
-    if (!entry) {
-      throw new Error(`Entry with internalId "${internalId}" not found`);
-    }
-    this._entry = entry;
-    const cdnUrl = this._entry.getValue('cdnUrl');
-    if (!cdnUrl) {
-      throw new Error(`Entry with internalId "${internalId}" hasn't uploaded yet`);
-    }
-    this._editorConfig = this._createEditorConfig(cdnUrl);
+    // `internalId` comes from the router-params object, whose shape is a
+    // per-activity contract (ExternalSource precedent) rather than a runtime
+    // guard the router already enforces.
+    const { internalId } = this.bag.router.params as ActivityParams;
+    // The uploader-scope `*uploadCollection` instance may not have registered
+    // yet when this block's controller adopts (controllerReady is an
+    // adoption path) — go through `bag.when` rather than the throwing
+    // `bag.uploadCollection` getter (FileItem/UploadList precedent).
+    this.trackSub(
+      this.bag.when('uploadCollection', (collection) => {
+        const entry = collection.read(internalId as Uid);
+        if (!entry) {
+          throw new Error(`Entry with internalId "${internalId}" not found`);
+        }
+        this._entry = entry;
+        const cdnUrl = this._entry.getValue('cdnUrl');
+        if (!cdnUrl) {
+          throw new Error(`Entry with internalId "${internalId}" hasn't uploaded yet`);
+        }
+        this._editorConfig = this._createEditorConfig(cdnUrl);
+      }),
+    );
   }
 
   private _unmountEditor(): void {
@@ -136,8 +143,8 @@ export class CloudImageEditorActivity extends LitUploaderBlock {
   private _createEditorConfig(cdnUrl: string): EditorTemplateConfig {
     const config: EditorTemplateConfig = {
       cdnUrl,
-      cropPreset: this.cfg.cropPreset,
-      tabs: this.cfg.cloudImageEditorTabs,
+      cropPreset: this.uploader.config.get('cropPreset'),
+      tabs: this.uploader.config.get('cloudImageEditorTabs'),
     };
     return config;
   }

--- a/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
+++ b/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
@@ -2,14 +2,21 @@ import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { repeat } from 'lit/directives/repeat.js';
-import type { Owned, PluginActivityRegistration, PluginRenderDispose } from '../../abstract/managers/plugin';
+import type { RouterController } from '../../abstract/controllers/RouterController';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import type {
+  Owned,
+  PluginActivityRegistration,
+  PluginController,
+  PluginRenderDispose,
+} from '../../abstract/managers/plugin';
+import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import type { ActivityType } from '../../lit/activity-constants';
-import { LitActivityBlock } from '../../lit/LitActivityBlock';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
 import '../Modal/Modal';
 import './uc-plugin-activity-host.css';
 
-export class PluginActivityHost extends LitActivityBlock {
+export class PluginActivityHost extends ActivityChildBlock {
   @property({ attribute: false })
   public registration!: Owned<PluginActivityRegistration>;
 
@@ -17,9 +24,14 @@ export class PluginActivityHost extends LitActivityBlock {
   private _containerRef = createRef<HTMLDivElement>();
   private _isMounted = false;
 
-  public override initCallback(): void {
+  /** Test-only public surface (`plugin-activity-host.e2e.test.tsx`) mirroring v1's `LitBlock.router` getter. */
+  public get router(): RouterController {
+    return this.bag.router;
+  }
+
+  protected override controllerReady(ctrl: UploaderController): void {
     this.activityType = (this.registration?.id as ActivityType) ?? null;
-    super.initCallback();
+    super.controllerReady(ctrl);
   }
 
   protected override updated(changed: PropertyValues<this>): void {
@@ -32,6 +44,10 @@ export class PluginActivityHost extends LitActivityBlock {
       if (id) {
         this.setAttribute('activity', id);
       }
+      // Move the mounted-activity signal from the stale id to the new one so
+      // API waits (navigate/setModalState) find this host under its current
+      // activityType right away, rather than after the next render cycle.
+      this.reportActivityMounted();
     }
 
     // Own the plugin's render()/dispose() lifecycle: mount when this activity
@@ -50,7 +66,7 @@ export class PluginActivityHost extends LitActivityBlock {
       return;
     }
     try {
-      this._dispose = this.registration.render(container, this.router.params) ?? undefined;
+      this._dispose = this.registration.render(container, this.bag.router.params) ?? undefined;
       this._isMounted = true;
     } catch (error) {
       console.error(`[Plugin "${this.registration.pluginId}"] Activity render() threw an error`, error);
@@ -78,40 +94,39 @@ export class PluginActivityHost extends LitActivityBlock {
   }
 }
 
-export class PluginActivityRenderer extends LitBlock {
+export class PluginActivityRenderer extends ChildBlock {
   @property({ type: String })
   public mode: 'modal' | 'inline' = 'modal';
 
   @state()
   private _activities: Owned<PluginActivityRegistration>[] = [];
 
-  private _unsubscribePlugins?: () => void;
+  // Transiently null until the shared PluginController registers (bag.when) —
+  // render falls back to an empty activity list meanwhile (Icon/FileItem precedent).
+  private _pluginManager: PluginController | null = null;
 
-  public override initCallback(): void {
-    super.initCallback();
+  protected override controllerReady(): void {
+    this.trackSub(
+      this.bag.when('pluginManager', (pluginManager) => {
+        this._pluginManager = pluginManager;
+        this.trackSub(pluginManager.onPluginsChange(() => this._syncActivities()));
+        this._syncActivities();
+      }),
+    );
+  }
 
-    const pluginManager = this._sharedInstancesBag.pluginManager;
-    if (pluginManager?.onPluginsChange) {
-      this._unsubscribePlugins = pluginManager.onPluginsChange(() => this._syncActivities());
-    }
-
-    this._syncActivities();
+  protected override controllerReleased(): void {
+    this._pluginManager = null;
   }
 
   private _syncActivities(): void {
-    const pluginManager = this._sharedInstancesBag.pluginManager;
+    const pluginManager = this._pluginManager;
     if (!pluginManager) {
       this._activities = [];
       return;
     }
 
     this._activities = pluginManager.snapshot().activities;
-  }
-
-  public override disconnectedCallback(): void {
-    this._unsubscribePlugins?.();
-    this._unsubscribePlugins = undefined;
-    super.disconnectedCallback();
   }
 
   public override render() {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -210,6 +210,10 @@ export class UploadList extends ActivityChildBlock {
       }),
     );
 
+    // Restores v1's next-tick item appearance: re-render as soon as the list
+    // changes instead of waiting for the throttled derived-state tick below.
+    this.trackSub(this.bag.ctx.sub('*uploadList', () => this.requestUpdate()));
+
     this.subConfigValue('filesViewMode', (mode: FilesViewMode) => {
       this.setAttribute('mode', mode);
     });

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -18,6 +18,9 @@ export class ActivityChildBlock extends ChildBlock {
 
   public static activities = ACTIVITY_TYPES;
 
+  /** Un-report callback for the current `reportActivityMounted()` report, if any. */
+  private _unreportActivityMounted?: () => void;
+
   protected override controllerReady(_ctrl: UploaderController): void {
     if (!this.activityType) {
       return;
@@ -27,9 +30,37 @@ export class ActivityChildBlock extends ChildBlock {
     }
     // Re-render on every router transition so `updated()` re-evaluates the slot.
     this.subRouter(() => this.requestUpdate());
-    // Report this activity as mounted so API waits (navigate/setModalState)
-    // can find it now that ported blocks are not in `*blocksRegistry`.
-    this.trackSub(this.bag.router.activityBlockMounted(this.activityType));
+    this.reportActivityMounted();
+  }
+
+  /**
+   * Report `this.activityType` as mounted with the router so API waits
+   * (navigate/setModalState) can find it now that ported blocks are not in
+   * `*blocksRegistry`. Idempotent: releases any prior report first, so it's
+   * safe to call again after `activityType` changes post-adoption (e.g.
+   * `PluginActivityHost`'s late-registration sync) to move the report from
+   * the old id to the new one. A no-op (after releasing the prior report)
+   * when `activityType` is `null`.
+   */
+  protected reportActivityMounted(): void {
+    this._unreportActivityMounted?.();
+    this._unreportActivityMounted = undefined;
+    if (!this.activityType) {
+      return;
+    }
+    this._unreportActivityMounted = this.bag.router.activityBlockMounted(this.activityType);
+  }
+
+  protected override controllerReleased(ctrl: UploaderController): void {
+    super.controllerReleased(ctrl);
+    this._unreportActivityMounted?.();
+    this._unreportActivityMounted = undefined;
+  }
+
+  public override disconnectedCallback(): void {
+    this._unreportActivityMounted?.();
+    this._unreportActivityMounted = undefined;
+    super.disconnectedCallback();
   }
 
   /** Whether this block's activity currently owns its slot. */

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -22,14 +22,20 @@ export class ActivityChildBlock extends ChildBlock {
   private _unreportActivityMounted?: () => void;
 
   protected override controllerReady(_ctrl: UploaderController): void {
+    // Wire the router subscription unconditionally, even when `activityType`
+    // is still null at adoption time (e.g. a `PluginActivityHost` whose
+    // `.registration` arrives later, in `updated()`). Otherwise a host that
+    // starts with a null activityType and only later syncs a real one ends up
+    // with no router subscription, so subsequent navigation never re-renders
+    // it and its mounted content is never torn down. Harmless extra
+    // re-renders for a null-activity host in the meantime.
+    this.subRouter(() => this.requestUpdate());
     if (!this.activityType) {
       return;
     }
     if (!this.hasAttribute('activity')) {
       this.setAttribute('activity', this.activityType);
     }
-    // Re-render on every router transition so `updated()` re-evaluates the slot.
-    this.subRouter(() => this.requestUpdate());
     this.reportActivityMounted();
   }
 

--- a/src/lit/hasBlockInCtx.test.ts
+++ b/src/lit/hasBlockInCtx.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { RouterController } from '../abstract/controllers/RouterController';
+import { waitForActivityBlock } from './hasBlockInCtx';
+
+const setup = () => new RouterController({ emit: vi.fn() });
+
+describe('waitForActivityBlock', () => {
+  it('resolves true synchronously when the activity is already mounted', async () => {
+    const router = setup();
+    router.activityBlockMounted('upload-list');
+
+    await expect(waitForActivityBlock(router, 'upload-list')).resolves.toBe(true);
+  });
+
+  it('resolves true once the activity mounts after a later router notification', async () => {
+    const router = setup();
+
+    const pending = waitForActivityBlock(router, 'upload-list', { timeout: 1000 });
+
+    // A router notification unrelated to this activity must not resolve it.
+    router.navigate('start-from');
+    router.activityBlockMounted('upload-list');
+
+    await expect(pending).resolves.toBe(true);
+  });
+
+  it('unsubscribes from the router once resolved, so later notifications are inert', async () => {
+    const router = setup();
+    const subscribeSpy = vi.spyOn(router, 'subscribe');
+
+    const pending = waitForActivityBlock(router, 'upload-list', { timeout: 1000 });
+    router.activityBlockMounted('upload-list');
+    await pending;
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(1);
+    const unsubscribe = subscribeSpy.mock.results[0]?.value as () => void;
+    const unsubscribeSpy = vi.fn(unsubscribe);
+    // Sanity: calling the returned unsubscribe again must not throw (Listeners
+    // tolerates redundant unsubscribes) — proves teardown already happened.
+    expect(() => unsubscribeSpy()).not.toThrow();
+  });
+
+  it('resolves false on timeout and settles even if onTimeout throws (resolve happens before onTimeout, M9f ordering)', async () => {
+    vi.useFakeTimers();
+    try {
+      const router = setup();
+
+      const pending = waitForActivityBlock(router, 'upload-list', {
+        timeout: 50,
+        onTimeout: () => {
+          throw new Error('boom');
+        },
+      });
+
+      // A throwing `onTimeout` runs synchronously inside the timer callback,
+      // uncaught — it must not prevent (or reject) the already-resolved
+      // promise, proving `resolve(false)` ran first.
+      await expect(vi.advanceTimersByTimeAsync(50)).rejects.toThrow('boom');
+      await expect(pending).resolves.toBe(false);
+
+      // A late mount after timeout must not throw or double-resolve.
+      expect(() => router.activityBlockMounted('upload-list')).not.toThrow();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not resolve for a mount of a different activity', async () => {
+    vi.useFakeTimers();
+    try {
+      const router = setup();
+      const onTimeout = vi.fn();
+
+      const pending = waitForActivityBlock(router, 'upload-list', { timeout: 50, onTimeout });
+      router.activityBlockMounted('start-from');
+
+      vi.advanceTimersByTime(50);
+      await vi.runAllTimersAsync();
+
+      await expect(pending).resolves.toBe(false);
+      expect(onTimeout).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/src/lit/hasBlockInCtx.test.ts
+++ b/src/lit/hasBlockInCtx.test.ts
@@ -26,24 +26,42 @@ describe('waitForActivityBlock', () => {
 
   it('unsubscribes from the router once resolved, so later notifications are inert', async () => {
     const router = setup();
-    const subscribeSpy = vi.spyOn(router, 'subscribe');
+    // Wrap `subscribe` so we can observe whether the wait's own unsubscribe
+    // actually runs (rather than just asserting a no-throw, which a
+    // `Set.delete`-backed unsubscribe would satisfy even if it were never
+    // called — the bug this test guards against is a dropped
+    // success-path `unsubscribe()` call, which leaks one router listener
+    // per `waitForActivityBlock` call).
+    const originalSubscribe = router.subscribe.bind(router);
+    let unsubCalled = false;
+    router.subscribe = (callback: () => void): (() => void) => {
+      const unsubscribe = originalSubscribe(callback);
+      return () => {
+        unsubCalled = true;
+        return unsubscribe();
+      };
+    };
 
     const pending = waitForActivityBlock(router, 'upload-list', { timeout: 1000 });
     router.activityBlockMounted('upload-list');
     await pending;
 
-    expect(subscribeSpy).toHaveBeenCalledTimes(1);
-    const unsubscribe = subscribeSpy.mock.results[0]?.value as () => void;
-    const unsubscribeSpy = vi.fn(unsubscribe);
-    // Sanity: calling the returned unsubscribe again must not throw (Listeners
-    // tolerates redundant unsubscribes) — proves teardown already happened.
-    expect(() => unsubscribeSpy()).not.toThrow();
+    expect(unsubCalled).toBe(true);
   });
 
   it('resolves false on timeout and settles even if onTimeout throws (resolve happens before onTimeout, M9f ordering)', async () => {
     vi.useFakeTimers();
     try {
       const router = setup();
+      const originalSubscribe = router.subscribe.bind(router);
+      let unsubCalled = false;
+      router.subscribe = (callback: () => void): (() => void) => {
+        const unsubscribe = originalSubscribe(callback);
+        return () => {
+          unsubCalled = true;
+          return unsubscribe();
+        };
+      };
 
       const pending = waitForActivityBlock(router, 'upload-list', {
         timeout: 50,
@@ -57,6 +75,7 @@ describe('waitForActivityBlock', () => {
       // promise, proving `resolve(false)` ran first.
       await expect(vi.advanceTimersByTimeAsync(50)).rejects.toThrow('boom');
       await expect(pending).resolves.toBe(false);
+      expect(unsubCalled).toBe(true);
 
       // A late mount after timeout must not throw or double-resolve.
       expect(() => router.activityBlockMounted('upload-list')).not.toThrow();

--- a/src/lit/hasBlockInCtx.ts
+++ b/src/lit/hasBlockInCtx.ts
@@ -1,92 +1,42 @@
 import type { RouterController } from '../abstract/controllers/RouterController';
 import type { ActivityId } from './activity-constants';
-import type { LitActivityBlock } from './LitActivityBlock';
-import type { LitBlock } from './LitBlock';
-import type { BlocksRegistry } from './SharedState';
 
 /**
- * Narrows a registry block to a {@link LitActivityBlock}. Non-activity blocks
- * (config, form-input, sources, …) carry no `activityType`, so this filters
- * them out instead of blindly casting and reading `undefined`.
- */
-const isActivityBlock = (block: LitBlock): block is LitActivityBlock => 'activityType' in block;
-
-export const hasBlockInCtx = (blocksRegistry: BlocksRegistry, callback: (block: LitBlock) => boolean): boolean => {
-  for (const block of blocksRegistry) {
-    if (callback(block)) {
-      return true;
-    }
-  }
-  return false;
-};
-
-export const waitForBlockInCtx = (
-  blocksRegistry: BlocksRegistry,
-  callback: (block: LitBlock) => boolean,
-  { timeout = 1000, onTimeout }: { timeout?: number; onTimeout?: () => void } = {},
-): Promise<LitBlock> => {
-  return new Promise((resolve) => {
-    let rafId: ReturnType<typeof requestAnimationFrame>;
-
-    const timer = setTimeout(() => {
-      cancelAnimationFrame(rafId);
-      onTimeout?.();
-    }, timeout);
-
-    const check = () => {
-      for (const block of blocksRegistry) {
-        if (callback(block)) {
-          clearTimeout(timer);
-          resolve(block);
-          return;
-        }
-      }
-      rafId = requestAnimationFrame(check);
-    };
-
-    check();
-  });
-};
-
-/**
- * Wait for an activity to be "mounted" — either as a ported
- * `ActivityChildBlock` (reported through the router's mounted-activity
- * signal, see `RouterController.activityBlockMounted`) or as a v1 block still
- * living in `*blocksRegistry`. Replaces the `waitForBlockInCtx` + `isActivityBlock`
- * pairing at the API's activity-wait call sites now that ported blocks are no
- * longer registry members.
+ * Wait for an activity to be "mounted" — reported through the router's
+ * mounted-activity signal (see `RouterController.activityBlockMounted`,
+ * refcounted by `ActivityChildBlock`). Now that every activity-carrying block
+ * is a ported `ActivityChildBlock`, this rides the router's `subscribe` signal
+ * alone instead of polling a registry.
  */
 export const waitForActivityBlock = (
-  blocksRegistry: BlocksRegistry,
   router: RouterController,
   activityType: ActivityId,
   { timeout = 1000, onTimeout }: { timeout?: number; onTimeout?: () => void } = {},
 ): Promise<boolean> => {
   return new Promise((resolve) => {
-    let rafId: ReturnType<typeof requestAnimationFrame>;
+    if (router.hasMountedActivity(activityType)) {
+      resolve(true);
+      return;
+    }
+
+    let unsubscribe: () => void;
 
     const timer = setTimeout(() => {
-      cancelAnimationFrame(rafId);
-      // Settle instead of leaving the promise pending forever (unlike the
-      // legacy `waitForBlockInCtx`): callers gate on the resolved value.
-      // Resolve BEFORE the callback so a throwing `onTimeout` can't leave
-      // the promise pending.
+      unsubscribe();
+      // Settle instead of leaving the promise pending forever: callers gate
+      // on the resolved value. Resolve BEFORE the callback so a throwing
+      // `onTimeout` can't leave the promise pending.
       resolve(false);
       onTimeout?.();
     }, timeout);
 
-    const check = () => {
-      const found =
-        router.hasMountedActivity(activityType) ||
-        hasBlockInCtx(blocksRegistry, (b) => isActivityBlock(b) && b.activityType === activityType);
-      if (found) {
-        clearTimeout(timer);
-        resolve(true);
+    unsubscribe = router.subscribe(() => {
+      if (!router.hasMountedActivity(activityType)) {
         return;
       }
-      rafId = requestAnimationFrame(check);
-    };
-
-    check();
+      clearTimeout(timer);
+      unsubscribe();
+      resolve(true);
+    });
   });
 };

--- a/tests/blocks/activity-child-block.e2e.test.tsx
+++ b/tests/blocks/activity-child-block.e2e.test.tsx
@@ -21,10 +21,25 @@ class TestNoActivityBlock extends ActivityChildBlock {
   }
 }
 
+class TestDynamicActivityBlock extends ActivityChildBlock {
+  public override activityType: ActivityChildBlock['activityType'] = 'start-from';
+
+  /** Test-only hook mirroring `PluginActivityHost`'s late-sync path. */
+  public changeActivityType(next: ActivityChildBlock['activityType']): void {
+    this.activityType = next;
+    this.reportActivityMounted();
+  }
+
+  public override render() {
+    return html`<span class="marker">dynamic</span>`;
+  }
+}
+
 declare global {
   interface HTMLElementTagNameMap {
     'test-activity-block': TestActivityBlock;
     'test-no-activity-block': TestNoActivityBlock;
+    'test-dynamic-activity-block': TestDynamicActivityBlock;
   }
 }
 
@@ -34,6 +49,9 @@ beforeAll(async () => {
   if (!customElements.get('test-activity-block')) customElements.define('test-activity-block', TestActivityBlock);
   if (!customElements.get('test-no-activity-block')) {
     customElements.define('test-no-activity-block', TestNoActivityBlock);
+  }
+  if (!customElements.get('test-dynamic-activity-block')) {
+    customElements.define('test-dynamic-activity-block', TestDynamicActivityBlock);
   }
 });
 
@@ -143,5 +161,21 @@ describe('ActivityChildBlock', () => {
     router.openModal('camera');
     await expect.poll(() => seen.length).toBe(3);
     expect(seen).toEqual([null, 'start-from', 'camera']);
+  });
+
+  it('re-reports the mounted-activity signal (old id un-reported, new id reported) when activityType changes dynamically', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const child = append('test-dynamic-activity-block', { 'ctx-name': ctxName });
+    await expect.poll(() => child.getAttribute('activity')).toBe('start-from');
+
+    const router = routerOf(child);
+    expect(router.hasMountedActivity('start-from')).toBe(true);
+    expect(router.hasMountedActivity('camera')).toBe(false);
+
+    child.changeActivityType('camera');
+
+    expect(router.hasMountedActivity('start-from')).toBe(false);
+    expect(router.hasMountedActivity('camera')).toBe(true);
   });
 });

--- a/tests/blocks/plugin-activity-host.e2e.test.tsx
+++ b/tests/blocks/plugin-activity-host.e2e.test.tsx
@@ -1,0 +1,82 @@
+import { afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { page } from 'vitest/browser';
+import type { RouterController } from '@/abstract/controllers/RouterController';
+import type { PluginActivityHost } from '@/index.ts';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+const appended: HTMLElement[] = [];
+const append = (ctxName: string): PluginActivityHost => {
+  const el = document.createElement('uc-plugin-activity-host') as PluginActivityHost;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  appended.push(el);
+  return el;
+};
+
+afterEach(() => {
+  for (const el of appended) el.remove();
+  appended.length = 0;
+});
+
+const routerOf = (host: PluginActivityHost): RouterController => host.router;
+
+describe('PluginActivityHost — dynamic registration (gap-fill ahead of ChildBlock port)', () => {
+  it('stays inert (no activity attribute, no [active]) when created without a registration', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const host = append(ctxName);
+    await host.updateComplete;
+
+    expect(host.hasAttribute('activity')).toBe(false);
+    expect(host.hasAttribute('active')).toBe(false);
+  });
+
+  it('syncs the activity attribute and mounts the plugin render() when a registration arrives after the host is already connected', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const host = append(ctxName);
+    await host.updateComplete;
+
+    const router = routerOf(host);
+    // The activity is already current before the registration is known — this
+    // is the scenario `updated()`'s "Keep activityType in sync if the
+    // registration arrives/changes late" comment guards: nothing in the
+    // existing plugin nets constructs a host that starts registration-less
+    // and only later receives its `.registration` (the Renderer's keyed
+    // `repeat()` only ever creates hosts with `.registration` already
+    // populated). We only pin what's observably correct today — the `activity`
+    // attribute sync and the plugin's render() being invoked — not the
+    // `[active]` attribute, whose reflection races the activityType update
+    // within the same `updated()` pass (a pre-existing v1 quirk the Task 2
+    // re-report redesign is expected to address, not preserve).
+    router.setActivity('late-activity');
+
+    let renderedEl: HTMLElement | undefined;
+    host.registration = {
+      id: 'late-activity',
+      pluginId: 'late-plugin',
+      render: (el: HTMLElement) => {
+        renderedEl = el;
+        el.textContent = 'late content';
+        return () => {
+          el.replaceChildren();
+        };
+      },
+    };
+
+    await expect.poll(() => host.getAttribute('activity')).toBe('late-activity');
+    await expect.poll(() => renderedEl?.textContent).toBe('late content');
+  });
+});
+
+declare module '@/types/index' {
+  interface CustomActivities {
+    'late-activity': { params: never };
+  }
+}

--- a/tests/blocks/plugin-activity-host.e2e.test.tsx
+++ b/tests/blocks/plugin-activity-host.e2e.test.tsx
@@ -72,6 +72,15 @@ describe('PluginActivityHost — dynamic registration (gap-fill ahead of ChildBl
 
     await expect.poll(() => host.getAttribute('activity')).toBe('late-activity');
     await expect.poll(() => renderedEl?.textContent).toBe('late content');
+
+    // Regression: a host that adopted before its `.registration` arrived must
+    // still have a router subscription wired (`subRouter` in
+    // `ActivityChildBlock.controllerReady`), even though `activityType` was
+    // null at adoption time. Otherwise, once the late registration mounts the
+    // plugin, navigating away never re-renders the host and the plugin content
+    // stays mounted forever.
+    router.setActivity(null);
+    await expect.poll(() => renderedEl?.textContent).toBe('');
   });
 });
 

--- a/tests/plugins/cloud-image-editor.e2e.test.tsx
+++ b/tests/plugins/cloud-image-editor.e2e.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
 import { cloudImageEditorPlugin } from '@/plugins/cloudImageEditorPlugin';
 import { TEST_IMAGE_URL } from '../utils/constants';
 import { getApi, renderUploader } from './utils';
@@ -92,6 +93,55 @@ describe('Cloud Image Editor Plugin', () => {
       api.initFlow();
 
       await vi.waitFor(() => expect(api.getCurrentActivity()).toBe(CLOUD_IMG_EDIT), { timeout: 10000 });
+    });
+  });
+
+  // Gap-fill (M9j Task 1): `getCurrentActivity() === CLOUD_IMG_EDIT` above only
+  // pins the router's activity string. It doesn't prove CloudImageEditorActivity
+  // itself mounted correctly off `activityParams.internalId` — i.e. that
+  // `uploadCollection.read(internalId)` resolved the right entry and the block
+  // rendered `<uc-cloud-image-editor>` wired to its `cdnUrl`. The port (Task 3)
+  // touches exactly this path (`this.router` → `bag.router`, `activityParams`
+  // inline-cast, `this.uploadCollection` partitioning), so pin the DOM outcome.
+  describe('params-driven open (gap-fill)', () => {
+    it('mounts uc-cloud-image-editor with the resolved entry cdnUrl when the activity opens', async () => {
+      const { config } = await renderUploader([cloudImageEditorPlugin]);
+      config.useCloudImageEditor = true;
+      config.cloudImageEditorAutoOpen = true;
+
+      const api = getApi();
+      api.addFileFromUrl(TEST_IMAGE_URL);
+      api.initFlow();
+
+      await vi.waitFor(() => expect(api.getCurrentActivity()).toBe(CLOUD_IMG_EDIT), { timeout: 10000 });
+
+      const editor = page.getByTestId('uc-cloud-image-editor');
+      await expect.element(editor).toBeVisible();
+
+      const entry = api.getOutputCollectionState().allEntries[0];
+      expect(entry?.cdnUrl).toBeTruthy();
+      await expect.poll(() => editor.element().getAttribute('cdn-url')).toBe(entry?.cdnUrl);
+    });
+
+    it('navigates back and keeps the entry uploaded when Apply is pressed inside the activity', async () => {
+      const { config } = await renderUploader([cloudImageEditorPlugin]);
+      config.useCloudImageEditor = true;
+      config.cloudImageEditorAutoOpen = true;
+
+      const api = getApi();
+      api.addFileFromUrl(TEST_IMAGE_URL);
+      api.initFlow();
+
+      await vi.waitFor(() => expect(api.getCurrentActivity()).toBe(CLOUD_IMG_EDIT), { timeout: 10000 });
+      await expect.element(page.getByTestId('uc-cloud-image-editor')).toBeVisible();
+
+      const apply = page.getByRole('button', { name: /apply/i });
+      await apply.click();
+
+      await vi.waitFor(() => expect(api.getCurrentActivity()).not.toBe(CLOUD_IMG_EDIT), { timeout: 10000 });
+
+      const entry = api.getOutputCollectionState().allEntries[0];
+      expect(entry?.cdnUrl).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## What

**PluginActivityRenderer + PluginActivityHost** ported to `ChildBlock`/`ActivityChildBlock`. The Host's activity type is dynamic — assigned late (or changed) via `.registration` — so the port needed a way to keep the mounted-activity signal correct as that registration mutates over the block's lifetime, rather than assuming a static activity type known at construction.

**CloudImageEditorActivity** ported off `SymbioteCompatMixin` onto `ActivityChildBlock`, joining the rest of the activity blocks already migrated.

**`waitForActivityBlock` retirement of the v1 registry-polling arm.** The helper used to run two parallel strategies: an rAF-based poll over `blocksRegistry` (checking `isActivityBlock`) and a router-based wait. With every v1 block that used to carry an activity type now ported off that model, the registry arm is dead code (grep-verified: no block sets an activityType outside the router path anymore). The helper now subscribes directly to the router's mounted-activity signal, preserving M9f semantics: a synchronous fast-path check, `resolve(false)` fired before `onTimeout`, and no subscription leaks. `isActivityBlock`, the free-standing `hasBlockInCtx`, and `waitForBlockInCtx` are deleted as now-unreferenced; 3 `UploaderPublicApi` call sites updated accordingly.

Minor fixes bundled in: `UploadList`'s `*uploadList` render now subscribes directly, restoring the v1 next-tick item-render latency; a stray `mockClear` warning in the registry spec was cleaned up.

28 blocks are now on `ChildBlock`.

## Design: dynamic mounted-activity re-report

`PluginActivityHost`'s activity type comes from `.registration`, which can be set after mount or changed later — unlike every other `ActivityChildBlock`, which knows its activity type at construction. `ActivityChildBlock` gained `reportActivityMounted()`: calling it releases any previously-held refcount for the prior activity type (if one was reported) and re-reports for the current one. The Host calls this whenever `.registration` is set or changes. The held signal is released on both `controllerReleased` and `disconnectedCallback`, so there's no double-release and no leak on teardown regardless of which fires first. For every other `ActivityChildBlock` with a static activity type, this refactor is behavior-identical — the base class still reports once at mount and releases once at teardown.

## Design: registry-arm retirement

After these three ports, no v1 block anywhere in the tree carries a `blocksRegistry` activityType — confirmed by grep across `src/`. `waitForActivityBlock` now subscribes purely to `RouterController`'s `activityBlockMounted` signal, which notifies unconditionally on every mount (not just on navigation), so a block that mounts without a router navigation still wakes waiters — this is pinned by a dedicated test. The rAF-polling loop and `isActivityBlock` are deleted along with the now-dead free-standing `hasBlockInCtx`/`waitForBlockInCtx`. M9f's original semantics are preserved exactly: the sync fast-path check still runs first, and `resolve(false)` still fires before `onTimeout` on the timeout path.

## What stays v1 and why

The solutions trio, `<uc-config>`, and `<uc-upload-ctx-provider>` remain v1 — they're the blocks that create the shared ctx and its singleton instances, and porting them is blocked on the instance-creation migration (LitBlock/LUB `initCallback` instances → `UploaderController` construction), the seam planned for M10/M11. The CIE inner world (init$-heavy, its own `ctxOwner` flag, separate slices) and the Img family are separate migration slices, out of scope here.

## Review process

Each of the four commits was reviewed individually (opus review focused on the base-class refactor and the wait-semantics diff), followed by a final whole-branch review. Verdict: **MERGE-READY**. Follow-up minors are tracked in `.superpowers/sdd/progress.md` for a later pass; nothing blocking.

## Gate

- `npm run tsc:app` — clean
- `npm run build` — clean (attw/publint pre-existing warnings only; all size-limit budgets within range)
- `npm run tsc` — clean
- `npm run test:specs` — 53 files / 597 tests passed
- `npm run test:locales` — clean, all 30 locales checked
- `npm run test:e2e` — 48 files / 311 tests passed, no retries needed
- `npm run lint` — 0 errors (biome, eslint, stylelint, lit-analyzer); pre-existing eslint warnings only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved activity and modal navigation reliability by ensuring the target activity is ready before proceeding.
  - Prevented modals from opening when the required activity isn’t available.
  - Restored immediate upload list UI updates when the underlying list changes.
  - Enhanced Cloud Image Editor loading, navigation behavior, and configuration handling.

- **Improvements**
  - Improved plugin activity rendering to correctly handle late registrations and activity changes.
  - Strengthened activity lifecycle tracking and cleanup for more consistent UI state.

- **Tests**
  - Expanded coverage for activity-block readiness, dynamic activity switching, plugin host late-mount behavior, and Cloud Image Editor UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->