### PR TITLE
feat(m9k): UploaderController owns the ctx-scope managers (instance-creation migration, part 1)

### DIFF
--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,7 +1,11 @@
-import { describe, expect, it } from 'vitest';
-import { EventBus } from '../EventBus';
+import { describe, expect, it, vi } from 'vitest';
+import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import { EventBus, UploaderEventType } from '../EventBus';
+import { LocaleManager } from '../managers/LocaleManager';
+import { TelemetryManager } from '../managers/TelemetryManager';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
+import { RouterController } from './RouterController';
 import { UploadCollectionController } from './UploadCollectionController';
 import { UploaderController } from './UploaderController';
 
@@ -63,6 +67,124 @@ describe('UploaderController', () => {
   it('destroy() tears down without throwing', () => {
     const controller = new UploaderController();
     expect(() => controller.destroy()).not.toThrow();
+  });
+
+  describe('ctx-scope managers', () => {
+    it('constructs its own localeManager, eventEmitter, telemetryManager, and router', () => {
+      const controller = new UploaderController();
+      expect(controller.localeManager).toBeInstanceOf(LocaleManager);
+      expect(controller.eventEmitter).toBeInstanceOf(EventEmitter);
+      expect(controller.telemetryManager).toBeInstanceOf(TelemetryManager);
+      expect(controller.router).toBeInstanceOf(RouterController);
+    });
+
+    it('uses injected managers instead of constructing its own', () => {
+      const localeManager = new LocaleManager({ config: new ConfigController(), locale: new LocaleController() });
+      const eventEmitter = new EventEmitter(new EventBus());
+      const telemetryManager = new TelemetryManager({
+        config: new ConfigController(),
+        getSolution: () => null,
+        getActivity: () => null,
+      });
+      const router = new RouterController({ emit: () => {} });
+
+      const controller = new UploaderController({ localeManager, eventEmitter, telemetryManager, router });
+
+      expect(controller.localeManager).toBe(localeManager);
+      expect(controller.eventEmitter).toBe(eventEmitter);
+      expect(controller.telemetryManager).toBe(telemetryManager);
+      expect(controller.router).toBe(router);
+    });
+
+    it("wires the router's emit to the controller's own emit, debouncing modal transitions", () => {
+      const controller = new UploaderController();
+      const emitSpy = vi.spyOn(controller, 'emit');
+
+      controller.router.openModal('camera' as never);
+
+      expect(emitSpy).toHaveBeenCalledWith(UploaderEventType.MODAL_OPEN, { modalId: 'camera' }, { debounce: true });
+    });
+  });
+
+  describe('emit', () => {
+    it('dispatches through the owned EventEmitter/EventBus to a listener', () => {
+      const controller = new UploaderController();
+      const handler = vi.fn();
+      controller.eventEmitter.on(UploaderEventType.UPLOAD_CLICK, handler);
+
+      controller.emit(UploaderEventType.UPLOAD_CLICK);
+
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('mirrors the event to the owned TelemetryManager', () => {
+      const controller = new UploaderController();
+      const sendEventSpy = vi.spyOn(controller.telemetryManager, 'sendEvent');
+
+      controller.emit(UploaderEventType.UPLOAD_CLICK, undefined);
+
+      expect(sendEventSpy).toHaveBeenCalledWith({ eventType: UploaderEventType.UPLOAD_CLICK, payload: undefined });
+    });
+
+    it('resolves a function payload before mirroring to telemetry', () => {
+      const controller = new UploaderController();
+      const sendEventSpy = vi.spyOn(controller.telemetryManager, 'sendEvent');
+
+      controller.emit(UploaderEventType.DONE_CLICK, () => ({ foo: 'bar' }) as never);
+
+      expect(sendEventSpy).toHaveBeenCalledWith({
+        eventType: UploaderEventType.DONE_CLICK,
+        payload: { foo: 'bar' },
+      });
+    });
+
+    it('contains a telemetry mirror failure — the listener still ran, and emit never throws', () => {
+      const controller = new UploaderController();
+      const handler = vi.fn();
+      controller.eventEmitter.on(UploaderEventType.UPLOAD_CLICK, handler);
+      vi.spyOn(controller.telemetryManager, 'sendEvent').mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() => controller.emit(UploaderEventType.UPLOAD_CLICK)).not.toThrow();
+      expect(handler).toHaveBeenCalledTimes(1);
+    });
+
+    it('is a silent no-op after destroy()', () => {
+      const controller = new UploaderController();
+      const handler = vi.fn();
+      controller.eventEmitter.on(UploaderEventType.UPLOAD_CLICK, handler);
+      const sendEventSpy = vi.spyOn(controller.telemetryManager, 'sendEvent');
+
+      controller.destroy();
+      expect(() => controller.emit(UploaderEventType.UPLOAD_CLICK)).not.toThrow();
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(sendEventSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  it('destroy() tears down the ctx-scope managers too, in reverse construction order', () => {
+    const controller = new UploaderController();
+    const routerDestroy = vi.spyOn(controller.router, 'destroy');
+    const telemetryDestroy = vi.spyOn(controller.telemetryManager, 'destroy');
+    const eventEmitterDestroy = vi.spyOn(controller.eventEmitter, 'destroy');
+    const localeManagerDestroy = vi.spyOn(controller.localeManager, 'destroy');
+
+    controller.destroy();
+
+    expect(routerDestroy).toHaveBeenCalled();
+    expect(telemetryDestroy).toHaveBeenCalled();
+    expect(eventEmitterDestroy).toHaveBeenCalled();
+    expect(localeManagerDestroy).toHaveBeenCalled();
+
+    const routerOrder = routerDestroy.mock.invocationCallOrder[0]!;
+    const telemetryOrder = telemetryDestroy.mock.invocationCallOrder[0]!;
+    const eventEmitterOrder = eventEmitterDestroy.mock.invocationCallOrder[0]!;
+    const localeManagerOrder = localeManagerDestroy.mock.invocationCallOrder[0]!;
+    expect(routerOrder).toBeLessThan(telemetryOrder);
+    expect(telemetryOrder).toBeLessThan(eventEmitterOrder);
+    expect(eventEmitterOrder).toBeLessThan(localeManagerOrder);
   });
 
   it('is DOM-free — constructing touches no element APIs', () => {

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,6 +1,10 @@
-import { EventBus } from '../EventBus';
+import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import { EventBus, type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../EventBus';
+import { LocaleManager } from '../managers/LocaleManager';
+import { TelemetryManager } from '../managers/TelemetryManager';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
+import { RouterController } from './RouterController';
 import { UploadCollectionController } from './UploadCollectionController';
 
 /**
@@ -26,12 +30,26 @@ import { UploadCollectionController } from './UploadCollectionController';
  * substitute a fake or share an existing instance. This is deliberately just
  * default-parameter injection — no container/decorators; the DOM layer already
  * has its own wiring via `@lit/context`.
+ *
+ * M9k also moves four of the five v1 ctx-scope managers here (construction +
+ * teardown ownership): `localeManager`, `eventEmitter`, `telemetryManager`,
+ * `router`. `PluginController` (the fifth) stays constructed by the DOM layer
+ * (`LitBlock`) — it genuinely needs the PubSub ctx (`*lazyPlugins`, arbitrary
+ * shared state) and the `*publicApi` shared instance, neither of which the
+ * DOM-free controller can reach without importing `PubSub` here, which would
+ * both create a circular import (`PubSubCompat` already imports
+ * `UploaderController`) and break the "abstract/ touches no DOM" boundary in
+ * spirit. See the M9k task report for the full audit.
  */
 export type UploaderControllerDeps = {
   events?: EventBus;
   config?: ConfigController;
   locale?: LocaleController;
   collection?: UploadCollectionController;
+  localeManager?: LocaleManager;
+  eventEmitter?: EventEmitter;
+  telemetryManager?: TelemetryManager;
+  router?: RouterController;
 };
 
 export class UploaderController {
@@ -39,17 +57,71 @@ export class UploaderController {
   public readonly config: ConfigController;
   public readonly locale: LocaleController;
   public readonly collection: UploadCollectionController;
+  public readonly localeManager: LocaleManager;
+  public readonly eventEmitter: EventEmitter;
+  public readonly telemetryManager: TelemetryManager;
+  public readonly router: RouterController;
 
   // The solution (preset) identity of this uploader scope — a boot-time fact,
   // not reactive state: set once by the solution element, read lazily by
   // telemetry. Stored lowercased, payload-ready.
   private _solutionName: string | null = null;
+  private _destroyed = false;
 
   public constructor(deps: UploaderControllerDeps = {}) {
     this.events = deps.events ?? new EventBus();
     this.config = deps.config ?? new ConfigController();
     this.locale = deps.locale ?? new LocaleController();
     this.collection = deps.collection ?? new UploadCollectionController();
+
+    this.localeManager = deps.localeManager ?? new LocaleManager({ config: this.config, locale: this.locale });
+    this.eventEmitter = deps.eventEmitter ?? new EventEmitter(this.events);
+    this.telemetryManager =
+      deps.telemetryManager ??
+      new TelemetryManager({
+        config: this.config,
+        getSolution: () => this.solutionName,
+        getActivity: () => this.router.currentActivity,
+      });
+    this.router =
+      deps.router ??
+      new RouterController({
+        emit: (type, payload) => {
+          // Matches v1's `LitBlock._routerEmit`: modal transitions debounce,
+          // activity-change fires immediately.
+          const debounce = type === UploaderEventType.MODAL_OPEN || type === UploaderEventType.MODAL_CLOSE;
+          this.emit(type, payload, debounce ? { debounce: true } : undefined);
+        },
+      });
+  }
+
+  /**
+   * Telemetry-augmented emit — matches v1 `LitBlock.emit`'s guard + payload-
+   * function resolution exactly, plus `ChildBlock.emit`'s try/catch around the
+   * telemetry mirror (teardown-safe: a send racing `destroy()` must never
+   * throw back into the caller). A silent no-op once destroyed.
+   */
+  public emit<T extends UploaderEventKey>(
+    type: T,
+    payload?: UploaderEventPayload[T] | (() => UploaderEventPayload[T]),
+    options?: { debounce?: boolean | number },
+  ): void {
+    if (this._destroyed) {
+      return;
+    }
+
+    this.eventEmitter.emit(type, payload, options);
+
+    const resolvedPayload = typeof payload === 'function' ? payload() : payload;
+
+    try {
+      this.telemetryManager.sendEvent({
+        eventType: type,
+        payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
+      });
+    } catch {
+      // Telemetry may already be torn down — reporting must never throw.
+    }
   }
 
   public get solutionName(): string | null {
@@ -67,9 +139,17 @@ export class UploaderController {
   }
 
   public destroy(): void {
+    this._destroyed = true;
+
     this.events.destroy();
     this.config.destroy();
     this.locale.destroy();
     this.collection.destroy();
+
+    // Reverse construction order.
+    this.router.destroy();
+    this.telemetryManager.destroy();
+    this.eventEmitter.destroy();
+    this.localeManager.destroy();
   }
 }

--- a/src/abstract/managers/LocaleManager.test.ts
+++ b/src/abstract/managers/LocaleManager.test.ts
@@ -1,10 +1,20 @@
 import { describe, expect, it, vi } from 'vitest';
 import { ConfigController } from '../controllers/ConfigController';
 import { LocaleController } from '../controllers/LocaleController';
+import type { LocaleDefinition } from '../localeRegistry';
+import * as localeRegistry from '../localeRegistry';
 import { LocaleManager } from './LocaleManager';
 import type { PluginController } from './plugin';
 
 type FakePluginManager = Pick<PluginController, 'onPluginsChange' | 'snapshot'>;
+
+// Wraps the real resolver as the default implementation (so every other test
+// in this file resolves locales for real), while letting the same-tick
+// staleness spec below swap in controllable deferreds for specific calls.
+vi.mock('../localeRegistry', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../localeRegistry')>();
+  return { ...actual, resolveLocaleDefinition: vi.fn(actual.resolveLocaleDefinition) };
+});
 
 /**
  * Dedicated coverage for `LocaleManager.activate()` (M9k Task 3 follow-up):
@@ -112,5 +122,40 @@ describe('LocaleManager.activate', () => {
     const manager = new LocaleManager({ config, locale });
 
     expect(() => manager.destroy()).not.toThrow();
+  });
+
+  it('applies only the second locale when its stale-but-still-in-flight predecessor resolves later — even on the default "en" path', async () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+
+    let resolveEn!: (definition: Partial<LocaleDefinition>) => void;
+    let resolveFr!: (definition: Partial<LocaleDefinition>) => void;
+    const enPromise = new Promise<Partial<LocaleDefinition>>((resolve) => {
+      resolveEn = resolve;
+    });
+    const frPromise = new Promise<Partial<LocaleDefinition>>((resolve) => {
+      resolveFr = resolve;
+    });
+
+    const resolveMock = vi.mocked(localeRegistry.resolveLocaleDefinition);
+    // First call: activate()'s initial `en` subscription fire (a real ctx's
+    // default `localeName`). Second call: the rapid follow-up `fr` change.
+    resolveMock.mockImplementationOnce(() => enPromise as Promise<LocaleDefinition>);
+    resolveMock.mockImplementationOnce(() => frPromise as Promise<LocaleDefinition>);
+
+    manager.activate(null); // synchronously fires cb('en') -> resolveLocaleDefinition('en')
+    config.set('localeName', 'fr'); // same tick -> resolveLocaleDefinition('fr')
+
+    // Resolve out of order: the newer ("fr") request settles first, the
+    // stale ("en") one settles after. `await <promise>` here is guaranteed to
+    // run after LocaleManager's own continuation on that same promise, since
+    // its `.then` was registered first.
+    resolveFr({ upload: 'FR upload' });
+    await frPromise;
+    resolveEn({ upload: 'EN stale upload' });
+    await enPromise;
+
+    expect(locale.get('upload')).toBe('FR upload');
   });
 });

--- a/src/abstract/managers/LocaleManager.test.ts
+++ b/src/abstract/managers/LocaleManager.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../controllers/ConfigController';
+import { LocaleController } from '../controllers/LocaleController';
+import { LocaleManager } from './LocaleManager';
+import type { PluginController } from './plugin';
+
+type FakePluginManager = Pick<PluginController, 'onPluginsChange' | 'snapshot'>;
+
+/**
+ * Dedicated coverage for `LocaleManager.activate()` (M9k Task 3 follow-up):
+ * construction is side-effect-free (see the class doc), so `activate` is
+ * where all of v1's construction-time behavior — seeding, config
+ * subscriptions, plugin-manager coupling — actually lives. Pins its
+ * idempotency contract, which `UploaderController.test.ts` and the
+ * instance-lifecycle e2e specs don't exercise directly.
+ */
+describe('LocaleManager.activate', () => {
+  it('is idempotent: a second activate() does not re-register the config subscriptions', () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+    const subscribeSpy = vi.spyOn(config, 'subscribe');
+
+    manager.activate(null);
+    const afterFirst = subscribeSpy.mock.calls.length;
+    // localeName + localeDefinitionOverride — exactly two subscriptions wired.
+    expect(afterFirst).toBe(2);
+
+    manager.activate(null);
+    manager.activate(null);
+
+    expect(subscribeSpy).toHaveBeenCalledTimes(afterFirst);
+  });
+
+  it('is idempotent: a second activate() does not re-seed the en dictionary over a value set since', () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+
+    manager.activate(null);
+    // Simulate a value having changed since first activation (e.g. a plugin
+    // override, or the app writing a custom translation directly).
+    locale.set('upload', 'Custom upload label');
+
+    manager.activate(null);
+
+    expect(locale.get('upload')).toBe('Custom upload label');
+  });
+
+  it('re-couples to a new plugin manager on re-activate without stacking the old subscription', () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+
+    const unsub1 = vi.fn();
+    const pm1: FakePluginManager = {
+      onPluginsChange: vi.fn(() => unsub1),
+      snapshot: vi.fn(() => ({ l10n: [] }) as never),
+    };
+    manager.activate(pm1);
+    expect(pm1.onPluginsChange).toHaveBeenCalledTimes(1);
+    expect(unsub1).not.toHaveBeenCalled();
+
+    const unsub2 = vi.fn();
+    const pm2: FakePluginManager = {
+      onPluginsChange: vi.fn(() => unsub2),
+      snapshot: vi.fn(() => ({ l10n: [] }) as never),
+    };
+    manager.activate(pm2);
+
+    // The old coupling is released exactly once, not left dangling alongside
+    // the new one.
+    expect(unsub1).toHaveBeenCalledTimes(1);
+    expect(pm2.onPluginsChange).toHaveBeenCalledTimes(1);
+    expect(unsub2).not.toHaveBeenCalled();
+
+    manager.destroy();
+    expect(unsub2).toHaveBeenCalledTimes(1);
+    // Still just once — destroy() must not double-release the already-swapped-
+    // out first coupling.
+    expect(unsub1).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy() releases the config subscriptions and the plugin coupling: subsequent changes produce no callbacks', () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+
+    const unsub = vi.fn();
+    const pm: FakePluginManager = {
+      onPluginsChange: vi.fn(() => unsub),
+      snapshot: vi.fn(() => ({ l10n: [] }) as never),
+    };
+
+    manager.activate(pm);
+    manager.destroy();
+
+    expect(unsub).toHaveBeenCalledTimes(1);
+
+    const setSpy = vi.spyOn(locale, 'set');
+    // Both config keys LocaleManager wired subscriptions for — neither should
+    // reach the (now-unsubscribed) callbacks.
+    config.set('localeName', 'fr');
+    config.set('localeDefinitionOverride', { fr: { upload: 'Envoyer' } });
+
+    expect(setSpy).not.toHaveBeenCalled();
+  });
+
+  it('destroy() is safe to call before activate() (never activated)', () => {
+    const config = new ConfigController();
+    const locale = new LocaleController();
+    const manager = new LocaleManager({ config, locale });
+
+    expect(() => manager.destroy()).not.toThrow();
+  });
+});

--- a/src/abstract/managers/LocaleManager.ts
+++ b/src/abstract/managers/LocaleManager.ts
@@ -39,6 +39,7 @@ export class LocaleManager {
   private readonly _deps: LocaleManagerDeps;
   private _localeName = '';
   private _activated = false;
+  private _destroyed = false;
   private _unsubs = new Set<() => void>();
   private _pluginManager: Pick<PluginController, 'onPluginsChange' | 'snapshot'> | null = null;
   private _pluginManagerUnsub?: () => void;
@@ -84,7 +85,14 @@ export class LocaleManager {
         }
         this._localeName = localeName;
         const definition = await resolveLocaleDefinition(localeName);
-        if (localeName !== DEFAULT_LOCALE && this._localeName !== localeName) {
+        // Uniform staleness guard: `resolveLocaleDefinition` always crosses a
+        // microtask boundary — even for the `en` default — so a rapid
+        // second `localeName` change in the same tick can settle this
+        // continuation after `_localeName` has already moved on. Applying it
+        // then would clobber the newer locale's dictionary with the stale
+        // one's. Bail uniformly (no `en`-only carve-out) and also bail if
+        // the manager was torn down while this resolution was in flight.
+        if (this._destroyed || this._localeName !== localeName) {
           return;
         }
         this._applyPluginLocales(localeName);
@@ -166,6 +174,7 @@ export class LocaleManager {
   }
 
   public destroy(): void {
+    this._destroyed = true;
     this._pluginManagerUnsub?.();
     this._pluginManagerUnsub = undefined;
     for (const unsub of this._unsubs) {

--- a/src/abstract/managers/LocaleManager.ts
+++ b/src/abstract/managers/LocaleManager.ts
@@ -1,35 +1,84 @@
-import { SharedInstance, type SharedInstancesBag } from '../../lit/shared-instances';
 import { default as en } from '../../locales/file-uploader/en';
+import type { ConfigType } from '../../types';
+import type { ConfigController } from '../controllers/ConfigController';
+import type { LocaleController } from '../controllers/LocaleController';
 import { type LocaleDefinition, resolveLocaleDefinition } from '../localeRegistry';
-import { sharedConfigKey } from '../sharedConfigKey';
+import type { PluginController } from './plugin';
 
 export const localeStateKey = <T extends keyof LocaleDefinition>(key: T): `*l10n/${T}` => `*l10n/${key}`;
 export const DEFAULT_LOCALE = 'en';
 
-export class LocaleManager extends SharedInstance {
-  private _localeName = '';
+export type LocaleManagerDeps = {
+  /** v2 config source of truth — `localeName`/`localeDefinitionOverride` reads + subscriptions. */
+  config: ConfigController;
+  /** v2 locale string store — where the resolved dictionary is written. */
+  locale: LocaleController;
+};
 
-  public constructor(sharedInstancesBag: SharedInstancesBag) {
-    super(sharedInstancesBag);
+/**
+ * DOM-free locale orchestration (M9k port): deps-injected instead of
+ * `SharedInstance`-based, reading/writing the v2 `ConfigController`/
+ * `LocaleController` directly instead of the PubSub ctx.
+ *
+ * Construction itself is side-effect-free — `UploaderController` constructs
+ * this eagerly, and the controller is itself created lazily by *any* `*cfg/*`
+ * or `*l10n/*` ctx touch (`PubSubCompat._uploader`), including from contexts
+ * that never mount a block (e.g. a bare per-upload-entry ctx, or a unit test
+ * exercising the config facade alone). Seeding the `en` dictionary and wiring
+ * the config subscriptions as part of the constructor would leak locale state
+ * into every such scope. Instead {@link activate} — v1's actual construction-
+ * time work — runs once the DOM layer (`LitBlock`) is really initializing an
+ * uploader scope, the same point v1 constructed `LocaleManager` itself. It
+ * also takes the plugin-manager coupling (`onPluginsChange`/`snapshot`, for
+ * plugin-supplied `registerL10n` dictionaries): `PluginController` still
+ * requires the PubSub ctx (arbitrary shared state + the public API) and so
+ * stays constructed by the DOM layer, not the controller — see
+ * `UploaderController`'s class doc / the M9k task report.
+ */
+export class LocaleManager {
+  private readonly _deps: LocaleManagerDeps;
+  private _localeName = '';
+  private _activated = false;
+  private _unsubs = new Set<() => void>();
+  private _pluginManager: Pick<PluginController, 'onPluginsChange' | 'snapshot'> | null = null;
+  private _pluginManagerUnsub?: () => void;
+
+  public constructor(deps: LocaleManagerDeps) {
+    this._deps = deps;
+  }
+
+  /**
+   * Run the v1 construction-time work: seed the `en` defaults, wire the
+   * plugin-manager coupling, and subscribe to `localeName`/
+   * `localeDefinitionOverride`. Idempotent — the plugin-manager coupling is
+   * always re-wired (harmless: unsub-then-resub) but the one-time seeding +
+   * subscriptions only run once, so calling this again (e.g. a second block
+   * sharing the ctx) is safe.
+   */
+  public activate(pluginManager: Pick<PluginController, 'onPluginsChange' | 'snapshot'> | null): void {
+    this._pluginManagerUnsub?.();
+    this._pluginManagerUnsub = undefined;
+    this._pluginManager = pluginManager;
+    if (pluginManager?.onPluginsChange) {
+      this._pluginManagerUnsub = pluginManager.onPluginsChange(() => {
+        if (this._localeName) {
+          this._applyPluginLocales(this._localeName);
+        }
+      });
+    }
+
+    if (this._activated) {
+      return;
+    }
+    this._activated = true;
 
     for (const [key, value] of Object.entries(en) as [keyof LocaleDefinition, string][]) {
-      const noTranslation = this._ctx.has(localeStateKey(key)) ? !this._ctx.read(localeStateKey(key)) : true;
-      this._ctx.add(localeStateKey(key), value, noTranslation);
+      const noTranslation = this._deps.locale.has(key) ? !this._deps.locale.get(key) : true;
+      this._setLocale(key, value, noTranslation);
     }
 
-    const pluginManager = sharedInstancesBag.pluginManager;
-    if (pluginManager?.onPluginsChange) {
-      this.addSub(
-        pluginManager.onPluginsChange(() => {
-          if (this._localeName) {
-            this._applyPluginLocales(this._localeName);
-          }
-        }),
-      );
-    }
-
-    this.addSub(
-      this._ctx.sub(sharedConfigKey('localeName'), async (localeName) => {
+    this._unsubs.add(
+      this._subConfig('localeName', async (localeName) => {
         if (!localeName) {
           return;
         }
@@ -44,8 +93,8 @@ export class LocaleManager extends SharedInstance {
       }),
     );
 
-    this.addSub(
-      this._ctx.sub(sharedConfigKey('localeDefinitionOverride'), (localeDefinitionOverride) => {
+    this._unsubs.add(
+      this._subConfig('localeDefinitionOverride', (localeDefinitionOverride) => {
         if (!localeDefinitionOverride) {
           return;
         }
@@ -58,21 +107,45 @@ export class LocaleManager extends SharedInstance {
     );
   }
 
+  /**
+   * Subscribe to a config key's derived value: fires once immediately with
+   * the current value, then again only when it actually changes — the same
+   * per-key dedup semantics as `PubSubCompat`'s `*cfg/` facade (which this
+   * replaces for `LocaleManager`'s two config reads).
+   */
+  private _subConfig<K extends keyof ConfigType>(key: K, cb: (value: ConfigType[K]) => void): () => void {
+    let last = this._deps.config.get(key);
+    cb(last);
+    return this._deps.config.subscribe(() => {
+      const next = this._deps.config.get(key);
+      if (!Object.is(next, last)) {
+        last = next;
+        cb(next);
+      }
+    });
+  }
+
+  private _setLocale(key: string, value: string, rewrite: boolean): void {
+    if (!this._deps.locale.has(key) || rewrite) {
+      this._deps.locale.set(key, value);
+    }
+  }
+
   private _applyOverrides(localeName: string, definition: Partial<LocaleDefinition>): void {
-    const overrides = this._cfg.localeDefinitionOverride?.[localeName];
+    const overrides = this._deps.config.get('localeDefinitionOverride')?.[localeName];
     for (const [key, value] of Object.entries(definition) as [keyof LocaleDefinition, string][]) {
       const overriddenValue = overrides?.[key];
-      this._ctx.add(localeStateKey(key), overriddenValue ?? value, true);
+      this._setLocale(key, overriddenValue ?? value, true);
     }
   }
 
   private _applyPluginLocales(localeName: string): void {
-    const pluginManager = this._sharedInstancesBag.pluginManager;
-    if (!pluginManager) {
+    const manager = this._pluginManager;
+    if (!manager) {
       return;
     }
 
-    const snapshot = pluginManager.snapshot();
+    const snapshot = manager.snapshot();
     for (const entry of snapshot.l10n) {
       const { pluginId: _pluginId, ...locales } = entry as unknown as Record<string, Partial<LocaleDefinition>> & {
         pluginId?: string;
@@ -87,8 +160,21 @@ export class LocaleManager extends SharedInstance {
         if (value === undefined) {
           continue;
         }
-        this._ctx.add(localeStateKey(key), value, true);
+        this._setLocale(key, value, true);
       }
     }
+  }
+
+  public destroy(): void {
+    this._pluginManagerUnsub?.();
+    this._pluginManagerUnsub = undefined;
+    for (const unsub of this._unsubs) {
+      try {
+        unsub();
+      } catch {
+        // Ignore cleanup errors
+      }
+    }
+    this._unsubs.clear();
   }
 }

--- a/src/abstract/managers/TelemetryManager.test.ts
+++ b/src/abstract/managers/TelemetryManager.test.ts
@@ -229,6 +229,41 @@ describe('TelemetryManager', () => {
     expect(payload.activity).toBeNull();
   });
 
+  it('resolves solution/activity from the live getters, not a construction-time snapshot — covers construction before the solution/router register (the pre-connect timing the controller-owned move introduces)', async () => {
+    // Mirrors the real wiring in LitBlock.initCallback: `getSolution`/`getActivity`
+    // are closures re-evaluated on every send, not values captured once at
+    // construction. Constructing the manager while both are still unset (as
+    // happens if construction moves earlier than the solution/router exist)
+    // must not freeze a null forever — later registration must be reflected.
+    let solution: string | null = null;
+    let activity: string | null = null;
+    const config = new ConfigController();
+    const manager = new TelemetryManager({
+      config,
+      getSolution: () => solution,
+      getActivity: () => activity,
+    });
+    config.set('qualityInsights', true);
+
+    manager.sendEvent({ eventType: InternalEventType.INIT_SOLUTION });
+    await flush();
+    let payload = sendEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload.component).toBeNull();
+    expect(payload.activity).toBeNull();
+
+    sendEventMock.mockClear();
+    solution = 'UC-FILE-UPLOADER-REGULAR'.toLowerCase();
+    activity = 'start-from';
+    vi.setSystemTime(1_700_000_002_000); // distinct payload for the dedup check
+    manager.sendEvent({ eventType: EventType.MODAL_OPEN });
+    await flush();
+
+    expect(sendEventMock).toHaveBeenCalledTimes(1);
+    payload = sendEventMock.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(payload.component).toBe('uc-file-uploader-regular');
+    expect(payload.activity).toBe('start-from');
+  });
+
   it('dedupes payloads that differ only in key order', async () => {
     const { manager, enable } = setup();
     enable();

--- a/src/blocks/UploadCtxProvider/EventEmitter.test.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.test.ts
@@ -1,16 +1,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { EventBus } from '../../abstract/EventBus';
-import type { SharedInstancesBag } from '../../lit/shared-instances';
 import type { OutputFileEntry } from '../../types';
 import { EventEmitter, EventType } from './EventEmitter';
 
-// The facade reads `ctx.uploaderController().events`; stub that chain to a real
-// EventBus so we exercise the actual delegation (not a mock of it).
+// The facade wraps a real EventBus directly (owned by `UploaderController`)
+// so we exercise the actual delegation (not a mock of it).
 const setup = () => {
   const bus = new EventBus();
-  const ctx = { uploaderController: () => ({ events: bus }) };
-  const bag = { ctx } as unknown as SharedInstancesBag;
-  const emitter = new EventEmitter(bag);
+  const emitter = new EventEmitter(bus);
   return { emitter, bus };
 };
 

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -4,7 +4,6 @@ import {
   type UploaderEventPayload,
   UploaderEventType,
 } from '../../abstract/EventBus';
-import { SharedInstance } from '../../lit/shared-instances';
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 20;
 
@@ -28,16 +27,27 @@ export { UploaderEventType as EventType };
 export type { UploaderEventKey as EventKey, UploaderEventPayload as EventPayload };
 
 /**
- * Facade over the per-ctx DOM-free `EventBus` (`UploaderController.events`).
+ * Facade over the per-ctx DOM-free `EventBus`.
  *
  * `on`/`emit` delegate to the bus; the DOM `CustomEvent` dispatch lives in the
  * reactive `EventBridgeController` attached to `<uc-upload-ctx-provider>`. The
  * public surface (event types, debounce, payload thunks, `api.on`) is
  * unchanged — only the storage/dispatch moved behind the bus.
+ *
+ * M9k reshape: constructed and owned by `UploaderController` directly, so it
+ * takes the `EventBus` it wraps instead of a ctx-bound `SharedInstancesBag`
+ * (it previously extended `SharedInstance` only to reach
+ * `ctx.uploaderController().events` lazily — it never used any other
+ * `SharedInstance` facility, so no behavior is lost by holding the bus
+ * directly). `destroy()` is a no-op — the facade itself holds no
+ * subscriptions to unwind; it exists so the controller can treat all its
+ * owned managers uniformly.
  */
-export class EventEmitter extends SharedInstance {
-  private get _bus(): EventBus {
-    return this._ctx.uploaderController().events;
+export class EventEmitter {
+  private readonly _bus: EventBus;
+
+  public constructor(bus: EventBus) {
+    this._bus = bus;
   }
 
   public on<T extends UploaderEventKey>(type: T, handler: (payload: UploaderEventPayload[T]) => void): () => void {
@@ -60,5 +70,9 @@ export class EventEmitter extends SharedInstance {
     }
     const timeout = typeof debounce === 'number' ? debounce : DEFAULT_DEBOUNCE_TIMEOUT;
     this._bus.emitDebounced(type, resolve, timeout);
+  }
+
+  public destroy(): void {
+    // No-op: the facade holds no subscriptions of its own.
   }
 }

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -1,18 +1,17 @@
 import { LitElement } from 'lit';
 import { blockCtx } from '../abstract/CTX';
 import { ClipboardController } from '../abstract/controllers/ClipboardController';
-import { RouterController, type RouterControllerDeps } from '../abstract/controllers/RouterController';
-import { type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../abstract/EventBus';
+import type { RouterController } from '../abstract/controllers/RouterController';
 import { A11y } from '../abstract/managers/a11y';
-import { LocaleManager, localeStateKey } from '../abstract/managers/LocaleManager';
+import { type LocaleManager, localeStateKey } from '../abstract/managers/LocaleManager';
 import { PluginController } from '../abstract/managers/plugin';
 import { buildPluginApi } from '../abstract/managers/plugin/buildPluginApi';
 import { LazyPluginLoader } from '../abstract/managers/plugin/LazyPluginLoader';
-import { TelemetryManager } from '../abstract/managers/TelemetryManager';
+import type { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { sharedConfigKey } from '../abstract/sharedConfigKey';
 import { initialConfig } from '../blocks/Config/initialConfig';
-import { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
+import type { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
 import { PubSub } from '../lit/PubSubCompat';
 import type { ConfigType } from '../types';
 import { getLocaleDirection } from '../utils/getLocaleDirection';
@@ -26,6 +25,7 @@ import { RegisterableElementMixin } from './RegisterableElementMixin';
 import type { SharedState } from './SharedState';
 import { SymbioteMixin } from './SymbioteCompatMixin';
 import {
+  controllerOwnedInstanceKeys,
   createSharedInstancesBag,
   type ISharedInstance,
   type SharedInstancesBag,
@@ -109,10 +109,34 @@ export class LitBlock extends LitBlockBase {
           debug: createDebugPrinter(() => sharedInstancesBag.ctx, 'PluginController'),
         }),
     );
-    this._addSharedContextInstance('*eventEmitter', (sharedInstancesBag) => new EventEmitter(sharedInstancesBag));
-    this._addSharedContextInstance('*localeManager', (sharedInstancesBag) => new LocaleManager(sharedInstancesBag));
+    // The remaining four ctx-scope managers are constructed and owned by
+    // `UploaderController` (M9k) — these `_addSharedContextInstance` calls just
+    // re-expose the controller's instances under their v1 shared-instance keys
+    // (so `_getSharedContextInstance`/`bag.when`/`ctx.sub` readers are
+    // unaffected), while construction and teardown now live on the controller.
+    // `PluginController` stays constructed here — it needs the PubSub ctx
+    // (`*lazyPlugins`, the `*publicApi` instance), which the DOM-free
+    // controller must not reach (see `UploaderController`'s class doc).
+    this._addSharedContextInstance(
+      '*eventEmitter',
+      (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().eventEmitter,
+    );
+    this._addSharedContextInstance(
+      '*localeManager',
+      (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().localeManager,
+    );
+    // `LocaleManager`'s construction-time work (seeding the `en` dictionary,
+    // subscribing to `localeName`/`localeDefinitionOverride`, and wiring the
+    // plugin-manager coupling) is deferred out of `UploaderController`'s ctor
+    // (see `LocaleManager.activate`'s doc) — run it now, right where v1
+    // constructed `LocaleManager` itself. Both `*eventEmitter`/`*localeManager`
+    // and `*pluginManager` are registered by now.
+    this.localeManager.activate(this._sharedInstancesBag.pluginManager);
     this._addSharedContextInstance('*a11y', () => new A11y());
-    this._addSharedContextInstance('*router', () => new RouterController({ emit: this._routerEmit }));
+    this._addSharedContextInstance(
+      '*router',
+      (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().router,
+    );
     this._addSharedContextInstance(
       '*clipboard',
       (sharedInstancesBag) =>
@@ -126,13 +150,7 @@ export class LitBlock extends LitBlockBase {
     );
     this._addSharedContextInstance(
       '*telemetryManager',
-      (sharedInstancesBag) =>
-        new TelemetryManager({
-          config: sharedInstancesBag.ctx.uploaderController().config,
-          getSolution: () => sharedInstancesBag.ctx.uploaderController().solutionName,
-          getActivity: () =>
-            sharedInstancesBag.ctx.has('*router') ? sharedInstancesBag.ctx.read('*router').currentActivity : null,
-        }),
+      (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().telemetryManager,
     );
 
     this.sub(localeStateKey('locale-id'), (localeId: string) => {
@@ -168,23 +186,6 @@ export class LitBlock extends LitBlockBase {
   public get router(): RouterController {
     return this._getSharedContextInstance('*router');
   }
-
-  /**
-   * Telemetry-augmented emit, narrowed to the router's documented payloads and
-   * matching v1's debounce behavior (modal events debounce; activity-change
-   * fires immediately). Injected into the {@link RouterController}.
-   */
-  private _routerEmit: RouterControllerDeps['emit'] = (
-    type: UploaderEventKey,
-    payload: UploaderEventPayload[UploaderEventKey],
-  ): void => {
-    const debounce = type === UploaderEventType.MODAL_OPEN || type === UploaderEventType.MODAL_CLOSE;
-    // `this.emit` already accepts the widened `(UploaderEventKey, payload)` union
-    // that the field's `RouterEmit` type funnels down to, so no cast is needed —
-    // and it must stay a bound method call (`this.emit`, not an extracted ref) so
-    // it keeps its `this` when the router invokes it.
-    this.emit(type, payload, debounce ? { debounce: true } : undefined);
-  };
 
   /**
    * Subscribe to a value derived from router state: fires immediately with
@@ -312,7 +313,13 @@ export class LitBlock extends LitBlockBase {
   private _destroySharedContextInstances(): void {
     const instances = this._getSharedContextInstances();
     for (const [key, instance] of instances.entries()) {
-      instance?.destroy?.();
+      // Controller-owned instances (M9k) are destroyed by
+      // `UploaderController.destroy()`, which `PubSub.deleteCtx` triggers right
+      // after this loop — destroying them here too would tear them down while
+      // the ctx is still up. Still pub-null them below, same as every other key.
+      if (!controllerOwnedInstanceKeys.has(key as keyof SharedState)) {
+        instance?.destroy?.();
+      }
       this.pub(key as keyof SharedState, null as never);
     }
     instances.clear();

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -313,24 +313,27 @@ describe('PubSub (M9k Task 3: pre-connect construction timing)', () => {
     // ctx, matching the M9k Task 2 shift: the controller (and its four
     // managers) now come into being the moment *any* `*cfg/*`/`*l10n/*` key is
     // touched, not when a DOM element's `initCallback` runs.
-    const ctx = freshCtx();
-    expect(() => ctx.read('*cfg/multiple')).not.toThrow();
+    try {
+      const ctx = freshCtx();
+      expect(() => ctx.read('*cfg/multiple')).not.toThrow();
 
-    const controller = UploaderRegistry.get(ctx.id);
-    expect(controller).toBeDefined();
-    expect(controller!.localeManager).toBeInstanceOf(LocaleManager);
-    expect(controller!.eventEmitter).toBeInstanceOf(EventEmitter);
-    expect(controller!.telemetryManager).toBeInstanceOf(TelemetryManager);
-    expect(controller!.router).toBeInstanceOf(RouterController);
+      const controller = UploaderRegistry.get(ctx.id);
+      expect(controller).toBeDefined();
+      expect(controller!.localeManager).toBeInstanceOf(LocaleManager);
+      expect(controller!.eventEmitter).toBeInstanceOf(EventEmitter);
+      expect(controller!.telemetryManager).toBeInstanceOf(TelemetryManager);
+      expect(controller!.router).toBeInstanceOf(RouterController);
 
-    // Nothing on this path reaches into the DOM/global scope — a11y and
-    // clipboard (element-triggered only, added by `LitBlock.initCallback`)
-    // are the guard: this ctx never had a block connect, so they must not
-    // exist at all.
-    expect(ctx.has('*a11y')).toBe(false);
-    expect(ctx.has('*clipboard')).toBe(false);
+      // Nothing on this path reaches into the DOM/global scope — a11y and
+      // clipboard (element-triggered only, added by `LitBlock.initCallback`)
+      // are the guard: this ctx never had a block connect, so they must not
+      // exist at all.
+      expect(ctx.has('*a11y')).toBe(false);
+      expect(ctx.has('*clipboard')).toBe(false);
 
-    expect(addEventListenerSpy).not.toHaveBeenCalled();
-    addEventListenerSpy.mockRestore();
+      expect(addEventListenerSpy).not.toHaveBeenCalled();
+    } finally {
+      addEventListenerSpy.mockRestore();
+    }
   });
 });

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RouterController } from '../abstract/controllers/RouterController';
+import { LocaleManager } from '../abstract/managers/LocaleManager';
+import { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import { initialConfig } from '../blocks/Config/initialConfig';
+import { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
 import { PubSub } from './PubSubCompat';
 
 // Each test uses a unique ctx id and tears it down so the module-level
@@ -268,5 +272,65 @@ describe('PubSub (additional coverage)', () => {
     expect(secondController).not.toBe(firstController);
     // Fresh defaults — no leakage of the mutated value from the destroyed ctx.
     expect(secondCtx.read('*cfg/multiple')).toBe(initialConfig.multiple);
+  });
+
+  it('deleteCtx orders: ctx removal, then UploaderRegistry unregister (null-notify), then controller.destroy()', () => {
+    const ctx = freshCtx();
+    const id = ctx.id;
+    ctx.read('*cfg/multiple'); // triggers lazy controller creation
+    const controller = UploaderRegistry.get(id)!;
+
+    const callOrder: string[] = [];
+    const destroySpy = vi.spyOn(controller, 'destroy');
+
+    // `whenAvailable` fires synchronously with `null` from inside
+    // `UploaderRegistry.unregister` — record what the ctx/controller state
+    // looks like at that exact moment.
+    const unsub = UploaderRegistry.whenAvailable(id, (c) => {
+      if (c === null) {
+        callOrder.push('unregister-null-notify');
+        expect(PubSub.hasCtx(id)).toBe(false); // ctx already gone by this point
+        expect(destroySpy).not.toHaveBeenCalled(); // controller not yet destroyed
+      }
+    });
+
+    destroySpy.mockImplementation(() => {
+      callOrder.push('controller.destroy');
+    });
+
+    PubSub.deleteCtx(id);
+    unsub();
+
+    expect(callOrder).toEqual(['unregister-null-notify', 'controller.destroy']);
+  });
+});
+
+describe('PubSub (M9k Task 3: pre-connect construction timing)', () => {
+  it('touching a *cfg/* key before any element connects builds all four controller-owned managers, with no global side effects', () => {
+    const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
+
+    // Bare ctx + a config read — no `<uc-config>`/`LitBlock` ever touches this
+    // ctx, matching the M9k Task 2 shift: the controller (and its four
+    // managers) now come into being the moment *any* `*cfg/*`/`*l10n/*` key is
+    // touched, not when a DOM element's `initCallback` runs.
+    const ctx = freshCtx();
+    expect(() => ctx.read('*cfg/multiple')).not.toThrow();
+
+    const controller = UploaderRegistry.get(ctx.id);
+    expect(controller).toBeDefined();
+    expect(controller!.localeManager).toBeInstanceOf(LocaleManager);
+    expect(controller!.eventEmitter).toBeInstanceOf(EventEmitter);
+    expect(controller!.telemetryManager).toBeInstanceOf(TelemetryManager);
+    expect(controller!.router).toBeInstanceOf(RouterController);
+
+    // Nothing on this path reaches into the DOM/global scope — a11y and
+    // clipboard (element-triggered only, added by `LitBlock.initCallback`)
+    // are the guard: this ctx never had a block connect, so they must not
+    // exist at all.
+    expect(ctx.has('*a11y')).toBe(false);
+    expect(ctx.has('*clipboard')).toBe(false);
+
+    expect(addEventListenerSpy).not.toHaveBeenCalled();
+    addEventListenerSpy.mockRestore();
   });
 });

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -245,4 +245,28 @@ describe('PubSub (additional coverage)', () => {
     expect(() => PubSub.deleteCtx(ctx.id)).not.toThrow();
     expect(PubSub.hasCtx(ctx.id)).toBe(false);
   });
+
+  it('reusing the same ctx id after a full teardown rebuilds a brand-new controller, not the destroyed one', () => {
+    const id = freshCtx().id;
+    const firstCtx = PubSub.getCtx<Record<string, unknown>>(id)!;
+    firstCtx.pub('*cfg/multiple', false); // mutate away from the default
+    const firstController = UploaderRegistry.get(id);
+    expect(firstController).toBeDefined();
+
+    PubSub.deleteCtx(id);
+    expect(PubSub.hasCtx(id)).toBe(false);
+    expect(UploaderRegistry.get(id)).toBeUndefined();
+
+    // Same id, re-registered — the controller-owned managers this milestone
+    // moves onto UploaderController must not survive under a stale reference
+    // keyed by ctx id; a fresh registration must get a fresh controller.
+    const secondCtx = PubSub.registerCtx<Record<string, unknown>>({ plain: 'seed' }, id);
+    secondCtx.read('*cfg/multiple'); // triggers lazy controller (re-)creation
+    const secondController = UploaderRegistry.get(id);
+
+    expect(secondController).toBeDefined();
+    expect(secondController).not.toBe(firstController);
+    // Fresh defaults — no leakage of the mutated value from the destroyed ctx.
+    expect(secondCtx.read('*cfg/multiple')).toBe(initialConfig.multiple);
+  });
 });

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -90,6 +90,23 @@ const instanceKeyMap = {
   validationManager: '*validationManager',
 } satisfies Record<string, keyof SharedState>;
 
+/**
+ * The v1 shared-instance keys whose backing instance is now constructed
+ * *and* destroyed by `UploaderController` (M9k), not by the DOM layer.
+ * `LitBlock._destroySharedContextInstances` still pub-nulls these keys (so
+ * `bag.when`/`ctx.sub` readers see the same teardown signal as before) but
+ * must skip calling `.destroy()` on them directly — `UploaderController.destroy()`
+ * owns that call, and it runs *after* the DOM layer's pub-null loop (via
+ * `PubSub.deleteCtx`), so double-destroying here would tear them down early,
+ * while the ctx (and any reader still using it) is still technically "up".
+ */
+export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new Set([
+  instanceKeyMap.eventEmitter,
+  instanceKeyMap.localeManager,
+  instanceKeyMap.telemetryManager,
+  instanceKeyMap.router,
+]);
+
 type InstanceTypeMap = {
   [key in keyof typeof instanceKeyMap]: SharedState[(typeof instanceKeyMap)[key]];
 };

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -99,12 +99,24 @@ const instanceKeyMap = {
  * owns that call, and it runs *after* the DOM layer's pub-null loop (via
  * `PubSub.deleteCtx`), so double-destroying here would tear them down early,
  * while the ctx (and any reader still using it) is still technically "up".
+ *
+ * `*uploadCollection` joins this set too (M9k Task 3): it was already
+ * *constructed* by the controller (`controller.collection`, since Task 2),
+ * but until now it was also `.destroy()`-ed here in the DOM loop AND again by
+ * `UploaderController.destroy()` — a harmless-but-real double-destroy (the
+ * collection's `destroy()` just re-clears already-empty collections the
+ * second time). None of the sibling shared instances registered after it
+ * (`*secureUploadsManager`, `*uploadController`, `*validationManager`,
+ * `*uploadEvents`) read from the collection during their own `.destroy()`,
+ * so deferring its real destroy to the controller (same as the other four)
+ * is order-safe.
  */
 export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new Set([
   instanceKeyMap.eventEmitter,
   instanceKeyMap.localeManager,
   instanceKeyMap.telemetryManager,
   instanceKeyMap.router,
+  instanceKeyMap.uploadCollection,
 ]);
 
 type InstanceTypeMap = {

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -1,0 +1,174 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { TelemetryManager } from '@/abstract/managers/TelemetryManager';
+import type { Config, UploadCtxProvider } from '@/index.js';
+import { PubSub } from '@/lit/PubSubCompat';
+import { getCtxName } from '../utils/getCtxName';
+import { cleanup } from '../utils/test-renderer';
+import '../../types/jsx';
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+/**
+ * Gap-fill ahead of M9k Task 2 (moving construction of RouterController,
+ * PluginController, TelemetryManager, LocaleManager, EventEmitter off
+ * `LitBlock.initCallback` onto `UploaderController`). Pins instance-lifecycle
+ * behavior nothing else currently exercises, so the construction move has a
+ * regression net.
+ */
+describe('instance lifecycle (config-only ctx)', () => {
+  it('a config-only ctx (no uploader block) still builds every LitBlock-scope instance, and tears down cleanly', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" qualityInsights={false} testMode></uc-config>);
+
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const ctx = PubSub.getCtx(ctxName)!;
+
+    // Every instance `LitBlock.initCallback` adds unconditionally, even with
+    // no uploader block in the tree.
+    expect(ctx.has('*blocksRegistry')).toBe(true);
+    expect(ctx.has('*pluginManager')).toBe(true);
+    expect(ctx.has('*eventEmitter')).toBe(true);
+    expect(ctx.has('*localeManager')).toBe(true);
+    expect(ctx.has('*a11y')).toBe(true);
+    expect(ctx.has('*router')).toBe(true);
+    expect(ctx.has('*clipboard')).toBe(true);
+    expect(ctx.has('*telemetryManager')).toBe(true);
+
+    // `*uploadCollection` is added by `LitUploaderBlock`, not `LitBlock` —
+    // `<uc-config>` alone must not create it.
+    expect(ctx.has('*uploadCollection')).toBe(false);
+
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      cleanup();
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
+  });
+});
+
+describe('instance lifecycle (emit contract, router-driven path)', () => {
+  it('a router-driven navigation dispatches the documented event on the provider AND mirrors it to telemetry', async () => {
+    const sendEventSpy = vi.spyOn(TelemetryManager.prototype, 'sendEvent');
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const openHandler = vi.fn<(e: CustomEvent<unknown>) => void>();
+    ctxProvider.addEventListener('modal-open', openHandler);
+
+    sendEventSpy.mockClear(); // drop init-solution/config noise from setup
+
+    // The router's own navigation — not a block calling `emit` directly —
+    // drives this: `RouterController` → `LitBlock._routerEmit` → `LitBlock.emit`.
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+    await expect.poll(() => openHandler.mock.calls.length).toBe(1);
+    expect((openHandler.mock.calls[0][0] as CustomEvent).detail).toMatchObject({ modalId: 'start-from' });
+
+    // Telemetry mirror: the same router-driven emit reaches `sendEvent` with
+    // the matching documented event type (debounced, but the queued call
+    // still lands within the poll window).
+    await expect.poll(() => sendEventSpy.mock.calls.some((call) => call[0]?.eventType === 'modal-open')).toBe(true);
+
+    sendEventSpy.mockRestore();
+  });
+
+  it('emitting on a LitBlock instance after its ctx has been torn down is a silent no-op (no telemetry, no throw)', async () => {
+    const sendEventSpy = vi.spyOn(TelemetryManager.prototype, 'sendEvent');
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+
+    // Keep a live reference to a v1 LitBlock past the DOM teardown — same
+    // shape as a queued callback holding a reference to an unmounted block.
+    const config = page.getByTestId('uc-config').query()! as Config;
+
+    cleanup();
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+    sendEventSpy.mockClear();
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      expect(() => config.emit('modal-close', { modalId: 'start-from', hasActiveModals: false })).not.toThrow();
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
+    expect(sendEventSpy).not.toHaveBeenCalled();
+
+    sendEventSpy.mockRestore();
+  });
+});
+
+describe('instance lifecycle (destroy -> recreate cycle)', () => {
+  it('reusing the same ctx-name after a full teardown rebuilds fresh instances, not the destroyed ones', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const firstCtx = PubSub.getCtx(ctxName)!;
+    const firstRouter = firstCtx.read('*router');
+    const firstTelemetry = firstCtx.read('*telemetryManager');
+
+    // Prove the first router carries real navigation state before teardown.
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    expect(firstRouter.currentActivity).not.toBeNull();
+
+    cleanup();
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+    // Same ctx-name, brand-new elements.
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const secondCtx = PubSub.getCtx(ctxName)!;
+    const secondRouter = secondCtx.read('*router');
+    const secondTelemetry = secondCtx.read('*telemetryManager');
+
+    expect(secondRouter).not.toBe(firstRouter);
+    expect(secondTelemetry).not.toBe(firstTelemetry);
+    // Fresh router state — no leaked navigation from the destroyed ctx.
+    expect(secondRouter.currentActivity).toBeNull();
+  });
+});

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -172,3 +172,44 @@ describe('instance lifecycle (destroy -> recreate cycle)', () => {
     expect(secondRouter.currentActivity).toBeNull();
   });
 });
+
+describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
+  it('a full ctx teardown destroys each controller-owned manager exactly once', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const ctx = PubSub.getCtx(ctxName)!;
+
+    // The five controller-owned shared instances (M9k): teardown runs through
+    // two paths — `LitBlock._destroySharedContextInstances` (the DOM-layer
+    // pub-null loop) and `UploaderController.destroy()` (via
+    // `PubSub.deleteCtx`) — and only the latter may actually call `.destroy()`
+    // on these, or they'd be torn down twice.
+    const eventEmitter = ctx.read('*eventEmitter');
+    const localeManager = ctx.read('*localeManager');
+    const telemetryManager = ctx.read('*telemetryManager');
+    const router = ctx.read('*router');
+    const uploadCollection = ctx.read('*uploadCollection');
+
+    const eventEmitterDestroy = vi.spyOn(eventEmitter, 'destroy');
+    const localeManagerDestroy = vi.spyOn(localeManager, 'destroy');
+    const telemetryManagerDestroy = vi.spyOn(telemetryManager, 'destroy');
+    const routerDestroy = vi.spyOn(router, 'destroy');
+    const uploadCollectionDestroy = vi.spyOn(uploadCollection, 'destroy');
+
+    cleanup();
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+    expect(eventEmitterDestroy).toHaveBeenCalledTimes(1);
+    expect(localeManagerDestroy).toHaveBeenCalledTimes(1);
+    expect(telemetryManagerDestroy).toHaveBeenCalledTimes(1);
+    expect(routerDestroy).toHaveBeenCalledTimes(1);
+    expect(uploadCollectionDestroy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -70,26 +70,28 @@ describe('instance lifecycle (emit contract, router-driven path)', () => {
       </>,
     );
 
-    const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
-    const openHandler = vi.fn<(e: CustomEvent<unknown>) => void>();
-    ctxProvider.addEventListener('modal-open', openHandler);
+    try {
+      const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+      const openHandler = vi.fn<(e: CustomEvent<unknown>) => void>();
+      ctxProvider.addEventListener('modal-open', openHandler);
 
-    sendEventSpy.mockClear(); // drop init-solution/config noise from setup
+      sendEventSpy.mockClear(); // drop init-solution/config noise from setup
 
-    // The router's own navigation — not a block calling `emit` directly —
-    // drives this: `RouterController` → `UploaderController.emit`.
-    await page.getByText('Upload files', { exact: true }).click();
-    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+      // The router's own navigation — not a block calling `emit` directly —
+      // drives this: `RouterController` → `UploaderController.emit`.
+      await page.getByText('Upload files', { exact: true }).click();
+      await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
 
-    await expect.poll(() => openHandler.mock.calls.length).toBe(1);
-    expect((openHandler.mock.calls[0][0] as CustomEvent).detail).toMatchObject({ modalId: 'start-from' });
+      await expect.poll(() => openHandler.mock.calls.length).toBe(1);
+      expect((openHandler.mock.calls[0][0] as CustomEvent).detail).toMatchObject({ modalId: 'start-from' });
 
-    // Telemetry mirror: the same router-driven emit reaches `sendEvent` with
-    // the matching documented event type (debounced, but the queued call
-    // still lands within the poll window).
-    await expect.poll(() => sendEventSpy.mock.calls.some((call) => call[0]?.eventType === 'modal-open')).toBe(true);
-
-    sendEventSpy.mockRestore();
+      // Telemetry mirror: the same router-driven emit reaches `sendEvent` with
+      // the matching documented event type (debounced, but the queued call
+      // still lands within the poll window).
+      await expect.poll(() => sendEventSpy.mock.calls.some((call) => call[0]?.eventType === 'modal-open')).toBe(true);
+    } finally {
+      sendEventSpy.mockRestore();
+    }
   });
 
   it('emitting on a LitBlock instance after its ctx has been torn down is a silent no-op (no telemetry, no throw)', async () => {
@@ -104,29 +106,31 @@ describe('instance lifecycle (emit contract, router-driven path)', () => {
     );
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
 
-    // Keep a live reference to a v1 LitBlock past the DOM teardown — same
-    // shape as a queued callback holding a reference to an unmounted block.
-    const config = page.getByTestId('uc-config').query()! as Config;
-
-    cleanup();
-    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
-
-    sendEventSpy.mockClear();
-    const errors: string[] = [];
-    const onError = (event: ErrorEvent) => {
-      errors.push(String(event.error?.message ?? event.message));
-      event.preventDefault();
-    };
-    window.addEventListener('error', onError);
     try {
-      expect(() => config.emit('modal-close', { modalId: 'start-from', hasActiveModals: false })).not.toThrow();
-    } finally {
-      window.removeEventListener('error', onError);
-    }
-    expect(errors).toEqual([]);
-    expect(sendEventSpy).not.toHaveBeenCalled();
+      // Keep a live reference to a v1 LitBlock past the DOM teardown — same
+      // shape as a queued callback holding a reference to an unmounted block.
+      const config = page.getByTestId('uc-config').query()! as Config;
 
-    sendEventSpy.mockRestore();
+      cleanup();
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+
+      sendEventSpy.mockClear();
+      const errors: string[] = [];
+      const onError = (event: ErrorEvent) => {
+        errors.push(String(event.error?.message ?? event.message));
+        event.preventDefault();
+      };
+      window.addEventListener('error', onError);
+      try {
+        expect(() => config.emit('modal-close', { modalId: 'start-from', hasActiveModals: false })).not.toThrow();
+      } finally {
+        window.removeEventListener('error', onError);
+      }
+      expect(errors).toEqual([]);
+      expect(sendEventSpy).not.toHaveBeenCalled();
+    } finally {
+      sendEventSpy.mockRestore();
+    }
   });
 });
 

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -3,6 +3,7 @@ import { page } from 'vitest/browser';
 import { TelemetryManager } from '@/abstract/managers/TelemetryManager';
 import type { Config, UploadCtxProvider } from '@/index.js';
 import { PubSub } from '@/lit/PubSubCompat';
+import type { SharedState } from '@/lit/SharedState';
 import { getCtxName } from '../utils/getCtxName';
 import { cleanup } from '../utils/test-renderer';
 import '../../types/jsx';
@@ -25,7 +26,7 @@ describe('instance lifecycle (config-only ctx)', () => {
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" qualityInsights={false} testMode></uc-config>);
 
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
-    const ctx = PubSub.getCtx(ctxName)!;
+    const ctx = PubSub.getCtx<SharedState>(ctxName)!;
 
     // Every instance `LitBlock.initCallback` adds unconditionally, even with
     // no uploader block in the tree.
@@ -145,7 +146,7 @@ describe('instance lifecycle (destroy -> recreate cycle)', () => {
       </>,
     );
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
-    const firstCtx = PubSub.getCtx(ctxName)!;
+    const firstCtx = PubSub.getCtx<SharedState>(ctxName)!;
     const firstRouter = firstCtx.read('*router');
     const firstTelemetry = firstCtx.read('*telemetryManager');
 
@@ -166,7 +167,7 @@ describe('instance lifecycle (destroy -> recreate cycle)', () => {
       </>,
     );
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
-    const secondCtx = PubSub.getCtx(ctxName)!;
+    const secondCtx = PubSub.getCtx<SharedState>(ctxName)!;
     const secondRouter = secondCtx.read('*router');
     const secondTelemetry = secondCtx.read('*telemetryManager');
 
@@ -188,7 +189,7 @@ describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
       </>,
     );
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
-    const ctx = PubSub.getCtx(ctxName)!;
+    const ctx = PubSub.getCtx<SharedState>(ctxName)!;
 
     // The five controller-owned shared instances (M9k): teardown runs through
     // two paths — `LitBlock._destroySharedContextInstances` (the DOM-layer

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -77,7 +77,7 @@ describe('instance lifecycle (emit contract, router-driven path)', () => {
     sendEventSpy.mockClear(); // drop init-solution/config noise from setup
 
     // The router's own navigation — not a block calling `emit` directly —
-    // drives this: `RouterController` → `LitBlock._routerEmit` → `LitBlock.emit`.
+    // drives this: `RouterController` → `UploaderController.emit`.
     await page.getByText('Upload files', { exact: true }).click();
     await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
 


### PR DESCRIPTION
## What

Part 1 of the instance-creation migration: `UploaderController` now constructs and owns **five** instances — `localeManager`, `eventEmitter`, `telemetryManager`, `router` (built with a new controller-level `emit`: EventEmitter dispatch + teardown-safe telemetry mirror), and the pre-existing `collection` re-exposure (`*uploadCollection`).

Ctx keys are unchanged for all consumers — `LitBlock`'s registrations for these keys are now **re-exposers**: element teardown pub-nulls all keys as before, but skips `destroy()` for controller-owned ones. `UploaderController.destroy()` is the sole owner of their destruction. `deleteCtx` ordering is unchanged: ctx delete → registry null-notify → `controller.destroy()`.

`*uploadCollection` was joined to `controllerOwnedInstanceKeys`, closing a double-destroy bug where both the element teardown and the controller could call `destroy()` on the same collection instance.

## Design notes

- **LocaleManager ctor/activate split**: pure constructor + idempotent `activate(pluginManager)`. Necessary because the controller can be lazily created on any cfg touch — side effects in the ctor would have leaked into every such lazily-created controller instance. Caught by a Task-1 pin test.
- **EventEmitter reshape**: taken off `SharedInstance`, now constructed directly from the `EventBus` rather than resolved through the shared-instance registry, since the controller owns its lifecycle directly.
- **LitBlock/ChildBlock `emit` deliberately NOT delegated** to the controller's `emit`. Their guards observe the pub-null teardown signal, which fires *before* `controller.destroy()`. Delegating would shift the M9i-pinned teardown-race window.
- **`*uploadCollection` double-destroy fix**: adding it to `controllerOwnedInstanceKeys` ensures only the controller destroys it, not the element teardown path too.

## Deliberately deferred (the slicing)

- **PluginController** — needs `*lazyPlugins`/`*publicApi` ctx state threaded through first.
- **A11y / ClipboardController** — DOM-at-construction; needs the core/adapter split (planned M9l, following the `EventBridgeController` precedent).
- **The uploader-scope set** (secureUploads → uploadController → publicApi → validation → uploadEvents) — needs an explicit uploader-present gate (planned M9m).
- **`blocksRegistry`** — element-owned, drives teardown; out of scope here.

This is part 1 of the seam that unblocks porting `solutions/`, `Config`, and `UploadCtxProvider` (M9n).

## Review process

Four commits, each reviewed individually (opus review on the construction-move commit); final whole-branch review verdict: **MERGE-READY**. Follow-ups tracked in `.superpowers/sdd/progress.md`.

## Gate (real per-stage counts, this run)

| Stage | Result |
|---|---|
| `tsc:app` | clean, no errors |
| `build` | clean (svg-sprites → lib → ssr-stubs → jsx:types, attw + publint + size-limit all green) |
| `tsc` | "TypeScript: No errors found" |
| `test:specs` | **54 test files / 615 tests passed** |
| `test:locales` | clean, all locales checked, no errors |
| `test:e2e` | **49 test files / 316 tests passed** (no retries needed; known `uc-crop-frame` flake did not occur this run) |
| `lint` | 0 errors (biome + eslint + stylelint + lit-analyzer --strict); 17 pre-existing eslint warnings, unrelated files |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Controller-managed locale, event, telemetry, and routing services now support injected (DOM-free) construction and explicit activation/teardown; modal-open events are mirrored to telemetry.
* **Bug Fixes**
  * Event emission becomes a silent no-op after controller teardown.
  * Telemetry mirroring is resilient to failures, resolves dynamic payload functions safely, and uses live solution/activity getters.
  * Locale activation is idempotent, prevents race-condition overwrites, and cleans up all subscriptions correctly.
* **Tests**
  * Added/expanded Vitest and browser E2E coverage for lifecycle ordering, telemetry mirroring, and locale/routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->