### PR TITLE
feat(m9l): a11y + clipboard lazy-arm split and controller ownership (instance-creation migration, part 2)

### DIFF
--- a/src/abstract/controllers/ClipboardController.test.ts
+++ b/src/abstract/controllers/ClipboardController.test.ts
@@ -357,6 +357,93 @@ describe('ClipboardController', () => {
     expect(onFileAdd).not.toHaveBeenCalled();
   });
 
+  it('construction attaches no window listener (arming is deferred to first registerScope)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+
+    track(setup({ pasteScope: 'global', currentActivity: 'start-from' }).layer);
+
+    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste');
+    expect(pasteAdds).toHaveLength(0);
+  });
+
+  it('arms exactly once across multiple registerScope calls (idempotent)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const { layer } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+    track(layer);
+
+    layer.registerScope(connectedScope());
+    layer.registerScope(connectedScope());
+    layer.registerScope(connectedScope());
+
+    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste');
+    expect(pasteAdds).toHaveLength(1);
+  });
+
+  it('disarms only once the last registered scope is unregistered', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { layer } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+    track(layer);
+
+    const unregisterA = layer.registerScope(connectedScope());
+    const unregisterB = layer.registerScope(connectedScope());
+
+    unregisterA();
+    expect(removeSpy.mock.calls.filter((call) => call[0] === 'paste')).toHaveLength(0);
+
+    unregisterB();
+    expect(removeSpy.mock.calls.filter((call) => call[0] === 'paste')).toHaveLength(1);
+  });
+
+  it('re-arms after a full disarm + re-registration cycle (scopes can cycle 0 → 1 → 0 → 1)', async () => {
+    const { layer, api } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+    track(layer);
+
+    const unregisterFirst = layer.registerScope(connectedScope());
+    unregisterFirst();
+
+    layer.registerScope(connectedScope());
+    window.dispatchEvent(pasteEvent([fileItem(new File(['x'], 'x.txt'))]));
+    await flush();
+
+    expect(api.addFileFromObject).toHaveBeenCalled();
+  });
+
+  it('destroy() disarms unconditionally, and registrations after destroy() do not re-arm', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const { layer, api } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+
+    layer.registerScope(connectedScope());
+    layer.destroy();
+    addSpy.mockClear();
+
+    layer.registerScope(connectedScope());
+    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste');
+    expect(pasteAdds).toHaveLength(0);
+
+    window.dispatchEvent(pasteEvent([fileItem(new File(['x'], 'x.txt'))]));
+    await flush();
+    expect(api.addFileFromObject).not.toHaveBeenCalled();
+  });
+
+  it('default eventTarget (window) is dereferenced lazily at arm time, not at construction', () => {
+    // Constructing with no injected eventTarget must not touch `window` at
+    // all until the first registerScope arms the listener.
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const layer = new ClipboardController({
+      getPasteScope: () => 'global',
+      getCurrentActivity: () => null,
+      addFileFromObject: vi.fn(),
+      addFileFromUrl: vi.fn(),
+      onFileAdd: vi.fn(),
+    });
+    track(layer);
+
+    expect(addSpy.mock.calls.filter((call) => call[0] === 'paste')).toHaveLength(0);
+
+    layer.registerScope(connectedScope());
+    expect(addSpy.mock.calls.filter((call) => call[0] === 'paste')).toHaveLength(1);
+  });
+
   it('the window paste listener add/remove count returns to baseline across a full construct → registerScope → unregister → destroy() cycle', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');

--- a/src/abstract/controllers/ClipboardController.test.ts
+++ b/src/abstract/controllers/ClipboardController.test.ts
@@ -339,8 +339,8 @@ describe('ClipboardController', () => {
 
   // Gap-fill ahead of M9l's lazy-arm split: a fresh instance with
   // `registerScope` never called even once (not merely with a disconnected
-  // scope) — this is exactly the shape a config-only ctx produces today
-  // (`LitBlock.initCallback` constructs `*clipboard` unconditionally;
+  // scope) — this is exactly the shape a config-only ctx produces
+  // (`UploaderController` constructs `*clipboard` unconditionally;
   // `registerScope` only runs from `LitSolutionBlock`/`CloudImageEditor`
   // `initCallback`). Pins the load-bearing fact behind arm-on-registration:
   // `_hasConnectedScope()` over an empty `Set` is unconditionally `false`, so
@@ -449,8 +449,8 @@ describe('ClipboardController', () => {
     const removeSpy = vi.spyOn(window, 'removeEventListener');
 
     // Pins pairing, not timing: whether `addEventListener('paste', ...)` fires
-    // at construction (today) or is deferred to first `registerScope` (M9l's
-    // lazy-arm split), the net effect of a full lifecycle must be that every
+    // at construction (v1) or on first `registerScope` (M9l's lazy-arm split,
+    // current), the net effect of a full lifecycle must be that every
     // `paste` listener this instance added is removed by the time `destroy()`
     // returns — no leaked window listener survives the cycle.
     const { layer } = setup({ pasteScope: 'global', currentActivity: 'start-from' });

--- a/src/abstract/controllers/ClipboardController.test.ts
+++ b/src/abstract/controllers/ClipboardController.test.ts
@@ -336,4 +336,38 @@ describe('ClipboardController', () => {
 
     expect(api.addFileFromObject).not.toHaveBeenCalled();
   });
+
+  // Gap-fill ahead of M9l's lazy-arm split: a fresh instance with
+  // `registerScope` never called even once (not merely with a disconnected
+  // scope) — this is exactly the shape a config-only ctx produces today
+  // (`LitBlock.initCallback` constructs `*clipboard` unconditionally;
+  // `registerScope` only runs from `LitSolutionBlock`/`CloudImageEditor`
+  // `initCallback`). Pins the load-bearing fact behind arm-on-registration:
+  // `_hasConnectedScope()` over an empty `Set` is unconditionally `false`, so
+  // `_handlePasteEvent` bails before any side effect.
+  it('a never-registered instance is inert on a real window paste event', async () => {
+    const { layer, api, onFileAdd } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+    track(layer);
+
+    window.dispatchEvent(pasteEvent([fileItem(new File(['x'], 'x.png'))]));
+    await flush();
+
+    expect(api.addFileFromObject).not.toHaveBeenCalled();
+    expect(api.addFileFromUrl).not.toHaveBeenCalled();
+    expect(onFileAdd).not.toHaveBeenCalled();
+  });
+
+  it('the window paste listener is added exactly once at construction and removed exactly once at destroy()', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const { layer } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
+    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste');
+    expect(pasteAdds).toHaveLength(1);
+
+    layer.destroy();
+    const pasteRemoves = removeSpy.mock.calls.filter((call) => call[0] === 'paste');
+    expect(pasteRemoves).toHaveLength(1);
+    expect(pasteRemoves[0]?.[1]).toBe(pasteAdds[0]?.[1]);
+  });
 });

--- a/src/abstract/controllers/ClipboardController.test.ts
+++ b/src/abstract/controllers/ClipboardController.test.ts
@@ -357,17 +357,24 @@ describe('ClipboardController', () => {
     expect(onFileAdd).not.toHaveBeenCalled();
   });
 
-  it('the window paste listener is added exactly once at construction and removed exactly once at destroy()', () => {
+  it('the window paste listener add/remove count returns to baseline across a full construct → registerScope → unregister → destroy() cycle', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');
 
+    // Pins pairing, not timing: whether `addEventListener('paste', ...)` fires
+    // at construction (today) or is deferred to first `registerScope` (M9l's
+    // lazy-arm split), the net effect of a full lifecycle must be that every
+    // `paste` listener this instance added is removed by the time `destroy()`
+    // returns — no leaked window listener survives the cycle.
     const { layer } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
-    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste');
-    expect(pasteAdds).toHaveLength(1);
-
+    const unregister = layer.registerScope(connectedScope());
+    unregister();
     layer.destroy();
-    const pasteRemoves = removeSpy.mock.calls.filter((call) => call[0] === 'paste');
-    expect(pasteRemoves).toHaveLength(1);
-    expect(pasteRemoves[0]?.[1]).toBe(pasteAdds[0]?.[1]);
+
+    const pasteAdds = addSpy.mock.calls.filter((call) => call[0] === 'paste').map((call) => call[1]);
+    const pasteRemoves = removeSpy.mock.calls.filter((call) => call[0] === 'paste').map((call) => call[1]);
+
+    expect(pasteAdds.length).toBeGreaterThan(0);
+    expect(pasteRemoves).toEqual(pasteAdds);
   });
 });

--- a/src/abstract/controllers/ClipboardController.ts
+++ b/src/abstract/controllers/ClipboardController.ts
@@ -27,13 +27,18 @@ export type ClipboardControllerDeps = {
  */
 export class ClipboardController {
   private _deps: ClipboardControllerDeps;
-  private _eventTarget: Pick<Window, 'addEventListener' | 'removeEventListener'>;
+  private readonly _eventTarget: Pick<Window, 'addEventListener' | 'removeEventListener'> | undefined;
+  private _armedEventTarget: Pick<Window, 'addEventListener' | 'removeEventListener'> | undefined;
   private _scopes: Set<Node> = new Set();
   private _listener: (event: ClipboardEvent) => void;
+  private _armed = false;
+  private _destroyed = false;
 
   public constructor(deps: ClipboardControllerDeps) {
     this._deps = deps;
-    this._eventTarget = deps.eventTarget ?? window;
+    // Stored as provided; the `window` default is resolved lazily in `_arm`
+    // so construction never touches `window` (safe in window-less contexts).
+    this._eventTarget = deps.eventTarget;
     // Isolate-and-warn (AGENTS.md #3): a rejection from an injected add-file
     // dep must stay contained here, not surface as an unhandled rejection.
     this._listener = (event) => {
@@ -41,7 +46,29 @@ export class ClipboardController {
         console.warn('[uc] clipboard paste handling failed', err);
       });
     };
-    this._eventTarget.addEventListener('paste', this._listener);
+  }
+
+  /**
+   * Attaches the window `paste` listener. Lazy: called on the first
+   * registered scope (0 → 1) rather than at construction, and re-callable
+   * after a full disarm (scopes can cycle 0 → 1 → 0 → 1).
+   */
+  private _arm(): void {
+    if (this._armed || this._destroyed) {
+      return;
+    }
+    this._armed = true;
+    this._armedEventTarget = this._eventTarget ?? window;
+    this._armedEventTarget.addEventListener('paste', this._listener);
+  }
+
+  private _disarm(): void {
+    if (!this._armed) {
+      return;
+    }
+    this._armed = false;
+    this._armedEventTarget?.removeEventListener('paste', this._listener);
+    this._armedEventTarget = undefined;
   }
 
   private _isEditableTarget(target: EventTarget | null): boolean {
@@ -190,15 +217,27 @@ export class ClipboardController {
    * must merely be connected). Returns an unregister fn.
    */
   public registerScope(scope: Node): () => void {
+    if (this._destroyed) {
+      return () => {};
+    }
+
+    const wasEmpty = this._scopes.size === 0;
     this._scopes.add(scope);
+    if (wasEmpty) {
+      this._arm();
+    }
 
     return () => {
       this._scopes.delete(scope);
+      if (this._scopes.size === 0) {
+        this._disarm();
+      }
     };
   }
 
   public destroy(): void {
-    this._eventTarget.removeEventListener('paste', this._listener);
+    this._destroyed = true;
+    this._disarm();
     this._scopes.clear();
   }
 }

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
 import { EventBus, UploaderEventType } from '../EventBus';
+import { A11y } from '../managers/a11y';
 import { LocaleManager } from '../managers/LocaleManager';
 import { TelemetryManager } from '../managers/TelemetryManager';
+import { ClipboardController } from './ClipboardController';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
 import { RouterController } from './RouterController';
@@ -70,12 +72,14 @@ describe('UploaderController', () => {
   });
 
   describe('ctx-scope managers', () => {
-    it('constructs its own localeManager, eventEmitter, telemetryManager, and router', () => {
+    it('constructs its own localeManager, eventEmitter, telemetryManager, router, a11y, and clipboard', () => {
       const controller = new UploaderController();
       expect(controller.localeManager).toBeInstanceOf(LocaleManager);
       expect(controller.eventEmitter).toBeInstanceOf(EventEmitter);
       expect(controller.telemetryManager).toBeInstanceOf(TelemetryManager);
       expect(controller.router).toBeInstanceOf(RouterController);
+      expect(controller.a11y).toBeInstanceOf(A11y);
+      expect(controller.clipboard).toBeInstanceOf(ClipboardController);
     });
 
     it('uses injected managers instead of constructing its own', () => {
@@ -87,13 +91,30 @@ describe('UploaderController', () => {
         getActivity: () => null,
       });
       const router = new RouterController({ emit: () => {} });
+      const a11y = new A11y();
+      const clipboard = new ClipboardController({
+        getPasteScope: () => false,
+        getCurrentActivity: () => null,
+        addFileFromObject: () => {},
+        addFileFromUrl: () => {},
+        onFileAdd: () => {},
+      });
 
-      const controller = new UploaderController({ localeManager, eventEmitter, telemetryManager, router });
+      const controller = new UploaderController({
+        localeManager,
+        eventEmitter,
+        telemetryManager,
+        router,
+        a11y,
+        clipboard,
+      });
 
       expect(controller.localeManager).toBe(localeManager);
       expect(controller.eventEmitter).toBe(eventEmitter);
       expect(controller.telemetryManager).toBe(telemetryManager);
       expect(controller.router).toBe(router);
+      expect(controller.a11y).toBe(a11y);
+      expect(controller.clipboard).toBe(clipboard);
     });
 
     it("wires the router's emit to the controller's own emit, debouncing modal transitions", () => {
@@ -166,6 +187,8 @@ describe('UploaderController', () => {
 
   it('destroy() tears down the ctx-scope managers too, in reverse construction order', () => {
     const controller = new UploaderController();
+    const clipboardDestroy = vi.spyOn(controller.clipboard, 'destroy');
+    const a11yDestroy = vi.spyOn(controller.a11y, 'destroy');
     const routerDestroy = vi.spyOn(controller.router, 'destroy');
     const telemetryDestroy = vi.spyOn(controller.telemetryManager, 'destroy');
     const eventEmitterDestroy = vi.spyOn(controller.eventEmitter, 'destroy');
@@ -173,18 +196,77 @@ describe('UploaderController', () => {
 
     controller.destroy();
 
+    expect(clipboardDestroy).toHaveBeenCalled();
+    expect(a11yDestroy).toHaveBeenCalled();
     expect(routerDestroy).toHaveBeenCalled();
     expect(telemetryDestroy).toHaveBeenCalled();
     expect(eventEmitterDestroy).toHaveBeenCalled();
     expect(localeManagerDestroy).toHaveBeenCalled();
 
+    const clipboardOrder = clipboardDestroy.mock.invocationCallOrder[0]!;
+    const a11yOrder = a11yDestroy.mock.invocationCallOrder[0]!;
     const routerOrder = routerDestroy.mock.invocationCallOrder[0]!;
     const telemetryOrder = telemetryDestroy.mock.invocationCallOrder[0]!;
     const eventEmitterOrder = eventEmitterDestroy.mock.invocationCallOrder[0]!;
     const localeManagerOrder = localeManagerDestroy.mock.invocationCallOrder[0]!;
+    expect(clipboardOrder).toBeLessThan(a11yOrder);
+    expect(a11yOrder).toBeLessThan(routerOrder);
     expect(routerOrder).toBeLessThan(telemetryOrder);
     expect(telemetryOrder).toBeLessThan(eventEmitterOrder);
     expect(eventEmitterOrder).toBeLessThan(localeManagerOrder);
+  });
+
+  it('destroy() tolerates running with the api never set (no paste ever happened)', () => {
+    const controller = new UploaderController();
+    expect(() => controller.destroy()).not.toThrow();
+  });
+
+  describe('api (uploader-scope public API — element-constructed, controller-held)', () => {
+    it('throws if accessed before setApi()', () => {
+      const controller = new UploaderController();
+      expect(() => controller.api).toThrow(/setApi/);
+    });
+
+    it('returns the instance passed to setApi()', () => {
+      const controller = new UploaderController();
+      const fakeApi = { addFileFromObject: vi.fn(), addFileFromUrl: vi.fn() } as never;
+
+      controller.setApi(fakeApi);
+
+      expect(controller.api).toBe(fakeApi);
+    });
+
+    it("wires the clipboard controller's add-file callbacks to setApi()'s instance, resolved lazily", async () => {
+      const controller = new UploaderController();
+      const addFileFromObject = vi.fn();
+      const addFileFromUrl = vi.fn();
+
+      // setApi() runs AFTER the clipboard controller is already constructed —
+      // proving the callbacks resolve `api` lazily rather than capturing it
+      // at construction time.
+      controller.setApi({ addFileFromObject, addFileFromUrl } as never);
+
+      const file = new File(['x'], 'x.txt');
+      const scope = document.createElement('div');
+      document.body.appendChild(scope);
+      controller.clipboard.registerScope(scope);
+      try {
+        const clipboardData = {
+          items: [{ kind: 'file', getAsFile: () => file }],
+        } as unknown as DataTransfer;
+        const event = new ClipboardEvent('paste', { clipboardData: undefined });
+        Object.defineProperty(event, 'clipboardData', { value: clipboardData });
+        Object.defineProperty(event, 'target', { value: scope });
+        window.dispatchEvent(event);
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(addFileFromObject).toHaveBeenCalledWith(file, { source: 'clipboard' });
+      } finally {
+        scope.remove();
+        controller.destroy();
+      }
+    });
   });
 
   it('is DOM-free — constructing touches no element APIs', () => {

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,7 +1,10 @@
 import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
 import { EventBus, type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../EventBus';
+import { A11y } from '../managers/a11y';
 import { LocaleManager } from '../managers/LocaleManager';
 import { TelemetryManager } from '../managers/TelemetryManager';
+import type { UploaderPublicApi } from '../UploaderPublicApi';
+import { ClipboardController } from './ClipboardController';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
 import { RouterController } from './RouterController';
@@ -31,15 +34,26 @@ import { UploadCollectionController } from './UploadCollectionController';
  * default-parameter injection — no container/decorators; the DOM layer already
  * has its own wiring via `@lit/context`.
  *
- * M9k also moves four of the five v1 ctx-scope managers here (construction +
+ * M9k moved four of the six v1 ctx-scope managers here (construction +
  * teardown ownership): `localeManager`, `eventEmitter`, `telemetryManager`,
- * `router`. `PluginController` (the fifth) stays constructed by the DOM layer
- * (`LitBlock`) — it genuinely needs the PubSub ctx (`*lazyPlugins`, arbitrary
- * shared state) and the `*publicApi` shared instance, neither of which the
- * DOM-free controller can reach without importing `PubSub` here, which would
- * both create a circular import (`PubSubCompat` already imports
+ * `router`. M9l (Task 3) moves the remaining two that don't need the PubSub
+ * ctx: `a11y`, `clipboard`. `PluginController` stays constructed by the DOM
+ * layer (`LitBlock`) — it genuinely needs the PubSub ctx (`*lazyPlugins`,
+ * arbitrary shared state) and the `*publicApi` shared instance, neither of
+ * which the DOM-free controller can reach without importing `PubSub` here,
+ * which would both create a circular import (`PubSubCompat` already imports
  * `UploaderController`) and break the "abstract/ touches no DOM" boundary in
  * spirit. See the M9k task report for the full audit.
+ *
+ * `clipboard`'s add-file callbacks need the uploader-scope public API
+ * (`*publicApi`), which is itself DOM-layer-constructed (`LitUploaderBlock`,
+ * since `UploaderPublicApi` needs the shared-instances bag) — the controller
+ * does not, and must not, construct it. Instead the controller holds a
+ * settable `api` reference (`setApi`, mirroring the existing `setSolutionName`
+ * pattern): `LitUploaderBlock` calls it right after constructing `*publicApi`.
+ * `clipboard`'s callbacks read `this.api` lazily, at paste time — which is
+ * always after `setApi` has run, since a paste can only ever add a file
+ * through an already-constructed uploader element.
  */
 export type UploaderControllerDeps = {
   events?: EventBus;
@@ -50,6 +64,8 @@ export type UploaderControllerDeps = {
   eventEmitter?: EventEmitter;
   telemetryManager?: TelemetryManager;
   router?: RouterController;
+  a11y?: A11y;
+  clipboard?: ClipboardController;
 };
 
 export class UploaderController {
@@ -61,11 +77,17 @@ export class UploaderController {
   public readonly eventEmitter: EventEmitter;
   public readonly telemetryManager: TelemetryManager;
   public readonly router: RouterController;
+  public readonly a11y: A11y;
+  public readonly clipboard: ClipboardController;
 
   // The solution (preset) identity of this uploader scope — a boot-time fact,
   // not reactive state: set once by the solution element, read lazily by
   // telemetry. Stored lowercased, payload-ready.
   private _solutionName: string | null = null;
+  // The uploader-scope public API — element-constructed (see class doc),
+  // handed to the controller once it exists. Only `clipboard`'s add-file
+  // callbacks read this, and only at paste time.
+  private _api: UploaderPublicApi | null = null;
   private _destroyed = false;
 
   public constructor(deps: UploaderControllerDeps = {}) {
@@ -92,6 +114,16 @@ export class UploaderController {
           const debounce = type === UploaderEventType.MODAL_OPEN || type === UploaderEventType.MODAL_CLOSE;
           this.emit(type, payload, debounce ? { debounce: true } : undefined);
         },
+      });
+    this.a11y = deps.a11y ?? new A11y();
+    this.clipboard =
+      deps.clipboard ??
+      new ClipboardController({
+        getPasteScope: () => this.config.get('pasteScope'),
+        getCurrentActivity: () => this.router.currentActivity,
+        addFileFromObject: (file, options) => this.api.addFileFromObject(file, options),
+        addFileFromUrl: (url, options) => this.api.addFileFromUrl(url, options),
+        onFileAdd: () => this.router.traverse('onFileAdd'),
       });
   }
 
@@ -138,6 +170,24 @@ export class UploaderController {
     this._solutionName = name.toLowerCase();
   }
 
+  /**
+   * The uploader-scope public API — see the class doc. Throws if read before
+   * `setApi()` has run (parity with v1's `getSharedInstance` default of
+   * `isRequired: true`: reaching a paste handler without an API is a bug, not
+   * a silent no-op).
+   */
+  public get api(): UploaderPublicApi {
+    if (!this._api) {
+      throw new Error('Unexpected error: UploaderController.api accessed before setApi()');
+    }
+    return this._api;
+  }
+
+  /** Called once by `LitUploaderBlock` right after constructing `*publicApi`. */
+  public setApi(api: UploaderPublicApi): void {
+    this._api = api;
+  }
+
   public destroy(): void {
     this._destroyed = true;
 
@@ -147,6 +197,8 @@ export class UploaderController {
     this.collection.destroy();
 
     // Reverse construction order.
+    this.clipboard.destroy();
+    this.a11y.destroy();
     this.router.destroy();
     this.telemetryManager.destroy();
     this.eventEmitter.destroy();

--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LitBlock } from '../../lit/LitBlock';
+import { A11y } from './a11y';
+
+// `A11y.registerBlock` only reaches into its argument as a `Node` (see
+// `ScopedMinimalWindow.registerScope`); a bare DOM element stands in for a
+// `LitBlock` here so these specs don't need a full Lit fixture.
+const asLitBlock = (node: Node): LitBlock => node as unknown as LitBlock;
+
+/**
+ * Coverage gap-fill ahead of M9l's lazy-arm split (A11y currently attaches its
+ * `keyux`-driven window listeners at construction, before any block registers
+ * a scope). These pin CURRENT behavior:
+ *  - a constructed-but-unregistered instance is provably inert on real window
+ *    events (the load-bearing fact for "arm-on-registration is
+ *    behavior-identical to arm-at-construction");
+ *  - registering a block's scope is what makes keyux features observable;
+ *  - `destroy()` returns the real `window` listener count to baseline (no
+ *    leaked `click`/`focusin`/`focusout`/`keyuxJump` listeners survive it).
+ */
+describe('A11y', () => {
+  const instances: A11y[] = [];
+  const track = (instance: A11y) => {
+    instances.push(instance);
+    return instance;
+  };
+
+  afterEach(() => {
+    for (const instance of instances.splice(0)) {
+      instance.destroy();
+    }
+    document.body.innerHTML = '';
+    vi.restoreAllMocks();
+  });
+
+  const pressableButton = (): HTMLButtonElement => {
+    const button = document.createElement('button');
+    document.body.append(button);
+    return button;
+  };
+
+  it('a constructed instance with no registered block is inert on real window keydown events', () => {
+    track(new A11y());
+    const button = pressableButton();
+
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    // pressKeyUX would add this class on Enter/Space against a button/anchor
+    // target — it never fires because `ScopedMinimalWindow`'s scope gate
+    // (`this._scope.some(...)` over an empty array) is unconditionally false.
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
+
+  it('registering a block scope makes keyux features observable inside that scope', () => {
+    const a11y = track(new A11y());
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    const button = document.createElement('button');
+    scope.append(button);
+
+    a11y.registerBlock(asLitBlock(scope));
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(button.classList.contains('is-pressed')).toBe(true);
+  });
+
+  it('keydown events targeting an element outside every registered scope stay inert', () => {
+    const a11y = track(new A11y());
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    a11y.registerBlock(asLitBlock(scope));
+
+    // Button lives outside the registered scope.
+    const outsideButton = pressableButton();
+    outsideButton.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(outsideButton.classList.contains('is-pressed')).toBe(false);
+  });
+
+  it('a keydown event whose target is not a DOM node (dispatched directly on window) stays inert regardless of scope', () => {
+    const a11y = track(new A11y());
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    a11y.registerBlock(asLitBlock(scope));
+
+    // Dispatched directly on `window`, `event.target` is the `Window` object
+    // itself — not a `Node` — so `ScopedMinimalWindow`'s wrapped listener must
+    // bail before ever consulting the scope list.
+    expect(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))).not.toThrow();
+  });
+
+  it('destroy() returns the real window listener count to baseline (add/remove pairing across all keyux event types)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+
+    const a11y = new A11y();
+    const addedTypes = addSpy.mock.calls.map((call) => call[0]).sort();
+    expect(addedTypes.length).toBeGreaterThan(0);
+
+    a11y.destroy();
+    const removedTypes = removeSpy.mock.calls.map((call) => call[0]).sort();
+
+    // Every `window.addEventListener` this instance made (click, focusin,
+    // focusout, keydown, keyup, keyuxJump — one per keyux feature) is undone
+    // by a matching `window.removeEventListener` of the same type.
+    expect(removedTypes).toEqual(addedTypes);
+  });
+
+  it('destroy() leaves subsequent window keydown events inert even against a previously registered scope', () => {
+    const a11y = new A11y();
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    const button = document.createElement('button');
+    scope.append(button);
+    a11y.registerBlock(asLitBlock(scope));
+
+    a11y.destroy();
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
+});

--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -8,9 +8,9 @@ import { A11y } from './a11y';
 const asLitBlock = (node: Node): LitBlock => node as unknown as LitBlock;
 
 /**
- * Coverage gap-fill ahead of M9l's lazy-arm split (A11y currently attaches its
- * `keyux`-driven window listeners at construction, before any block registers
- * a scope). These pin CURRENT behavior:
+ * Coverage written ahead of M9l's lazy-arm split (v1 attached the
+ * `keyux`-driven window listeners at construction; they now arm on the first
+ * `registerBlock`). These pins are timing-agnostic and hold either way:
  *  - a constructed-but-unregistered instance is provably inert on real window
  *    events (the load-bearing fact for "arm-on-registration is
  *    behavior-identical to arm-at-construction");
@@ -135,8 +135,8 @@ describe('A11y', () => {
     const removeSpy = vi.spyOn(window, 'removeEventListener');
 
     // Pins pairing, not timing: whether the keyux window listeners attach at
-    // construction (today) or are deferred to first `registerBlock` (M9l's
-    // lazy-arm split), the net effect of a full lifecycle — including a real
+    // construction (v1) or on first `registerBlock` (M9l's lazy-arm split,
+    // current), the net effect of a full lifecycle — including a real
     // scope registration — must be that every `window.addEventListener` this
     // instance made (click, focusin, focusout, keydown, keyup, keyuxJump — one
     // per keyux feature) is undone by a matching `removeEventListener` of the

--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -89,20 +89,29 @@ describe('A11y', () => {
     expect(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))).not.toThrow();
   });
 
-  it('destroy() returns the real window listener count to baseline (add/remove pairing across all keyux event types)', () => {
+  it('destroy() returns the real window listener count to baseline across a full construct → registerBlock → destroy() cycle', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');
 
+    // Pins pairing, not timing: whether the keyux window listeners attach at
+    // construction (today) or are deferred to first `registerBlock` (M9l's
+    // lazy-arm split), the net effect of a full lifecycle — including a real
+    // scope registration — must be that every `window.addEventListener` this
+    // instance made (click, focusin, focusout, keydown, keyup, keyuxJump — one
+    // per keyux feature) is undone by a matching `removeEventListener` of the
+    // same type by the time `destroy()` returns. No unregister path exists for
+    // a registered block, so `registerBlock` then `destroy()` is the full cycle.
     const a11y = new A11y();
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    a11y.registerBlock(asLitBlock(scope));
+
     const addedTypes = addSpy.mock.calls.map((call) => call[0]).sort();
     expect(addedTypes.length).toBeGreaterThan(0);
 
     a11y.destroy();
     const removedTypes = removeSpy.mock.calls.map((call) => call[0]).sort();
 
-    // Every `window.addEventListener` this instance made (click, focusin,
-    // focusout, keydown, keyup, keyuxJump — one per keyux feature) is undone
-    // by a matching `window.removeEventListener` of the same type.
     expect(removedTypes).toEqual(addedTypes);
   });
 

--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -89,6 +89,47 @@ describe('A11y', () => {
     expect(() => window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter' }))).not.toThrow();
   });
 
+  it('construction attaches no window listener (arming is deferred to first registerBlock)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+
+    track(new A11y());
+
+    expect(addSpy).not.toHaveBeenCalled();
+  });
+
+  it('arms exactly once across multiple registerBlock calls (idempotent)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const a11y = track(new A11y());
+
+    a11y.registerBlock(asLitBlock(document.createElement('div')));
+    const firstCallCount = addSpy.mock.calls.length;
+    expect(firstCallCount).toBeGreaterThan(0);
+
+    a11y.registerBlock(asLitBlock(document.createElement('div')));
+    a11y.registerBlock(asLitBlock(document.createElement('div')));
+
+    expect(addSpy.mock.calls.length).toBe(firstCallCount);
+  });
+
+  it('destroy() disarms unconditionally, and registerBlock after destroy() does not re-arm', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const a11y = new A11y();
+
+    a11y.registerBlock(asLitBlock(document.createElement('div')));
+    a11y.destroy();
+    addSpy.mockClear();
+
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    const button = document.createElement('button');
+    scope.append(button);
+    a11y.registerBlock(asLitBlock(scope));
+
+    expect(addSpy).not.toHaveBeenCalled();
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
+
   it('destroy() returns the real window listener count to baseline across a full construct → registerBlock → destroy() cycle', () => {
     const addSpy = vi.spyOn(window, 'addEventListener');
     const removeSpy = vi.spyOn(window, 'removeEventListener');

--- a/src/abstract/managers/a11y.ts
+++ b/src/abstract/managers/a11y.ts
@@ -68,9 +68,23 @@ class ScopedMinimalWindow implements MinimalWindow {
 export class A11y implements ISharedInstance {
   private _destroyKeyUX: ReturnType<typeof startKeyUX> | undefined;
   private readonly _scopedWindow: ScopedMinimalWindow;
+  private _armed = false;
+  private _destroyed = false;
 
   public constructor() {
     this._scopedWindow = new ScopedMinimalWindow();
+  }
+
+  /**
+   * Attaches the keyux window listeners. Lazy: called on first
+   * `registerBlock` rather than at construction, so a constructed-but-unused
+   * instance never touches `window`.
+   */
+  private _arm(): void {
+    if (this._armed || this._destroyed) {
+      return;
+    }
+    this._armed = true;
     this._destroyKeyUX = startKeyUX(this._scopedWindow, [
       focusGroupKeyUX(),
       pressKeyUX('is-pressed'),
@@ -80,11 +94,18 @@ export class A11y implements ISharedInstance {
   }
 
   public registerBlock(scope: LitBlock): void {
+    if (this._destroyed) {
+      return;
+    }
     this._scopedWindow.registerScope(scope);
+    this._arm();
   }
 
   public destroy(): void {
+    this._destroyed = true;
+    this._armed = false;
     this._destroyKeyUX?.();
+    this._destroyKeyUX = undefined;
     this._scopedWindow.destroy();
   }
 }

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -1,8 +1,8 @@
 import { LitElement } from 'lit';
 import { blockCtx } from '../abstract/CTX';
-import { ClipboardController } from '../abstract/controllers/ClipboardController';
+import type { ClipboardController } from '../abstract/controllers/ClipboardController';
 import type { RouterController } from '../abstract/controllers/RouterController';
-import { A11y } from '../abstract/managers/a11y';
+import type { A11y } from '../abstract/managers/a11y';
 import { type LocaleManager, localeStateKey } from '../abstract/managers/LocaleManager';
 import { PluginController } from '../abstract/managers/plugin';
 import { buildPluginApi } from '../abstract/managers/plugin/buildPluginApi';
@@ -109,10 +109,11 @@ export class LitBlock extends LitBlockBase {
           debug: createDebugPrinter(() => sharedInstancesBag.ctx, 'PluginController'),
         }),
     );
-    // The remaining four ctx-scope managers are constructed and owned by
-    // `UploaderController` (M9k) — these `_addSharedContextInstance` calls just
-    // re-expose the controller's instances under their v1 shared-instance keys
-    // (so `_getSharedContextInstance`/`bag.when`/`ctx.sub` readers are
+    // The remaining ctx-scope managers are constructed and owned by
+    // `UploaderController` (M9k five + M9l's `a11y`/`clipboard`) — these
+    // `_addSharedContextInstance` calls just re-expose the controller's
+    // instances under their v1 shared-instance keys (so
+    // `_getSharedContextInstance`/`bag.when`/`ctx.sub` readers are
     // unaffected), while construction and teardown now live on the controller.
     // `PluginController` stays constructed here — it needs the PubSub ctx
     // (`*lazyPlugins`, the `*publicApi` instance), which the DOM-free
@@ -132,21 +133,14 @@ export class LitBlock extends LitBlockBase {
     // constructed `LocaleManager` itself. Both `*eventEmitter`/`*localeManager`
     // and `*pluginManager` are registered by now.
     this.localeManager.activate(this._sharedInstancesBag.pluginManager);
-    this._addSharedContextInstance('*a11y', () => new A11y());
+    this._addSharedContextInstance('*a11y', (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().a11y);
     this._addSharedContextInstance(
       '*router',
       (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().router,
     );
     this._addSharedContextInstance(
       '*clipboard',
-      (sharedInstancesBag) =>
-        new ClipboardController({
-          getPasteScope: () => sharedInstancesBag.ctx.read(sharedConfigKey('pasteScope')),
-          getCurrentActivity: () => sharedInstancesBag.router.currentActivity,
-          addFileFromObject: (file, options) => sharedInstancesBag.api.addFileFromObject(file, options),
-          addFileFromUrl: (url, options) => sharedInstancesBag.api.addFileFromUrl(url, options),
-          onFileAdd: () => sharedInstancesBag.router.traverse('onFileAdd'),
-        }),
+      (sharedInstancesBag) => sharedInstancesBag.ctx.uploaderController().clipboard,
     );
     this._addSharedContextInstance(
       '*telemetryManager',

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -61,7 +61,15 @@ export class LitUploaderBlock extends LitActivityBlock {
     // Register *publicApi before *validationManager: the ValidationController
     // resolves `sharedInstancesBag.api` (which constructs *publicApi on demand),
     // so the api factory must already be registered when validation first runs.
-    this._addSharedContextInstance('*publicApi', (sharedInstancesBag) => new UploaderPublicApi(sharedInstancesBag));
+    // Also hand it straight to the controller (`setApi`) — the DOM-free
+    // `ClipboardController` (constructed by `UploaderController`, M9l) needs it
+    // for its add-file callbacks, but only the DOM layer can construct
+    // `UploaderPublicApi` (it needs the shared-instances bag).
+    this._addSharedContextInstance('*publicApi', (sharedInstancesBag) => {
+      const api = new UploaderPublicApi(sharedInstancesBag);
+      this.sharedCtx.uploaderController().setApi(api);
+      return api;
+    });
     this._addSharedContextInstance('*validationManager', (sharedInstancesBag) => {
       const uploader = this.sharedCtx.uploaderController();
       return new ValidationController({

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ClipboardController } from '../abstract/controllers/ClipboardController';
 import { RouterController } from '../abstract/controllers/RouterController';
+import { A11y } from '../abstract/managers/a11y';
 import { LocaleManager } from '../abstract/managers/LocaleManager';
 import { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
@@ -305,14 +307,17 @@ describe('PubSub (additional coverage)', () => {
   });
 });
 
-describe('PubSub (M9k Task 3: pre-connect construction timing)', () => {
-  it('touching a *cfg/* key before any element connects builds all four controller-owned managers, with no global side effects', () => {
+describe('PubSub (M9k/M9l Task 3: pre-connect construction timing)', () => {
+  it('touching a *cfg/* key before any element connects builds all six controller-owned managers, with no global side effects', () => {
     const addEventListenerSpy = vi.spyOn(window, 'addEventListener');
 
     // Bare ctx + a config read — no `<uc-config>`/`LitBlock` ever touches this
-    // ctx, matching the M9k Task 2 shift: the controller (and its four
+    // ctx, matching the M9k Task 2 shift: the controller (and its owned
     // managers) now come into being the moment *any* `*cfg/*`/`*l10n/*` key is
-    // touched, not when a DOM element's `initCallback` runs.
+    // touched, not when a DOM element's `initCallback` runs. M9l Task 2's
+    // lazy-arm split (a11y/clipboard attach zero window listeners at
+    // construction, only on first registration) is what makes constructing
+    // them this early safe.
     try {
       const ctx = freshCtx();
       expect(() => ctx.read('*cfg/multiple')).not.toThrow();
@@ -323,11 +328,14 @@ describe('PubSub (M9k Task 3: pre-connect construction timing)', () => {
       expect(controller!.eventEmitter).toBeInstanceOf(EventEmitter);
       expect(controller!.telemetryManager).toBeInstanceOf(TelemetryManager);
       expect(controller!.router).toBeInstanceOf(RouterController);
+      expect(controller!.a11y).toBeInstanceOf(A11y);
+      expect(controller!.clipboard).toBeInstanceOf(ClipboardController);
 
-      // Nothing on this path reaches into the DOM/global scope — a11y and
-      // clipboard (element-triggered only, added by `LitBlock.initCallback`)
-      // are the guard: this ctx never had a block connect, so they must not
-      // exist at all.
+      // Nothing on this path reaches into the DOM/global scope. The ctx
+      // itself never sees `*a11y`/`*clipboard` — those v1 shared-instance
+      // keys are only registered by `LitBlock.initCallback` (element-
+      // triggered), and this ctx never had a block connect — even though the
+      // controller now constructs both instances eagerly alongside the rest.
       expect(ctx.has('*a11y')).toBe(false);
       expect(ctx.has('*clipboard')).toBe(false);
 

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -110,6 +110,11 @@ const instanceKeyMap = {
  * `*uploadEvents`) read from the collection during their own `.destroy()`,
  * so deferring its real destroy to the controller (same as the other four)
  * is order-safe.
+ *
+ * `*a11y` and `*clipboard` join the set in M9l (Task 3): the same recipe —
+ * `LitBlock` still pub-nulls both keys in `_destroySharedContextInstances`,
+ * but `UploaderController.destroy()` now owns the actual `.destroy()` call
+ * for both (see its destroy-order doc), since it constructs them too.
  */
 export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new Set([
   instanceKeyMap.eventEmitter,
@@ -117,6 +122,8 @@ export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new S
   instanceKeyMap.telemetryManager,
   instanceKeyMap.router,
   instanceKeyMap.uploadCollection,
+  instanceKeyMap.a11y,
+  instanceKeyMap.clipboard,
 ]);
 
 type InstanceTypeMap = {


### PR DESCRIPTION
## What

Part 2 of the instance-creation migration for `A11y`/`ClipboardController`:

1. **Investigation + gap pins**: proved zero-scope `A11y`/`ClipboardController` instances are behaviorally inert — every keyux DOM effect lives behind the scope gate, and clipboard's pre-gate work is read-only. Added full-cycle listener-pairing pins (register → destroy), timing-agnostic by design, ahead of the split.
2. **Lazy-arm split**: both managers now attach **zero** window listeners at construction. They arm on the first `registerBlock`/`registerScope` call, and disarm on the last unregister or `destroy()` (idempotent, re-armable for clipboard's scope cycles). Post-destroy state is inert. Clipboard's window default is resolved only at arm time, so construction is window-less-safe.
3. **Ownership (M9k recipe)**: both are now constructed in `UploaderController`'s constructor; `controllerOwnedInstanceKeys` grows to seven entries; LitBlock re-exposers and reverse-order destroy follow the existing pattern. The pre-connect pin was extended to cover a bare cfg touch building both with still-zero listeners. Added a `UploaderController.api`/`setApi()` seam for clipboard's paste-time `publicApi` access.

Element call sites (`LitSolutionBlock` `registerBlock`/`registerScope`) are **untouched** — they are the adapter the arm/disarm hooks into.

## Why it's safe

The inertness investigation (adversarially verified against the keyux plugin sources) shows a zero-scope `A11y`/`ClipboardController` instance produces no observable DOM effects, so arming on registration instead of construction is behavior-identical. Headless compositions (no scope ever registered) never arm under the new code — but v1 was equally inert there, since nothing beyond construction ever ran. `pasteScope`'s documented contract promises nothing without an active solution/scope, so nothing documented changes.

## Design: the `setApi` seam

Clipboard's add-file callbacks need the uploader-scope `UploaderPublicApi`, which `UploaderController` doesn't own outright. `setApi` is called eagerly from `LitUploaderBlock.initCallback`'s `*publicApi` resolver, ahead of any possible arm (guaranteed by Lit's super-chain `connectedCallback`/`initCallback` ordering). Combined with per-ctx controller lifetime (one controller per `ctx-name`, never reused across contexts), staleness is structurally impossible — this was opus-adjudicated as sound during review.

## What remains element-constructed

- **`PluginController`** — still coupled to ctx-state (`*lazyPlugins`/`*publicApi`), not yet ready to migrate.
- **`blocksRegistry`** — element-owned, out of scope here.
- **uploader-scope instance set** — deferred to M9m behind an uploader-present gate.

### Plan (not this PR)
- **M9m**: uploader-scope set behind an uploader-present gate (secureUploads → uploadController → publicApi → validation → uploadEvents); re-home `$['*collectionErrors']`/`ctx.pub('*uploadList')` closures; preserve `observe()` timing.
- **M9n**: ctx-creator ports (solutions/Config/UploadCtxProvider) + retire `_addSharedContextInstance`; `PluginController` ownership once `*lazyPlugins`/`*publicApi` migrate.

## Review process

Adversarial verification of the inertness investigation, opus review of the ownership/`setApi` seam, final whole-branch verdict **MERGE-READY**. Follow-ups queued in `.superpowers/sdd/progress.md` for M9m: identity pins for the newly owned keys, nulling `_api` on destroy, tightening the re-arm spy assertions.

## Gate (real counts)

- `npm run tsc:app` — clean, no errors
- `npm run build` — passed (all size-limit budgets green)
- `npm run tsc` (app + test + e2e + node) — "TypeScript: No errors found"
- `npm run test:specs` — **55 test files / 637 tests passed**
- `npm run test:locales` — all locale groups checked, clean
- `npm run test:e2e` — **49 test files / 316 tests passed** (no crop-frame flake retry needed this run)
- `npm run lint` — biome/stylelint/lit-analyzer clean; ESLint 0 errors, 17 pre-existing warnings (unrelated files, unchanged by this branch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced the uploader controller with built-in accessibility and clipboard support.
  * Added an uploader public API that must be set before clipboard-related actions can run.
  * Clipboard paste now participates in the uploader file flow (including traversal).

* **Bug Fixes**
  * Improved lifecycle handling for browser `paste` and keyboard interactions: listeners are only activated when needed and are properly cleaned up.
  * Prevented accessibility and clipboard handlers from reactivating after destruction.

* **Tests**
  * Expanded test coverage for scope registration/unregistration, teardown behavior, and API wiring.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->