### PR TITLE
feat(m9m): uploader-scope set onto UploaderController behind an uploader-present gate (instance-creation migration, part 3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     },
     {
       "path": "web/uc-cloud-image-editor.min.js",
-      "limit": "58 KB"
+      "limit": "50 KB"
     },
     {
       "path": "web/uc-file-uploader-regular.min.js",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     },
     {
       "path": "web/uc-cloud-image-editor.min.js",
-      "limit": "50 KB"
+      "limit": "58 KB"
     },
     {
       "path": "web/uc-file-uploader-regular.min.js",

--- a/src/abstract/controllers/ClipboardController.test.ts
+++ b/src/abstract/controllers/ClipboardController.test.ts
@@ -395,6 +395,7 @@ describe('ClipboardController', () => {
   });
 
   it('re-arms after a full disarm + re-registration cycle (scopes can cycle 0 → 1 → 0 → 1)', async () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
     const { layer, api } = setup({ pasteScope: 'global', currentActivity: 'start-from' });
     track(layer);
 
@@ -406,6 +407,10 @@ describe('ClipboardController', () => {
     await flush();
 
     expect(api.addFileFromObject).toHaveBeenCalled();
+    // Precision over the functional re-arm assertion above: the double cycle
+    // (arm → disarm → re-arm) must add the `paste` listener exactly twice —
+    // once per arm — not merely "at least once".
+    expect(addSpy.mock.calls.filter((call) => call[0] === 'paste')).toHaveLength(2);
   });
 
   it('destroy() disarms unconditionally, and registrations after destroy() do not re-arm', async () => {

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -16,6 +16,7 @@ import { UploaderController, type UploaderScopeDeps } from './UploaderController
 import { ValidationController } from './ValidationController';
 
 const makeUploaderScopeDeps = (overrides: Partial<UploaderScopeDeps> = {}): UploaderScopeDeps => ({
+  controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
   getFileHooks: () => [],
   getOutputItem: (() => ({}) as never) as never,
   getApi: () => ({}) as never,

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -8,8 +8,33 @@ import { ClipboardController } from './ClipboardController';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
 import { RouterController } from './RouterController';
+import { SecureUploadsController } from './SecureUploadsController';
 import { UploadCollectionController } from './UploadCollectionController';
-import { UploaderController } from './UploaderController';
+import { UploadController } from './UploadController';
+import { UploadEventsController } from './UploadEventsController';
+import { UploaderController, type UploaderScopeDeps } from './UploaderController';
+import { ValidationController } from './ValidationController';
+
+const makeUploaderScopeDeps = (overrides: Partial<UploaderScopeDeps> = {}): UploaderScopeDeps => ({
+  getFileHooks: () => [],
+  getOutputItem: (() => ({}) as never) as never,
+  getApi: () => ({}) as never,
+  setCollectionErrors: () => {},
+  emitCommonUploadFailed: () => {},
+  emit: () => {},
+  getOutputCollectionState: () => ({}) as never,
+  getOutputData: () => [],
+  runOnAddHooks: () => {},
+  uploadTrigger: () => new Set(),
+  setUploadList: () => {},
+  getCollectionState: () => null,
+  setCollectionState: () => {},
+  getCommonProgress: () => 0,
+  setCommonProgress: () => {},
+  setGroupInfo: () => {},
+  getCollectionErrors: () => [],
+  ...overrides,
+});
 
 describe('UploaderController', () => {
   it('constructs with event, config, and locale controllers', () => {
@@ -281,5 +306,133 @@ describe('UploaderController', () => {
     } finally {
       globalThis.document = realDocument;
     }
+  });
+
+  describe('attachUploaderScope (the upload stack, behind the uploader-present gate)', () => {
+    it('throws accessing any of the four getters before attach — matching the `api` getter convention', () => {
+      const controller = new UploaderController();
+      expect(() => controller.secureUploadsManager).toThrow(/attachUploaderScope/);
+      expect(() => controller.uploadController).toThrow(/attachUploaderScope/);
+      expect(() => controller.validationManager).toThrow(/attachUploaderScope/);
+      expect(() => controller.uploadEvents).toThrow(/attachUploaderScope/);
+    });
+
+    it('constructs the four sub-controllers, wired to the same config/collection', () => {
+      const controller = new UploaderController();
+
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+
+      expect(controller.secureUploadsManager).toBeInstanceOf(SecureUploadsController);
+      expect(controller.uploadController).toBeInstanceOf(UploadController);
+      expect(controller.validationManager).toBeInstanceOf(ValidationController);
+      expect(controller.uploadEvents).toBeInstanceOf(UploadEventsController);
+
+      controller.destroy();
+    });
+
+    it('starts the upload-events collection observation (v1 parity: observe() at the end of construction)', () => {
+      const controller = new UploaderController();
+      const observeSpy = vi.spyOn(UploadEventsController.prototype, 'observe');
+
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+
+      expect(observeSpy).toHaveBeenCalledTimes(1);
+
+      controller.destroy();
+      observeSpy.mockRestore();
+    });
+
+    it('is idempotent — a second call does not reconstruct any of the four', () => {
+      const controller = new UploaderController();
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+      const secureUploadsManager = controller.secureUploadsManager;
+      const uploadController = controller.uploadController;
+      const validationManager = controller.validationManager;
+      const uploadEvents = controller.uploadEvents;
+
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+
+      expect(controller.secureUploadsManager).toBe(secureUploadsManager);
+      expect(controller.uploadController).toBe(uploadController);
+      expect(controller.validationManager).toBe(validationManager);
+      expect(controller.uploadEvents).toBe(uploadEvents);
+
+      controller.destroy();
+    });
+
+    it('is inert after destroy() — a late attach never constructs the stack', () => {
+      const controller = new UploaderController();
+      controller.destroy();
+
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+
+      expect(() => controller.secureUploadsManager).toThrow(/attachUploaderScope/);
+      expect(() => controller.uploadController).toThrow(/attachUploaderScope/);
+      expect(() => controller.validationManager).toThrow(/attachUploaderScope/);
+      expect(() => controller.uploadEvents).toThrow(/attachUploaderScope/);
+    });
+
+    it("routes onResolverError to the controller's own telemetryManager", async () => {
+      const controller = new UploaderController();
+      const sendEventError = vi.spyOn(controller.telemetryManager, 'sendEventError');
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+      controller.config.set('secureUploadsSignatureResolver', (() => {
+        throw new Error('boom');
+      }) as never);
+
+      await controller.secureUploadsManager.getSecureToken();
+
+      expect(sendEventError).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.stringContaining('secureUploadsSignatureResolver'),
+      );
+
+      controller.destroy();
+    });
+
+    it('destroy() tears down the four in reverse construction order, before the collection', () => {
+      const controller = new UploaderController();
+      controller.attachUploaderScope(makeUploaderScopeDeps());
+
+      const uploadEventsDestroy = vi.spyOn(controller.uploadEvents, 'destroy');
+      const validationDestroy = vi.spyOn(controller.validationManager, 'destroy');
+      const uploadControllerDestroy = vi.spyOn(controller.uploadController, 'destroy');
+      const secureUploadsDestroy = vi.spyOn(controller.secureUploadsManager, 'destroy');
+      const collectionDestroy = vi.spyOn(controller.collection, 'destroy');
+
+      controller.destroy();
+
+      expect(uploadEventsDestroy).toHaveBeenCalled();
+      expect(validationDestroy).toHaveBeenCalled();
+      expect(uploadControllerDestroy).toHaveBeenCalled();
+      expect(secureUploadsDestroy).toHaveBeenCalled();
+      expect(collectionDestroy).toHaveBeenCalled();
+
+      const uploadEventsOrder = uploadEventsDestroy.mock.invocationCallOrder[0]!;
+      const validationOrder = validationDestroy.mock.invocationCallOrder[0]!;
+      const uploadControllerOrder = uploadControllerDestroy.mock.invocationCallOrder[0]!;
+      const secureUploadsOrder = secureUploadsDestroy.mock.invocationCallOrder[0]!;
+      const collectionOrder = collectionDestroy.mock.invocationCallOrder[0]!;
+
+      expect(uploadEventsOrder).toBeLessThan(validationOrder);
+      expect(validationOrder).toBeLessThan(uploadControllerOrder);
+      expect(uploadControllerOrder).toBeLessThan(secureUploadsOrder);
+      // uploadEvents.unobserve() must detach from a still-live collection.
+      expect(secureUploadsOrder).toBeLessThan(collectionOrder);
+    });
+
+    it('destroy() tolerates never having attached the uploader scope', () => {
+      const controller = new UploaderController();
+      expect(() => controller.destroy()).not.toThrow();
+    });
+
+    it('destroy() nulls the held api — accessing it afterwards throws (M9l follow-up)', () => {
+      const controller = new UploaderController();
+      controller.setApi({ addFileFromObject: vi.fn(), addFileFromUrl: vi.fn() } as never);
+
+      controller.destroy();
+
+      expect(() => controller.api).toThrow(/setApi/);
+    });
   });
 });

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -1,4 +1,5 @@
 import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import { applyInitialCrop } from '../applyInitialCrop';
 import { EventBus, type UploaderEventKey, type UploaderEventPayload, UploaderEventType } from '../EventBus';
 import { A11y } from '../managers/a11y';
 import { LocaleManager } from '../managers/LocaleManager';
@@ -8,7 +9,11 @@ import { ClipboardController } from './ClipboardController';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
 import { RouterController } from './RouterController';
+import { SecureUploadsController, type SecureUploadsControllerDeps } from './SecureUploadsController';
 import { UploadCollectionController } from './UploadCollectionController';
+import { UploadController, type UploadControllerDeps } from './UploadController';
+import { UploadEventsController, type UploadEventsControllerDeps } from './UploadEventsController';
+import { ValidationController, type ValidationControllerDeps } from './ValidationController';
 
 /**
  * Root controller — one instance per uploader scope (keyed by `ctx-name` in
@@ -68,6 +73,63 @@ export type UploaderControllerDeps = {
   clipboard?: ClipboardController;
 };
 
+/**
+ * Every element-side (DOM/`PubSub`-touching) callback `attachUploaderScope`
+ * needs to build `SecureUploadsController`, `UploadController`,
+ * `ValidationController`, and `UploadEventsController` — the v1 shared-context
+ * resolvers' closures, moved verbatim. Everything that can resolve purely from
+ * the controller's own members (telemetry mirrors, `buildUploadOptions`,
+ * `applyInitialCrop`) is built internally by `attachUploaderScope` instead and
+ * does NOT appear here — see the field-by-field notes on each resolver below.
+ *
+ * Reuses each sub-controller's own `*Deps` field types (rather than
+ * redeclaring them) so a signature change downstream is a compile error here,
+ * not silent drift.
+ */
+export type UploaderScopeDeps = {
+  /** Debug logger — wired to the block's `debugPrint`. Shared by secureUploads + uploadController. */
+  debug?: SecureUploadsControllerDeps['debug'];
+  /** Snapshot of the registered plugin file hooks (bag.pluginManager). */
+  getFileHooks: UploadControllerDeps['getFileHooks'];
+  /** Resolves the public output entry (bag.api.getOutputItem) — shared by uploadController + uploadEvents. */
+  getOutputItem: UploadEventsControllerDeps['getOutputItem'];
+  /** The public API passed to validators (bag.api). */
+  getApi: ValidationControllerDeps['getApi'];
+  /** Sink for collection-level errors — v1 wrote `this.$['*collectionErrors']`. */
+  setCollectionErrors: ValidationControllerDeps['setCollectionErrors'];
+  /** Fires the debounced `common-upload-failed` event — reads bag.eventEmitter + bag.api, kept verbatim (api isn't controller-owned). */
+  emitCommonUploadFailed: ValidationControllerDeps['emitCommonUploadFailed'];
+  /**
+   * Telemetry-augmented emit — v1's `ctx.has('*eventEmitter')` teardown guard,
+   * kept verbatim: it observes the pub-null pass that runs BEFORE
+   * `UploaderController.destroy()`, and collapsing it onto `controller.emit`
+   * would shift that teardown-suppression window.
+   */
+  emit: UploadEventsControllerDeps['emit'];
+  getOutputCollectionState: UploadEventsControllerDeps['getOutputCollectionState'];
+  /** Needs the shared-instances bag (`getOutputData(bag)`) — DOM-layer only. */
+  getOutputData: UploadEventsControllerDeps['getOutputData'];
+  /** Runs plugin `onAdd` hooks — needs `bag.wait('pluginManager')`. */
+  runOnAddHooks: UploadEventsControllerDeps['runOnAddHooks'];
+
+  // ─── v1 shared-state bridge (`*`-keys via the `$` proxy) — element-side only ───
+  uploadTrigger: UploadEventsControllerDeps['uploadTrigger'];
+  setUploadList: UploadEventsControllerDeps['setUploadList'];
+  getCollectionState: UploadEventsControllerDeps['getCollectionState'];
+  setCollectionState: UploadEventsControllerDeps['setCollectionState'];
+  getCommonProgress: UploadEventsControllerDeps['getCommonProgress'];
+  setCommonProgress: UploadEventsControllerDeps['setCommonProgress'];
+  setGroupInfo: UploadEventsControllerDeps['setGroupInfo'];
+  getCollectionErrors: UploadEventsControllerDeps['getCollectionErrors'];
+};
+
+type UploaderScope = {
+  secureUploadsManager: SecureUploadsController;
+  uploadController: UploadController;
+  validationManager: ValidationController;
+  uploadEvents: UploadEventsController;
+};
+
 export class UploaderController {
   public readonly events: EventBus;
   public readonly config: ConfigController;
@@ -89,6 +151,10 @@ export class UploaderController {
   // callbacks read this, and only at paste time.
   private _api: UploaderPublicApi | null = null;
   private _destroyed = false;
+  // The upload stack — only constructed once an uploader is actually present
+  // in the scope (`attachUploaderScope`, called by `LitUploaderBlock`). A
+  // bare `<uc-config>` + provider ctx (no uploader tag) never gets one.
+  private _uploaderScope: UploaderScope | null = null;
 
   public constructor(deps: UploaderControllerDeps = {}) {
     this.events = deps.events ?? new EventBus();
@@ -188,12 +254,129 @@ export class UploaderController {
     this._api = api;
   }
 
+  /**
+   * Construct the upload stack — `SecureUploadsController`, `UploadController`,
+   * `ValidationController`, `UploadEventsController` — behind the
+   * uploader-present gate (only `LitUploaderBlock.initCallback` calls this; a
+   * scope with just `<uc-config>` + a provider never does). Idempotent: a
+   * second call is a no-op, matching `_addSharedContextInstance`'s
+   * first-write-wins semantics. Inert once `destroy()` has run.
+   *
+   * Construction order is load-bearing: `uploadController` needs
+   * `secureUploadsManager`; `uploadEvents` needs `validationManager` (and,
+   * internally, `uploadController.buildUploadOptions()`).
+   */
+  public attachUploaderScope(deps: UploaderScopeDeps): void {
+    if (this._uploaderScope || this._destroyed) {
+      return;
+    }
+
+    const secureUploadsManager = new SecureUploadsController({
+      config: this.config,
+      onResolverError: (error, context) => {
+        this.telemetryManager.sendEventError(error, context);
+      },
+      debug: deps.debug,
+    });
+
+    const uploadController = new UploadController({
+      collection: this.collection,
+      config: this.config,
+      secureUploads: secureUploadsManager,
+      getFileHooks: deps.getFileHooks,
+      getOutputItem: deps.getOutputItem,
+      onUploadError: (error, context) => {
+        // An upload's async error handler can fire after the scope (and its
+        // telemetry instance) is torn down — error *reporting* must never
+        // throw, or the original failure becomes an unhandled rejection.
+        try {
+          this.telemetryManager.sendEventError(error, context);
+        } catch (err) {
+          deps.debug?.('telemetry unavailable for an upload error report', err);
+        }
+      },
+      debug: deps.debug,
+    });
+
+    const validationManager = new ValidationController({
+      config: this.config,
+      collection: this.collection,
+      getApi: deps.getApi,
+      setCollectionErrors: deps.setCollectionErrors,
+      emitCommonUploadFailed: deps.emitCommonUploadFailed,
+      onValidatorError: (error, context) => {
+        this.telemetryManager.sendEventError(error, context);
+      },
+    });
+
+    const uploadEvents = new UploadEventsController({
+      collection: this.collection,
+      config: this.config,
+      validation: validationManager,
+      emit: deps.emit,
+      getOutputItem: deps.getOutputItem,
+      getOutputCollectionState: deps.getOutputCollectionState,
+      getOutputData: deps.getOutputData,
+      buildUploadOptions: () => uploadController.buildUploadOptions(),
+      runOnAddHooks: deps.runOnAddHooks,
+      applyInitialCrop: () => applyInitialCrop(this.collection, this.config.get('cropPreset')),
+      uploadTrigger: deps.uploadTrigger,
+      setUploadList: deps.setUploadList,
+      getCollectionState: deps.getCollectionState,
+      setCollectionState: deps.setCollectionState,
+      getCommonProgress: deps.getCommonProgress,
+      setCommonProgress: deps.setCommonProgress,
+      setGroupInfo: deps.setGroupInfo,
+      getCollectionErrors: deps.getCollectionErrors,
+    });
+
+    this._uploaderScope = { secureUploadsManager, uploadController, validationManager, uploadEvents };
+    uploadEvents.observe();
+  }
+
+  private _requireUploaderScope<TKey extends keyof UploaderScope>(key: TKey): UploaderScope[TKey] {
+    if (!this._uploaderScope) {
+      throw new Error(`Unexpected error: UploaderController.${key} accessed before attachUploaderScope()`);
+    }
+    return this._uploaderScope[key];
+  }
+
+  public get secureUploadsManager(): SecureUploadsController {
+    return this._requireUploaderScope('secureUploadsManager');
+  }
+
+  public get uploadController(): UploadController {
+    return this._requireUploaderScope('uploadController');
+  }
+
+  public get validationManager(): ValidationController {
+    return this._requireUploaderScope('validationManager');
+  }
+
+  public get uploadEvents(): UploadEventsController {
+    return this._requireUploaderScope('uploadEvents');
+  }
+
   public destroy(): void {
     this._destroyed = true;
 
     this.events.destroy();
     this.config.destroy();
     this.locale.destroy();
+
+    // The uploader-scope stack tears down BEFORE `this.collection.destroy()`,
+    // in reverse construction order: `UploadEventsController.unobserve()`
+    // detaches its `observeCollection`/`observeProperties` subscriptions,
+    // which must run while the collection they're registered against is
+    // still the live, intact instance — destroying the collection first would
+    // let its own teardown race those detaching observers.
+    if (this._uploaderScope) {
+      this._uploaderScope.uploadEvents.destroy();
+      this._uploaderScope.validationManager.destroy();
+      this._uploaderScope.uploadController.destroy();
+      this._uploaderScope.secureUploadsManager.destroy();
+    }
+
     this.collection.destroy();
 
     // Reverse construction order.
@@ -203,5 +386,10 @@ export class UploaderController {
     this.telemetryManager.destroy();
     this.eventEmitter.destroy();
     this.localeManager.destroy();
+
+    // M9l follow-up: restore v1's throw-on-teardown-straddle parity — reading
+    // `api` after destroy() must throw again, not keep returning a torn-down
+    // instance.
+    this._api = null;
   }
 }

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -9,11 +9,18 @@ import { ClipboardController } from './ClipboardController';
 import { ConfigController } from './ConfigController';
 import { LocaleController } from './LocaleController';
 import { RouterController } from './RouterController';
-import { SecureUploadsController, type SecureUploadsControllerDeps } from './SecureUploadsController';
+// The four uploader-scope classes are TYPE-ONLY imports (they erase at
+// runtime): `UploaderController` is constructed for every ctx — including
+// editor-only scopes that never upload — and a static value import here would
+// drag the whole upload stack (`@uploadcare/upload-client` and friends) into
+// bundles that can't tree-shake a reachable method body. The element layer
+// (`LitUploaderBlock`), which only exists in upload-capable bundles, injects
+// the constructors through `UploaderScopeDeps.controllers`.
+import type { SecureUploadsController, SecureUploadsControllerDeps } from './SecureUploadsController';
 import { UploadCollectionController } from './UploadCollectionController';
-import { UploadController, type UploadControllerDeps } from './UploadController';
-import { UploadEventsController, type UploadEventsControllerDeps } from './UploadEventsController';
-import { ValidationController, type ValidationControllerDeps } from './ValidationController';
+import type { UploadController, UploadControllerDeps } from './UploadController';
+import type { UploadEventsController, UploadEventsControllerDeps } from './UploadEventsController';
+import type { ValidationController, ValidationControllerDeps } from './ValidationController';
 
 /**
  * Root controller — one instance per uploader scope (keyed by `ctx-name` in
@@ -87,6 +94,18 @@ export type UploaderControllerDeps = {
  * not silent drift.
  */
 export type UploaderScopeDeps = {
+  /**
+   * The four sub-controller constructors, injected by the element layer (see
+   * the import note above) so editor-only bundles never carry the upload
+   * stack. Typed via `typeof X` type queries on the type-only imports, so the
+   * instance types still flow into the getters below.
+   */
+  controllers: {
+    SecureUploadsController: typeof SecureUploadsController;
+    UploadController: typeof UploadController;
+    ValidationController: typeof ValidationController;
+    UploadEventsController: typeof UploadEventsController;
+  };
   /** Debug logger — wired to the block's `debugPrint`. Shared by secureUploads + uploadController. */
   debug?: SecureUploadsControllerDeps['debug'];
   /** Snapshot of the registered plugin file hooks (bag.pluginManager). */
@@ -271,7 +290,7 @@ export class UploaderController {
       return;
     }
 
-    const secureUploadsManager = new SecureUploadsController({
+    const secureUploadsManager = new deps.controllers.SecureUploadsController({
       config: this.config,
       onResolverError: (error, context) => {
         this.telemetryManager.sendEventError(error, context);
@@ -279,7 +298,7 @@ export class UploaderController {
       debug: deps.debug,
     });
 
-    const uploadController = new UploadController({
+    const uploadController = new deps.controllers.UploadController({
       collection: this.collection,
       config: this.config,
       secureUploads: secureUploadsManager,
@@ -298,7 +317,7 @@ export class UploaderController {
       debug: deps.debug,
     });
 
-    const validationManager = new ValidationController({
+    const validationManager = new deps.controllers.ValidationController({
       config: this.config,
       collection: this.collection,
       getApi: deps.getApi,
@@ -309,7 +328,7 @@ export class UploaderController {
       },
     });
 
-    const uploadEvents = new UploadEventsController({
+    const uploadEvents = new deps.controllers.UploadEventsController({
       collection: this.collection,
       config: this.config,
       validation: validationManager,

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -293,7 +293,12 @@ export class UploaderController {
     const secureUploadsManager = new deps.controllers.SecureUploadsController({
       config: this.config,
       onResolverError: (error, context) => {
-        this.telemetryManager.sendEventError(error, context);
+        // Same teardown race as `onUploadError` below: reporting never throws.
+        try {
+          this.telemetryManager.sendEventError(error, context);
+        } catch (err) {
+          deps.debug?.('telemetry unavailable for a resolver error report', err);
+        }
       },
       debug: deps.debug,
     });
@@ -324,7 +329,12 @@ export class UploaderController {
       setCollectionErrors: deps.setCollectionErrors,
       emitCommonUploadFailed: deps.emitCommonUploadFailed,
       onValidatorError: (error, context) => {
-        this.telemetryManager.sendEventError(error, context);
+        // Same teardown race as `onUploadError` above: reporting never throws.
+        try {
+          this.telemetryManager.sendEventError(error, context);
+        } catch (err) {
+          deps.debug?.('telemetry unavailable for a validator error report', err);
+        }
       },
     });
 

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -34,9 +34,11 @@ export class LitUploaderBlock extends LitActivityBlock {
     // Register *publicApi before attaching the uploader scope:
     // `_addSharedContextInstance` runs its resolver eagerly, right here, not
     // lazily on first read — so *publicApi must already exist by the time
-    // `sharedInstancesBag.api` is resolved during `attachUploaderScope`
-    // (`ValidationController`'s ctor runs `_runAllValidators` synchronously,
-    // which reads `sharedInstancesBag.api` via `getApi`).
+    // `sharedInstancesBag.api` is first resolved. `ValidationController`'s
+    // ctor SCHEDULES `_runAllValidators` (debounce(0), a macrotask), so the
+    // `getApi` read lands after this initCallback's sync frame — registering
+    // *publicApi anywhere in this frame suffices, but keeping it first also
+    // serves `setApi` below, which clipboard needs before any paste can arm.
     // Also hand it straight to the controller (`setApi`) — the DOM-free
     // `ClipboardController` (constructed by `UploaderController`, M9l) needs it
     // for its add-file callbacks, but only the DOM layer can construct

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -58,9 +58,11 @@ export class LitUploaderBlock extends LitActivityBlock {
         debug: (...args) => this.debugPrint(...args),
       });
     });
-    // Register *publicApi before *validationManager: the ValidationController
-    // resolves `sharedInstancesBag.api` (which constructs *publicApi on demand),
-    // so the api factory must already be registered when validation first runs.
+    // Register *publicApi before *validationManager: `_addSharedContextInstance`
+    // runs its resolver eagerly, right here, not lazily on first read — so
+    // *publicApi must already exist by the time `sharedInstancesBag.api` is
+    // resolved below (the ValidationController ctor runs `_runAllValidators`
+    // synchronously, which reads `sharedInstancesBag.api` via `getApi`).
     // Also hand it straight to the controller (`setApi`) — the DOM-free
     // `ClipboardController` (constructed by `UploaderController`, M9l) needs it
     // for its add-file callbacks, but only the DOM layer can construct

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,11 +1,15 @@
 // @ts-check
 
 import { uploaderBlockCtx } from '../abstract/CTX';
-import type { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
+// Value imports on purpose: this element hands the four upload-stack
+// constructors to `UploaderController.attachUploaderScope` — the controller
+// itself only type-imports them, keeping editor-only bundles (which have no
+// `LitUploaderBlock`) free of `@uploadcare/upload-client` and friends.
+import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
-import type { UploadController } from '../abstract/controllers/UploadController';
-import type { UploadEventsController } from '../abstract/controllers/UploadEventsController';
-import type { ValidationController } from '../abstract/controllers/ValidationController';
+import { UploadController } from '../abstract/controllers/UploadController';
+import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
+import { ValidationController } from '../abstract/controllers/ValidationController';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
@@ -52,6 +56,7 @@ export class LitUploaderBlock extends LitActivityBlock {
     const uploader = this.sharedCtx.uploaderController();
     const ctx = this._sharedInstancesBag.ctx;
     uploader.attachUploaderScope({
+      controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
       debug: (...args) => this.debugPrint(...args),
       getFileHooks: () => this._sharedInstancesBag.pluginManager?.snapshot().fileHooks ?? [],
       getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,12 +1,11 @@
 // @ts-check
 
-import { applyInitialCrop } from '../abstract/applyInitialCrop';
 import { uploaderBlockCtx } from '../abstract/CTX';
-import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
+import type { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
-import { UploadController } from '../abstract/controllers/UploadController';
-import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
-import { ValidationController } from '../abstract/controllers/ValidationController';
+import type { UploadController } from '../abstract/controllers/UploadController';
+import type { UploadEventsController } from '../abstract/controllers/UploadEventsController';
+import type { ValidationController } from '../abstract/controllers/ValidationController';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
 import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
@@ -28,41 +27,12 @@ export class LitUploaderBlock extends LitActivityBlock {
     // shared instance resolves to it so all blocks share one source of truth.
     this._addSharedContextInstance('*uploadCollection', () => this.sharedCtx.uploaderController().collection);
 
-    this._addSharedContextInstance('*secureUploadsManager', (sharedInstancesBag) => {
-      return new SecureUploadsController({
-        config: this.sharedCtx.uploaderController().config,
-        onResolverError: (error, context) => {
-          sharedInstancesBag.telemetryManager.sendEventError(error, context);
-        },
-        debug: (...args) => this.debugPrint(...args),
-      });
-    });
-    this._addSharedContextInstance('*uploadController', (sharedInstancesBag) => {
-      const uploader = this.sharedCtx.uploaderController();
-      return new UploadController({
-        collection: uploader.collection,
-        config: uploader.config,
-        secureUploads: this.secureUploadsManager,
-        getFileHooks: () => sharedInstancesBag.pluginManager?.snapshot().fileHooks ?? [],
-        getOutputItem: (uid) => sharedInstancesBag.api.getOutputItem(uid),
-        onUploadError: (error, context) => {
-          // An upload's async error handler can fire after the ctx (and its
-          // telemetry instance) is torn down — error *reporting* must never
-          // throw, or the original failure becomes an unhandled rejection.
-          try {
-            sharedInstancesBag.telemetryManager.sendEventError(error, context);
-          } catch (err) {
-            this.debugPrint('telemetry unavailable for an upload error report', err);
-          }
-        },
-        debug: (...args) => this.debugPrint(...args),
-      });
-    });
-    // Register *publicApi before *validationManager: `_addSharedContextInstance`
-    // runs its resolver eagerly, right here, not lazily on first read — so
-    // *publicApi must already exist by the time `sharedInstancesBag.api` is
-    // resolved below (the ValidationController ctor runs `_runAllValidators`
-    // synchronously, which reads `sharedInstancesBag.api` via `getApi`).
+    // Register *publicApi before attaching the uploader scope:
+    // `_addSharedContextInstance` runs its resolver eagerly, right here, not
+    // lazily on first read — so *publicApi must already exist by the time
+    // `sharedInstancesBag.api` is resolved during `attachUploaderScope`
+    // (`ValidationController`'s ctor runs `_runAllValidators` synchronously,
+    // which reads `sharedInstancesBag.api` via `getApi`).
     // Also hand it straight to the controller (`setApi`) — the DOM-free
     // `ClipboardController` (constructed by `UploaderController`, M9l) needs it
     // for its add-file callbacks, but only the DOM layer can construct
@@ -72,74 +42,71 @@ export class LitUploaderBlock extends LitActivityBlock {
       this.sharedCtx.uploaderController().setApi(api);
       return api;
     });
-    this._addSharedContextInstance('*validationManager', (sharedInstancesBag) => {
-      const uploader = this.sharedCtx.uploaderController();
-      return new ValidationController({
-        config: uploader.config,
-        collection: uploader.collection,
-        getApi: () => sharedInstancesBag.api,
-        setCollectionErrors: (errors) => {
-          this.$['*collectionErrors'] = errors;
-        },
-        emitCommonUploadFailed: () => {
-          sharedInstancesBag.eventEmitter.emit(
-            EventType.COMMON_UPLOAD_FAILED,
-            () => sharedInstancesBag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-            { debounce: true },
-          );
-        },
-        onValidatorError: (error, context) => {
-          sharedInstancesBag.telemetryManager.sendEventError(error, context);
-        },
-      });
+
+    // `SecureUploadsController`, `UploadController`, `ValidationController`,
+    // and `UploadEventsController` are constructed by `UploaderController`
+    // itself (`attachUploaderScope`, M9m) — behind the uploader-present gate,
+    // idempotent (first uploader block to connect wins, matching the old
+    // `_addSharedContextInstance` first-write-wins semantics). This element
+    // only supplies the callbacks that must stay DOM/PubSub-side.
+    const uploader = this.sharedCtx.uploaderController();
+    const ctx = this._sharedInstancesBag.ctx;
+    uploader.attachUploaderScope({
+      debug: (...args) => this.debugPrint(...args),
+      getFileHooks: () => this._sharedInstancesBag.pluginManager?.snapshot().fileHooks ?? [],
+      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>
+        this._sharedInstancesBag.api.getOutputItem<TStatus>(uid),
+      getApi: () => this._sharedInstancesBag.api,
+      setCollectionErrors: (errors) => {
+        this.$['*collectionErrors'] = errors;
+      },
+      emitCommonUploadFailed: () => {
+        this._sharedInstancesBag.eventEmitter.emit(
+          EventType.COMMON_UPLOAD_FAILED,
+          () => this._sharedInstancesBag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
+          { debounce: true },
+        );
+      },
+      // Emit parity with LitBlock.emit: EventEmitter dispatch + telemetry
+      // mirror, guarded for teardown (emissions can race ctx destruction).
+      emit: (type, payload, options) => {
+        const eventEmitter = ctx.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
+        if (!eventEmitter) return;
+        eventEmitter.emit(type, payload, options);
+        const resolvedPayload = typeof payload === 'function' ? payload() : payload;
+        try {
+          this._sharedInstancesBag.telemetryManager.sendEvent({
+            eventType: type,
+            payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
+          });
+        } catch (err) {
+          this.debugPrint('telemetry unavailable for an upload event report', err);
+        }
+      },
+      getOutputCollectionState: () => this._sharedInstancesBag.api.getOutputCollectionState(),
+      getOutputData: () => getOutputData(this._sharedInstancesBag),
+      runOnAddHooks: (entry) =>
+        void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+      uploadTrigger: () => ctx.read('*uploadTrigger'),
+      setUploadList: (list) => ctx.pub('*uploadList', list),
+      getCollectionState: () => ctx.read('*collectionState'),
+      setCollectionState: (state) => ctx.pub('*collectionState', state),
+      getCommonProgress: () => ctx.read('*commonProgress'),
+      setCommonProgress: (progress) => ctx.pub('*commonProgress', progress),
+      setGroupInfo: (group) => ctx.pub('*groupInfo', group),
+      getCollectionErrors: () => ctx.read('*collectionErrors'),
     });
 
-    // The collection→events derivation lives in the DOM-free UploadEventsController,
-    // a per-ctx shared instance — first-write-wins, so exactly one is created no
-    // matter how many blocks register it or in what order they connect/disconnect.
-    this._addSharedContextInstance('*uploadEvents', (sharedInstancesBag) => {
-      const uploader = this.sharedCtx.uploaderController();
-      const ctx = sharedInstancesBag.ctx;
-      const uploadEvents = new UploadEventsController({
-        collection: uploader.collection,
-        config: uploader.config,
-        validation: sharedInstancesBag.validationManager,
-        // Emit parity with LitBlock.emit: EventEmitter dispatch + telemetry
-        // mirror, guarded for teardown (emissions can race ctx destruction).
-        emit: (type, payload, options) => {
-          const eventEmitter = ctx.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
-          if (!eventEmitter) return;
-          eventEmitter.emit(type, payload, options);
-          const resolvedPayload = typeof payload === 'function' ? payload() : payload;
-          try {
-            sharedInstancesBag.telemetryManager.sendEvent({
-              eventType: type,
-              payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
-            });
-          } catch (err) {
-            this.debugPrint('telemetry unavailable for an upload event report', err);
-          }
-        },
-        getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>
-          sharedInstancesBag.api.getOutputItem<TStatus>(uid),
-        getOutputCollectionState: () => sharedInstancesBag.api.getOutputCollectionState(),
-        getOutputData: () => getOutputData(sharedInstancesBag),
-        buildUploadOptions: () => sharedInstancesBag.uploadController.buildUploadOptions(),
-        runOnAddHooks: (entry) =>
-          void sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
-        applyInitialCrop: () => applyInitialCrop(uploader.collection, uploader.config.get('cropPreset')),
-        uploadTrigger: () => ctx.read('*uploadTrigger'),
-        setUploadList: (list) => ctx.pub('*uploadList', list),
-        getCollectionState: () => ctx.read('*collectionState'),
-        setCollectionState: (state) => ctx.pub('*collectionState', state),
-        getCommonProgress: () => ctx.read('*commonProgress'),
-        setCommonProgress: (progress) => ctx.pub('*commonProgress', progress),
-        setGroupInfo: (group) => ctx.pub('*groupInfo', group),
-        getCollectionErrors: () => ctx.read('*collectionErrors'),
-      });
-      uploadEvents.observe();
-      return uploadEvents;
-    });
+    // The four are now controller-owned identity — these re-exposers just
+    // let existing shared-instance readers (`this.secureUploadsManager`, …)
+    // keep working unchanged.
+    this._addSharedContextInstance(
+      '*secureUploadsManager',
+      () => this.sharedCtx.uploaderController().secureUploadsManager,
+    );
+    this._addSharedContextInstance('*uploadController', () => this.sharedCtx.uploaderController().uploadController);
+    this._addSharedContextInstance('*validationManager', () => this.sharedCtx.uploaderController().validationManager);
+    this._addSharedContextInstance('*uploadEvents', () => this.sharedCtx.uploaderController().uploadEvents);
   }
 
   public getAPI(): UploaderPublicApi {

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -115,6 +115,14 @@ const instanceKeyMap = {
  * `LitBlock` still pub-nulls both keys in `_destroySharedContextInstances`,
  * but `UploaderController.destroy()` now owns the actual `.destroy()` call
  * for both (see its destroy-order doc), since it constructs them too.
+ *
+ * `*secureUploadsManager`, `*uploadController`, `*validationManager`, and
+ * `*uploadEvents` join the set in M9m (Task 2): `UploaderController.
+ * attachUploaderScope()` now constructs and (in `destroy()`) tears down all
+ * four, gated on an uploader actually being present in the scope.
+ * `LitUploaderBlock`'s `_addSharedContextInstance` calls for these four keys
+ * are re-exposers only (`() => this.sharedCtx.uploaderController().X`) — the
+ * same recipe as the others above.
  */
 export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new Set([
   instanceKeyMap.eventEmitter,
@@ -124,6 +132,10 @@ export const controllerOwnedInstanceKeys: ReadonlySet<keyof SharedState> = new S
   instanceKeyMap.uploadCollection,
   instanceKeyMap.a11y,
   instanceKeyMap.clipboard,
+  instanceKeyMap.secureUploadsManager,
+  instanceKeyMap.uploadController,
+  instanceKeyMap.validationManager,
+  instanceKeyMap.uploadEvents,
 ]);
 
 type InstanceTypeMap = {

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -248,6 +248,10 @@ describe('instance lifecycle (controller-owned identity pins, M9l final-review f
       '*uploadCollection': () => controller.collection,
       '*a11y': () => controller.a11y,
       '*clipboard': () => controller.clipboard,
+      '*secureUploadsManager': () => controller.secureUploadsManager,
+      '*uploadController': () => controller.uploadController,
+      '*validationManager': () => controller.validationManager,
+      '*uploadEvents': () => controller.uploadEvents,
     } satisfies Record<string, () => unknown>;
 
     // Fence: `controllerOwnedInstanceKeys` must not outgrow this map.

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -4,6 +4,7 @@ import { TelemetryManager } from '@/abstract/managers/TelemetryManager';
 import type { Config, UploadCtxProvider } from '@/index.js';
 import { PubSub } from '@/lit/PubSubCompat';
 import type { SharedState } from '@/lit/SharedState';
+import { controllerOwnedInstanceKeys } from '@/lit/shared-instances';
 import { getCtxName } from '../utils/getCtxName';
 import { cleanup } from '../utils/test-renderer';
 import '../../types/jsx';
@@ -216,5 +217,46 @@ describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
     expect(telemetryManagerDestroy).toHaveBeenCalledTimes(1);
     expect(routerDestroy).toHaveBeenCalledTimes(1);
     expect(uploadCollectionDestroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('instance lifecycle (controller-owned identity pins, M9l final-review follow-up)', () => {
+  it('every controller-owned shared-instance key resolves to the exact instance UploaderController owns (no re-shadowing)', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+    const controller = ctx.uploaderController();
+
+    // Explicit key -> controller-member map: self-documenting, and the two
+    // assertions below make it exhaustive against `controllerOwnedInstanceKeys`
+    // itself (imported, not hand-copied) — a key added to the Set without a
+    // matching entry here fails loudly instead of silently passing every
+    // other test while an element-side `new X()` re-shadows the real,
+    // controller-owned instance (and leaks its listeners at teardown).
+    const ownerByKey: Record<string, () => unknown> = {
+      '*eventEmitter': () => controller.eventEmitter,
+      '*localeManager': () => controller.localeManager,
+      '*telemetryManager': () => controller.telemetryManager,
+      '*router': () => controller.router,
+      '*uploadCollection': () => controller.collection,
+      '*a11y': () => controller.a11y,
+      '*clipboard': () => controller.clipboard,
+    } satisfies Record<string, () => unknown>;
+
+    // Fence: `controllerOwnedInstanceKeys` must not outgrow this map.
+    expect(new Set(Object.keys(ownerByKey))).toEqual(new Set(controllerOwnedInstanceKeys));
+
+    for (const key of controllerOwnedInstanceKeys) {
+      const getOwnerInstance = ownerByKey[key];
+      expect(getOwnerInstance, `no identity-pin mapping registered for key "${String(key)}"`).toBeDefined();
+      expect(ctx.read(key)).toBe(getOwnerInstance!());
+    }
   });
 });

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
+import { UploadEventsController } from '@/abstract/controllers/UploadEventsController';
 import { TelemetryManager } from '@/abstract/managers/TelemetryManager';
 import type { Config, UploadCtxProvider } from '@/index.js';
 import { PubSub } from '@/lit/PubSubCompat';
@@ -43,6 +44,23 @@ describe('instance lifecycle (config-only ctx)', () => {
     // `*uploadCollection` is added by `LitUploaderBlock`, not `LitBlock` —
     // `<uc-config>` alone must not create it.
     expect(ctx.has('*uploadCollection')).toBe(false);
+
+    // The four upload-stack keys (M9m `attachUploaderScope`) are only
+    // registered by `LitUploaderBlock.initCallback` — a bare `<uc-config>`
+    // never runs that path, so none of them exist either.
+    expect(ctx.has('*secureUploadsManager')).toBe(false);
+    expect(ctx.has('*uploadController')).toBe(false);
+    expect(ctx.has('*validationManager')).toBe(false);
+    expect(ctx.has('*uploadEvents')).toBe(false);
+
+    // And `attachUploaderScope` itself was never called — the controller's
+    // upload-stack getters still throw the pre-attach error, same as a
+    // freshly-constructed `UploaderController`.
+    const controller = ctx.uploaderController();
+    expect(() => controller.secureUploadsManager).toThrow(/attachUploaderScope/);
+    expect(() => controller.uploadController).toThrow(/attachUploaderScope/);
+    expect(() => controller.validationManager).toThrow(/attachUploaderScope/);
+    expect(() => controller.uploadEvents).toThrow(/attachUploaderScope/);
 
     const errors: string[] = [];
     const onError = (event: ErrorEvent) => {
@@ -150,6 +168,7 @@ describe('instance lifecycle (destroy -> recreate cycle)', () => {
     const firstCtx = PubSub.getCtx<SharedState>(ctxName)!;
     const firstRouter = firstCtx.read('*router');
     const firstTelemetry = firstCtx.read('*telemetryManager');
+    const firstUploadController = firstCtx.read('*uploadController');
 
     // Prove the first router carries real navigation state before teardown.
     await page.getByText('Upload files', { exact: true }).click();
@@ -171,9 +190,13 @@ describe('instance lifecycle (destroy -> recreate cycle)', () => {
     const secondCtx = PubSub.getCtx<SharedState>(ctxName)!;
     const secondRouter = secondCtx.read('*router');
     const secondTelemetry = secondCtx.read('*telemetryManager');
+    const secondUploadController = secondCtx.read('*uploadController');
 
     expect(secondRouter).not.toBe(firstRouter);
     expect(secondTelemetry).not.toBe(firstTelemetry);
+    // The upload-stack (M9m `attachUploaderScope`) is rebuilt fresh too — not
+    // resurrected from the destroyed scope.
+    expect(secondUploadController).not.toBe(firstUploadController);
     // Fresh router state — no leaked navigation from the destroyed ctx.
     expect(secondRouter.currentActivity).toBeNull();
   });
@@ -192,7 +215,7 @@ describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
     const ctx = PubSub.getCtx<SharedState>(ctxName)!;
 
-    // The five controller-owned shared instances (M9k): teardown runs through
+    // The controller-owned shared instances (M9k + M9m): teardown runs through
     // two paths — `LitBlock._destroySharedContextInstances` (the DOM-layer
     // pub-null loop) and `UploaderController.destroy()` (via
     // `PubSub.deleteCtx`) — and only the latter may actually call `.destroy()`
@@ -202,12 +225,23 @@ describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
     const telemetryManager = ctx.read('*telemetryManager');
     const router = ctx.read('*router');
     const uploadCollection = ctx.read('*uploadCollection');
+    // The four upload-stack instances (M9m `attachUploaderScope`): same
+    // single-owner concern — `LitUploaderBlock`'s re-exposers just resolve to
+    // the controller's instances, they never construct or destroy them.
+    const secureUploadsManager = ctx.read('*secureUploadsManager');
+    const uploadController = ctx.read('*uploadController');
+    const validationManager = ctx.read('*validationManager');
+    const uploadEvents = ctx.read('*uploadEvents');
 
     const eventEmitterDestroy = vi.spyOn(eventEmitter, 'destroy');
     const localeManagerDestroy = vi.spyOn(localeManager, 'destroy');
     const telemetryManagerDestroy = vi.spyOn(telemetryManager, 'destroy');
     const routerDestroy = vi.spyOn(router, 'destroy');
     const uploadCollectionDestroy = vi.spyOn(uploadCollection, 'destroy');
+    const secureUploadsManagerDestroy = vi.spyOn(secureUploadsManager, 'destroy');
+    const uploadControllerDestroy = vi.spyOn(uploadController, 'destroy');
+    const validationManagerDestroy = vi.spyOn(validationManager, 'destroy');
+    const uploadEventsDestroy = vi.spyOn(uploadEvents, 'destroy');
 
     cleanup();
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
@@ -217,6 +251,50 @@ describe('instance lifecycle (single-owner teardown, M9k Task 3)', () => {
     expect(telemetryManagerDestroy).toHaveBeenCalledTimes(1);
     expect(routerDestroy).toHaveBeenCalledTimes(1);
     expect(uploadCollectionDestroy).toHaveBeenCalledTimes(1);
+    expect(secureUploadsManagerDestroy).toHaveBeenCalledTimes(1);
+    expect(uploadControllerDestroy).toHaveBeenCalledTimes(1);
+    expect(validationManagerDestroy).toHaveBeenCalledTimes(1);
+    expect(uploadEventsDestroy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('instance lifecycle (attachUploaderScope idempotency across two LitUploaderBlock instances, M9m Task 3)', () => {
+  it('a second LitUploaderBlock joining the same ctx does not double-construct the upload stack', async () => {
+    const ctxName = getCtxName();
+    const observeSpy = vi.spyOn(UploadEventsController.prototype, 'observe');
+
+    try {
+      // First LitUploaderBlock instance: its `initCallback` calls
+      // `attachUploaderScope`, constructing the four sub-controllers and
+      // starting `UploadEventsController.observe()` once.
+      page.render(
+        <>
+          <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+          <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        </>,
+      );
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+      const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+      await expect.poll(() => ctx.has('*uploadController')).toBe(true);
+
+      const firstUploadController = ctx.read('*uploadController');
+      const firstUploadEvents = ctx.read('*uploadEvents');
+      expect(observeSpy).toHaveBeenCalledTimes(1);
+
+      // Second LitUploaderBlock instance joins the SAME ctx-name —
+      // `uc-upload-ctx-provider` also extends `LitUploaderBlock`, so its
+      // `initCallback` runs `attachUploaderScope` again against the same
+      // `UploaderController`. The idempotency guard (`this._uploaderScope`)
+      // must make this a no-op: same instances, no second `observe()`.
+      page.render(<uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>);
+      await expect.poll(() => page.getByTestId('uc-upload-ctx-provider').query()).not.toBeNull();
+
+      expect(ctx.read('*uploadController')).toBe(firstUploadController);
+      expect(ctx.read('*uploadEvents')).toBe(firstUploadEvents);
+      expect(observeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      observeSpy.mockRestore();
+    }
   });
 });
 

--- a/tests/validation.e2e.test.tsx
+++ b/tests/validation.e2e.test.tsx
@@ -1,6 +1,8 @@
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import type { Config, FuncFileValidator, OutputErrorCollection, OutputErrorFile, UploadCtxProvider } from '@/index';
+import { PubSub } from '@/lit/PubSubCompat';
+import type { SharedState } from '@/lit/SharedState';
 import { delay } from '@/utils/delay.js';
 import '../types/jsx';
 import { IMAGE } from './fixtures/files';
@@ -105,6 +107,40 @@ describe('Common upload collection validation', () => {
       api.addFileFromObject(IMAGE.PIXEL);
       api.initFlow();
       await expect.element(page.getByText(`At least 2 files required`)).toBeVisible();
+    });
+
+    // Gap-fill (M9m, ahead of moving ValidationController onto
+    // `UploaderController.attachUploaderScope()`): `ValidationController`'s
+    // constructor runs `_runAllValidators()` unconditionally, against
+    // whatever the collection looks like at that instant — nothing above
+    // pins that this ctor-time pass alone (with zero files, no `addFile*`
+    // call ever made) already populates `*collectionErrors`. Every other
+    // `multipleMin`/`multipleMax` test above sets the config *then* adds
+    // file(s), which also exercises the config-subscription rerun path;
+    // this one isolates the immediate, construction-time effect.
+    it('populates *collectionErrors for an out-of-bounds multipleMin immediately at construction, before any file is added', async () => {
+      const ctxName = `test-${Math.random().toString(36).slice(2)}`;
+      page.render(
+        <>
+          <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+          <uc-config
+            qualityInsights={false}
+            ctx-name={ctxName}
+            testMode
+            pubkey="demopublickey"
+            multipleMin={2}
+          ></uc-config>
+          <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+        </>,
+      );
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+      const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+
+      await expect
+        .poll(() => (ctx.read('*collectionErrors') as OutputErrorCollection[] | undefined)?.length ?? 0)
+        .toBeGreaterThan(0);
+      const errors = ctx.read('*collectionErrors') as OutputErrorCollection[];
+      expect(errors).toContainEqual(expect.objectContaining({ type: 'TOO_FEW_FILES' }));
     });
   });
 });


### PR DESCRIPTION
## What

`UploaderController.attachUploaderScope(deps)` constructs the upload stack — SecureUploads → Upload → Validation → UploadEvents (+`observe()`) — behind an explicit uploader-present gate, called from `LitUploaderBlock.initCallback` (after `*publicApi`+`setApi`). `controllerOwnedInstanceKeys` grows to 11. Getters throw pre-attach. `destroy()` tears the four instances down in reverse order iff attached, before `collection.destroy()`, and nulls `_api` (v1 teardown-throw parity restored). Identity pins added for every `controllerOwnedInstanceKeys` key (`ctx.read(key) === controller.member`) — the Set-equality fence fails on unmapped additions, guarding against re-shadowing regressions caught in M9l's review.

## Design: the injected-callback boundary

A typed `UploaderScopeDeps` carries the element-side callbacks into the controller **verbatim** — the 8 ctx-state bridges (writing `*uploadList`/`*collectionState`/`*commonProgress`/`*groupInfo`/`*collectionErrors`/`*uploadTrigger`, etc.) plus `setCollectionErrors`. These stay element-side because they touch PubSub directly; they re-home once those state keys migrate off PubSub (tracked as M10/M11 follow-up).

`uploadEvents`' emit closure is also injected rather than collapsed onto `controller.emit`, because it preserves a `ctx.has('*eventEmitter')` teardown guard — a pub-null window during teardown that the controller's own emit doesn't model. Converging the emit implementations (controller/LitBlock/ChildBlock/injected closure) is deferred until that teardown-window constraint retires.

`publicApi` stays element-built and bridged via `setApi` — verdict from prior review: it's a shared instance touching PubSub/lit/DOM, not a clean controller-owned construction.

## Design: constructor injection

An earlier version of this task tried passing `deps.controllers` via constructor injection (with `import type` only in `UploaderController`) after bumping the editor-only size budget — this was **rejected**. A live method body referencing the upload-stack constructors defeats tree-shaking and pulls `@uploadcare/upload-client` into editor-only bundles, which must stay independent of the upload stack. Reworked to keep the constructors behind the deferred `attachUploaderScope` call. Measured result: `web/uc-cloud-image-editor.min.js` at 47.22 kB against the original 50 kB budget (+0.75 kB over baseline — wiring only, no upload-client leakage).

## What remains element-built

`publicApi`, `PluginController`, and `blocksRegistry` are still constructed element-side. M9n picks up the ctx-creator ports (solutions/Config/UploadCtxProvider), `PluginController` ownership once `*lazyPlugins`/`*publicApi` migrate, and retiring `_addSharedContextInstance`.

## Review process

Each task in this branch went through a per-task review (opus on the move), including the constructor-injection size tradeoff above, which was rejected and reworked. The final whole-branch review verdict is MERGE-READY. Follow-ups are tracked in `.superpowers/sdd/progress.md`.

## Gate (real counts, this run)

- `tsc:app` — clean
- `build` — clean; `uc-cloud-image-editor.min.js` 47.21 kB / 50 kB budget
- `tsc` (app + e2e types) — no errors
- `test:specs` — 55 files / 646 tests passed
- `test:locales` — clean
- `test:e2e` — 49 files / 319 tests passed (no crop-frame flake retry triggered)
- `lint` — 0 errors, 17 pre-existing warnings (unrelated files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved uploader lifecycle handling with safer attachment, idempotent scope setup across multiple blocks, and reliable teardown/recreation.
  * Prevented duplicate upload-event observers when multiple uploader blocks share the same context.
  * Ensured uploader stack getters fail before attachment and again after destroy, restoring expected API errors.
  * Invalid “minimum files” settings now surface validation errors immediately (before files are added).
* **Tests**
  * Expanded e2e and unit coverage for uploader attachment, instance ownership/destroy behavior, shared-instance identity, clipboard listener behavior, and validation timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->