### PR TITLE
feat(m9n): controller-side ctx creation seam + UploadCtxProvider port (instance-creation migration, part 4)

### DIFF
--- a/src/abstract/CTX.ts
+++ b/src/abstract/CTX.ts
@@ -1,16 +1,20 @@
 import type { UploadcareGroup } from '@uploadcare/upload-client';
-import type { LitBlock } from '../lit/LitBlock';
 import type { OutputCollectionState, OutputErrorCollection } from '../types/index';
 import type { LazyPluginEntry } from './managers/plugin/LazyPluginLoader';
 
+// All seeds below are static values — none derive from an element instance.
+// (Audited ahead of the M9n ctx-creation seam: these used to take an unused
+// `fnCtx: LitBlock` parameter, kept only so call sites could write
+// `uploaderBlockCtx(this)`; dropped so the seam can build the full seed set
+// pre-any-element, with no element to pass.)
 export const blockCtx = () => ({});
 
-export const activityBlockCtx = (_fnCtx: LitBlock) => ({
+export const activityBlockCtx = () => ({
   ...blockCtx(),
 });
 
-export const uploaderBlockCtx = (fnCtx: LitBlock) => ({
-  ...activityBlockCtx(fnCtx),
+export const uploaderBlockCtx = () => ({
+  ...activityBlockCtx(),
   '*commonProgress': 0,
   '*uploadList': [],
   '*collectionErrors': [] as OutputErrorCollection[],
@@ -19,7 +23,7 @@ export const uploaderBlockCtx = (fnCtx: LitBlock) => ({
   '*uploadTrigger': new Set<string>(),
 });
 
-export const solutionBlockCtx = (fnCtx: LitBlock) => ({
-  ...uploaderBlockCtx(fnCtx),
+export const solutionBlockCtx = () => ({
+  ...uploaderBlockCtx(),
   '*lazyPlugins': null as LazyPluginEntry[] | null,
 });

--- a/src/abstract/controllers/UploaderController.test.ts
+++ b/src/abstract/controllers/UploaderController.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest';
 import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import type { Uid } from '../../lit/Uid';
 import { EventBus, UploaderEventType } from '../EventBus';
 import { A11y } from '../managers/a11y';
 import { LocaleManager } from '../managers/LocaleManager';
@@ -12,7 +13,7 @@ import { SecureUploadsController } from './SecureUploadsController';
 import { UploadCollectionController } from './UploadCollectionController';
 import { UploadController } from './UploadController';
 import { UploadEventsController } from './UploadEventsController';
-import { UploaderController, type UploaderScopeDeps } from './UploaderController';
+import { UploaderController, type UploaderScopeDeps, type UploaderStateBridges } from './UploaderController';
 import { ValidationController } from './ValidationController';
 
 const makeUploaderScopeDeps = (overrides: Partial<UploaderScopeDeps> = {}): UploaderScopeDeps => ({
@@ -20,20 +21,24 @@ const makeUploaderScopeDeps = (overrides: Partial<UploaderScopeDeps> = {}): Uplo
   getFileHooks: () => [],
   getOutputItem: (() => ({}) as never) as never,
   getApi: () => ({}) as never,
-  setCollectionErrors: () => {},
   emitCommonUploadFailed: () => {},
   emit: () => {},
   getOutputCollectionState: () => ({}) as never,
   getOutputData: () => [],
   runOnAddHooks: () => {},
-  uploadTrigger: () => new Set(),
-  setUploadList: () => {},
-  getCollectionState: () => null,
-  setCollectionState: () => {},
-  getCommonProgress: () => 0,
-  setCommonProgress: () => {},
-  setGroupInfo: () => {},
-  getCollectionErrors: () => [],
+  ...overrides,
+});
+
+const makeStateBridges = (overrides: Partial<UploaderStateBridges> = {}): UploaderStateBridges => ({
+  setCollectionErrors: vi.fn(),
+  uploadTrigger: vi.fn(() => new Set<Uid>()),
+  setUploadList: vi.fn(),
+  getCollectionState: vi.fn(() => null),
+  setCollectionState: vi.fn(),
+  getCommonProgress: vi.fn(() => 0),
+  setCommonProgress: vi.fn(),
+  setGroupInfo: vi.fn(),
+  getCollectionErrors: vi.fn(() => []),
   ...overrides,
 });
 
@@ -434,6 +439,99 @@ describe('UploaderController', () => {
       controller.destroy();
 
       expect(() => controller.api).toThrow(/setApi/);
+    });
+
+    describe('stateBridges (constructor-time, M9n Task 3 — no longer part of UploaderScopeDeps)', () => {
+      it("wires validation's setCollectionErrors from the constructor-injected stateBridges, not attach-time deps", () => {
+        const stateBridges = makeStateBridges();
+        const controller = new UploaderController({ stateBridges });
+        let capturedDeps: { setCollectionErrors: UploaderStateBridges['setCollectionErrors'] } | undefined;
+        const ValidationControllerSpy = vi.fn(function (
+          this: unknown,
+          deps: { setCollectionErrors: UploaderStateBridges['setCollectionErrors'] },
+        ) {
+          capturedDeps = deps;
+          return new ValidationController(deps as never);
+        }) as unknown as typeof ValidationController;
+
+        controller.attachUploaderScope({
+          ...makeUploaderScopeDeps(),
+          controllers: {
+            SecureUploadsController,
+            UploadController,
+            ValidationController: ValidationControllerSpy,
+            UploadEventsController,
+          },
+        });
+
+        expect(capturedDeps?.setCollectionErrors).toBe(stateBridges.setCollectionErrors);
+
+        controller.destroy();
+      });
+
+      it('wires all 8 uploadEvents state bridges from the constructor-injected stateBridges, not attach-time deps', () => {
+        const stateBridges = makeStateBridges();
+        const controller = new UploaderController({ stateBridges });
+        let capturedDeps:
+          | Pick<
+              UploaderStateBridges,
+              | 'uploadTrigger'
+              | 'setUploadList'
+              | 'getCollectionState'
+              | 'setCollectionState'
+              | 'getCommonProgress'
+              | 'setCommonProgress'
+              | 'setGroupInfo'
+              | 'getCollectionErrors'
+            >
+          | undefined;
+        const UploadEventsControllerSpy = vi.fn(function (
+          this: unknown,
+          deps: Pick<
+            UploaderStateBridges,
+            | 'uploadTrigger'
+            | 'setUploadList'
+            | 'getCollectionState'
+            | 'setCollectionState'
+            | 'getCommonProgress'
+            | 'setCommonProgress'
+            | 'setGroupInfo'
+            | 'getCollectionErrors'
+          >,
+        ) {
+          capturedDeps = deps;
+          return new UploadEventsController(deps as never);
+        }) as unknown as typeof UploadEventsController;
+
+        controller.attachUploaderScope({
+          ...makeUploaderScopeDeps(),
+          controllers: {
+            SecureUploadsController,
+            UploadController,
+            ValidationController,
+            UploadEventsController: UploadEventsControllerSpy,
+          },
+        });
+
+        expect(capturedDeps?.uploadTrigger).toBe(stateBridges.uploadTrigger);
+        expect(capturedDeps?.setUploadList).toBe(stateBridges.setUploadList);
+        expect(capturedDeps?.getCollectionState).toBe(stateBridges.getCollectionState);
+        expect(capturedDeps?.setCollectionState).toBe(stateBridges.setCollectionState);
+        expect(capturedDeps?.getCommonProgress).toBe(stateBridges.getCommonProgress);
+        expect(capturedDeps?.setCommonProgress).toBe(stateBridges.setCommonProgress);
+        expect(capturedDeps?.setGroupInfo).toBe(stateBridges.setGroupInfo);
+        expect(capturedDeps?.getCollectionErrors).toBe(stateBridges.getCollectionErrors);
+
+        controller.destroy();
+      });
+
+      it('defaults stateBridges to inert no-ops when not injected — attach never throws', () => {
+        const controller = new UploaderController();
+
+        expect(() => controller.attachUploaderScope(makeUploaderScopeDeps())).not.toThrow();
+
+        controller.destroy();
+      });
     });
   });
 });

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -233,9 +233,15 @@ export class UploaderController {
         addFileFromUrl: (url, options) => this.api.addFileFromUrl(url, options),
         onFileAdd: () => this.router.traverse('onFileAdd'),
       });
+    // Default no-op bridges for construction without a PubSub ctx (tests /
+    // non-element callers). `uploadTrigger` MUST return a STABLE set — the
+    // real bridge exposes the live `*uploadTrigger` set that
+    // `UploadEventsController` mutates in place (`.delete(...)`) and iterates,
+    // so a fresh `new Set()` per call would silently break those invariants.
+    const defaultUploadTrigger: ReturnType<UploaderStateBridges['uploadTrigger']> = new Set();
     this._stateBridges = deps.stateBridges ?? {
       setCollectionErrors: () => {},
-      uploadTrigger: () => new Set(),
+      uploadTrigger: () => defaultUploadTrigger,
       setUploadList: () => {},
       getCollectionState: () => null,
       setCollectionState: () => {},

--- a/src/abstract/controllers/UploaderController.ts
+++ b/src/abstract/controllers/UploaderController.ts
@@ -67,6 +67,31 @@ import type { ValidationController, ValidationControllerDeps } from './Validatio
  * always after `setApi` has run, since a paste can only ever add a file
  * through an already-constructed uploader element.
  */
+/**
+ * The v1 shared-state (`*`-key, via the `$`/`PubSub` proxy) read/write bridges
+ * that the upload stack needs — `ValidationController`'s `setCollectionErrors`
+ * and `UploadEventsController`'s 8. Built by whoever creates the controller
+ * (lit-side: `PubSubCompat._uploader()`, closing over that ctx's `pub`/`read`)
+ * and handed in at construction time, rather than injected later at
+ * `attachUploaderScope()` — so the controller's identity (and these bridges)
+ * exist from birth, before an uploader element ever attaches. The controller
+ * itself stays PubSub-free: it only ever calls these functions, never imports
+ * `PubSub`.
+ */
+export type UploaderStateBridges = {
+  /** Sink for collection-level errors — v1 wrote `this.$['*collectionErrors']`. */
+  setCollectionErrors: ValidationControllerDeps['setCollectionErrors'];
+  /** The live `*uploadTrigger` set (mutated in place on remove). */
+  uploadTrigger: UploadEventsControllerDeps['uploadTrigger'];
+  setUploadList: UploadEventsControllerDeps['setUploadList'];
+  getCollectionState: UploadEventsControllerDeps['getCollectionState'];
+  setCollectionState: UploadEventsControllerDeps['setCollectionState'];
+  getCommonProgress: UploadEventsControllerDeps['getCommonProgress'];
+  setCommonProgress: UploadEventsControllerDeps['setCommonProgress'];
+  setGroupInfo: UploadEventsControllerDeps['setGroupInfo'];
+  getCollectionErrors: UploadEventsControllerDeps['getCollectionErrors'];
+};
+
 export type UploaderControllerDeps = {
   events?: EventBus;
   config?: ConfigController;
@@ -78,6 +103,8 @@ export type UploaderControllerDeps = {
   router?: RouterController;
   a11y?: A11y;
   clipboard?: ClipboardController;
+  /** See `UploaderStateBridges` doc. Defaults to inert no-ops (editor-only scopes never attach an uploader). */
+  stateBridges?: UploaderStateBridges;
 };
 
 /**
@@ -92,6 +119,11 @@ export type UploaderControllerDeps = {
  * Reuses each sub-controller's own `*Deps` field types (rather than
  * redeclaring them) so a signature change downstream is a compile error here,
  * not silent drift.
+ *
+ * M9n (Task 3) moved the 9 v1 shared-state (`*`-key) read/write bridges —
+ * validation's `setCollectionErrors` and uploadEvents' 8 — out of this type
+ * and into `UploaderStateBridges`, injected at controller construction
+ * instead of here at attach time (see that type's doc).
  */
 export type UploaderScopeDeps = {
   /**
@@ -114,8 +146,6 @@ export type UploaderScopeDeps = {
   getOutputItem: UploadEventsControllerDeps['getOutputItem'];
   /** The public API passed to validators (bag.api). */
   getApi: ValidationControllerDeps['getApi'];
-  /** Sink for collection-level errors — v1 wrote `this.$['*collectionErrors']`. */
-  setCollectionErrors: ValidationControllerDeps['setCollectionErrors'];
   /** Fires the debounced `common-upload-failed` event — reads bag.eventEmitter + bag.api, kept verbatim (api isn't controller-owned). */
   emitCommonUploadFailed: ValidationControllerDeps['emitCommonUploadFailed'];
   /**
@@ -130,16 +160,6 @@ export type UploaderScopeDeps = {
   getOutputData: UploadEventsControllerDeps['getOutputData'];
   /** Runs plugin `onAdd` hooks — needs `bag.wait('pluginManager')`. */
   runOnAddHooks: UploadEventsControllerDeps['runOnAddHooks'];
-
-  // ─── v1 shared-state bridge (`*`-keys via the `$` proxy) — element-side only ───
-  uploadTrigger: UploadEventsControllerDeps['uploadTrigger'];
-  setUploadList: UploadEventsControllerDeps['setUploadList'];
-  getCollectionState: UploadEventsControllerDeps['getCollectionState'];
-  setCollectionState: UploadEventsControllerDeps['setCollectionState'];
-  getCommonProgress: UploadEventsControllerDeps['getCommonProgress'];
-  setCommonProgress: UploadEventsControllerDeps['setCommonProgress'];
-  setGroupInfo: UploadEventsControllerDeps['setGroupInfo'];
-  getCollectionErrors: UploadEventsControllerDeps['getCollectionErrors'];
 };
 
 type UploaderScope = {
@@ -174,6 +194,9 @@ export class UploaderController {
   // in the scope (`attachUploaderScope`, called by `LitUploaderBlock`). A
   // bare `<uc-config>` + provider ctx (no uploader tag) never gets one.
   private _uploaderScope: UploaderScope | null = null;
+  // See `UploaderStateBridges` doc. Lives from construction — a scope that
+  // never attaches an uploader (editor-only) simply never calls these.
+  private readonly _stateBridges: UploaderStateBridges;
 
   public constructor(deps: UploaderControllerDeps = {}) {
     this.events = deps.events ?? new EventBus();
@@ -210,6 +233,17 @@ export class UploaderController {
         addFileFromUrl: (url, options) => this.api.addFileFromUrl(url, options),
         onFileAdd: () => this.router.traverse('onFileAdd'),
       });
+    this._stateBridges = deps.stateBridges ?? {
+      setCollectionErrors: () => {},
+      uploadTrigger: () => new Set(),
+      setUploadList: () => {},
+      getCollectionState: () => null,
+      setCollectionState: () => {},
+      getCommonProgress: () => 0,
+      setCommonProgress: () => {},
+      setGroupInfo: () => {},
+      getCollectionErrors: () => [],
+    };
   }
 
   /**
@@ -326,7 +360,7 @@ export class UploaderController {
       config: this.config,
       collection: this.collection,
       getApi: deps.getApi,
-      setCollectionErrors: deps.setCollectionErrors,
+      setCollectionErrors: this._stateBridges.setCollectionErrors,
       emitCommonUploadFailed: deps.emitCommonUploadFailed,
       onValidatorError: (error, context) => {
         // Same teardown race as `onUploadError` above: reporting never throws.
@@ -349,14 +383,14 @@ export class UploaderController {
       buildUploadOptions: () => uploadController.buildUploadOptions(),
       runOnAddHooks: deps.runOnAddHooks,
       applyInitialCrop: () => applyInitialCrop(this.collection, this.config.get('cropPreset')),
-      uploadTrigger: deps.uploadTrigger,
-      setUploadList: deps.setUploadList,
-      getCollectionState: deps.getCollectionState,
-      setCollectionState: deps.setCollectionState,
-      getCommonProgress: deps.getCommonProgress,
-      setCommonProgress: deps.setCommonProgress,
-      setGroupInfo: deps.setGroupInfo,
-      getCollectionErrors: deps.getCollectionErrors,
+      uploadTrigger: this._stateBridges.uploadTrigger,
+      setUploadList: this._stateBridges.setUploadList,
+      getCollectionState: this._stateBridges.getCollectionState,
+      setCollectionState: this._stateBridges.setCollectionState,
+      getCommonProgress: this._stateBridges.getCommonProgress,
+      setCommonProgress: this._stateBridges.setCommonProgress,
+      setGroupInfo: this._stateBridges.setGroupInfo,
+      getCollectionErrors: this._stateBridges.getCollectionErrors,
     });
 
     this._uploaderScope = { secureUploadsManager, uploadController, validationManager, uploadEvents };

--- a/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
+++ b/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
@@ -1,29 +1,138 @@
-// @ts-check
-
+import { SecureUploadsController } from '../../abstract/controllers/SecureUploadsController';
+import { UploadController } from '../../abstract/controllers/UploadController';
+import { UploadEventsController } from '../../abstract/controllers/UploadEventsController';
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { ValidationController } from '../../abstract/controllers/ValidationController';
+import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
+import { ChildBlock } from '../../lit/ChildBlock';
+import { createDebugPrinter } from '../../lit/createDebugPrinter';
 import { EventBridgeController } from '../../lit/EventBridgeController';
-import { LitUploaderBlock } from '../../lit/LitUploaderBlock';
+import { getOutputData } from '../../lit/getOutputData';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState, OutputFileStatus } from '../../types/index';
 import { type EventPayload, EventType } from './EventEmitter';
 
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: This is intentional interface merging, used to add event listener types
-export class UploadCtxProvider extends LitUploaderBlock {
-  public declare attributesMeta: {
-    'ctx-name': string;
-  };
+export class UploadCtxProvider extends ChildBlock {
   public static override styleAttrs = ['uc-wgt-common'];
   public static EventType = EventType;
 
+  /** Same contract as v1 `LitBlock.debugPrint` (`createDebugPrinter`), scoped to this ctx. */
+  private _debugPrint = createDebugPrinter(() => this.bag.ctx, this.constructor.name);
+
   private _eventBridge: EventBridgeController | null = null;
 
-  public override initCallback() {
-    super.initCallback();
+  protected override controllerReady(ctrl: UploaderController): void {
+    // Re-adoption (release-while-connected followed by re-adopt) would otherwise
+    // stack a new EventBridgeController per adoption without ever removing the
+    // previous one's subscription — tear down the old instance first (mirrors
+    // the SourceListController pattern in SourceList.ts).
+    this._teardownEventBridge();
+
+    this._attachUploaderScopeIfNeeded(ctrl);
 
     // Bridge the per-ctx EventBus to documented DOM CustomEvents on this
-    // element. The reactive controller manages its own connect/disconnect.
-    this._eventBridge ??= new EventBridgeController(
+    // element. Recreated on every adoption (matching the teardown above) so
+    // its internal subscription is rebound to the *new* controller's bus
+    // rather than staying latched onto a released one.
+    this._eventBridge = new EventBridgeController(
       this,
-      () => this.sharedCtx.uploaderController().events,
-      (...args) => this.debugPrint(...args),
+      () => this.uploader.events,
+      (...args) => this._debugPrint(...args),
     );
+  }
+
+  protected override controllerReleased(): void {
+    this._teardownEventBridge();
+  }
+
+  private _teardownEventBridge(): void {
+    if (!this._eventBridge) {
+      return;
+    }
+    this._eventBridge.hostDisconnected();
+    this.removeController(this._eventBridge);
+    this._eventBridge = null;
+  }
+
+  /**
+   * `<uc-upload-ctx-provider>` must be able to attach the uploader scope
+   * itself, synchronously, the moment it adopts its controller — because
+   * `getAPI()`/`.api` are documented to work right after mount, and the
+   * solution block's own attach (`LitUploaderBlock.initCallback`, and the
+   * `<uc-drop-area>` inside its template) does not run until the solution's
+   * first Lit render, a microtask later. The ctx + controller already exist by
+   * adoption time (created by whichever block's `_initSharedContext` ran first
+   * — typically `<uc-config>`), so this fills the still-missing upload scope.
+   * In v1 `UploadCtxProvider` was itself a `LitUploaderBlock` and attached the
+   * scope in its synchronous `initCallback`; this preserves that exact
+   * guarantee on `ChildBlock`. All writes are guarded / idempotent
+   * (first-write-wins + `attachUploaderScope`'s own gate), so this is a no-op
+   * once a solution or a sibling provider has already attached.
+   *
+   * NOTE: the `attachUploaderScope(...)` deps below intentionally mirror
+   * `LitUploaderBlock.initCallback`'s — the two are kept in sync by hand.
+   * Extracting a shared builder is a queued follow-up (see the M9n ledger).
+   */
+  private _attachUploaderScopeIfNeeded(ctrl: UploaderController): void {
+    const ctx = this.bag.ctx;
+
+    if (!ctx.has('*uploadCollection')) {
+      ctx.add('*uploadCollection', ctrl.collection, true);
+    }
+
+    if (!ctx.has('*publicApi')) {
+      const api = new UploaderPublicApi(this.bag);
+      ctrl.setApi(api);
+      ctx.add('*publicApi', api, true);
+    }
+
+    ctrl.attachUploaderScope({
+      controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
+      debug: (...args) => this._debugPrint(...args),
+      getFileHooks: () => this.bag.pluginManager?.snapshot().fileHooks ?? [],
+      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => this.bag.api.getOutputItem<TStatus>(uid),
+      getApi: () => this.bag.api,
+      emitCommonUploadFailed: () => {
+        this.bag.eventEmitter.emit(
+          EventType.COMMON_UPLOAD_FAILED,
+          () => this.bag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
+          { debounce: true },
+        );
+      },
+      // Same contract as `ChildBlock.emit`: EventEmitter dispatch + telemetry
+      // mirror, guarded for teardown races.
+      emit: (type, payload, options) => this.emit(type, payload, options),
+      getOutputCollectionState: () => this.bag.api.getOutputCollectionState(),
+      getOutputData: () => getOutputData(this.bag),
+      runOnAddHooks: (entry) =>
+        void this.bag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+    });
+
+    // Re-expose the controller-owned instances under their v1 shared-instance
+    // keys (readers like `FileItem.bag.uploadController` expect them there).
+    if (!ctx.has('*secureUploadsManager')) {
+      ctx.add('*secureUploadsManager', ctrl.secureUploadsManager, true);
+    }
+    if (!ctx.has('*uploadController')) {
+      ctx.add('*uploadController', ctrl.uploadController, true);
+    }
+    if (!ctx.has('*validationManager')) {
+      ctx.add('*validationManager', ctrl.validationManager, true);
+    }
+    if (!ctx.has('*uploadEvents')) {
+      ctx.add('*uploadEvents', ctrl.uploadEvents, true);
+    }
+  }
+
+  /** Same contract as v1 `LitUploaderBlock.getAPI()` — returns the ctx's public API. */
+  public getAPI(): UploaderPublicApi {
+    return this.bag.api;
+  }
+
+  /** Same contract as v1 `LitUploaderBlock.get api()` — throws pre-adoption via `bag`. */
+  public get api(): UploaderPublicApi {
+    return this.bag.api;
   }
 }
 
@@ -31,7 +140,7 @@ type EventListenerMap = {
   [K in (typeof EventType)[keyof typeof EventType]]: (e: CustomEvent<EventPayload[K]>) => void;
 };
 
-export interface UploadCtxProvider extends LitUploaderBlock {
+export interface UploadCtxProvider extends ChildBlock {
   addEventListener<T extends keyof EventListenerMap>(
     type: T,
     listener: EventListenerMap[T],

--- a/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
+++ b/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
@@ -1,4 +1,5 @@
 import { SecureUploadsController } from '../../abstract/controllers/SecureUploadsController';
+import type { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import { UploadController } from '../../abstract/controllers/UploadController';
 import { UploadEventsController } from '../../abstract/controllers/UploadEventsController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
@@ -123,6 +124,16 @@ export class UploadCtxProvider extends ChildBlock {
     if (!ctx.has('*uploadEvents')) {
       ctx.add('*uploadEvents', ctrl.uploadEvents, true);
     }
+  }
+
+  /**
+   * Same contract as v1 `LitUploaderBlock.get uploadCollection()` — part of the
+   * documented `<uc-upload-ctx-provider>` type surface (pinned by
+   * `types/test/uc-upload-ctx-provider.test-d.tsx`). Throws pre-adoption via
+   * `bag`, exactly as the v1 getter did before `initCallback` ran.
+   */
+  public get uploadCollection(): UploadCollectionController {
+    return this.bag.uploadCollection;
   }
 
   /** Same contract as v1 `LitUploaderBlock.getAPI()` — returns the ctx's public API. */

--- a/src/lit/LitActivityBlock.ts
+++ b/src/lit/LitActivityBlock.ts
@@ -19,7 +19,7 @@ const ACTIVE_ATTR = 'active';
 export class LitActivityBlock extends LitBlock {
   public activityType: ActivityType = null;
 
-  public override init$ = activityBlockCtx(this);
+  public override init$ = activityBlockCtx();
 
   public override initCallback(): void {
     super.initCallback();

--- a/src/lit/LitSolutionBlock.ts
+++ b/src/lit/LitSolutionBlock.ts
@@ -8,7 +8,7 @@ import { LitBlock } from './LitBlock';
 export class LitSolutionBlock extends LitBlock {
   public static override styleAttrs = ['uc-wgt-common'];
   public static lazyPlugins: LazyPluginEntry[] | null = null;
-  public override init$ = solutionBlockCtx(this);
+  public override init$ = solutionBlockCtx();
 
   private _unregisterClipboardScope: (() => void) | null = null;
 

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -22,7 +22,7 @@ export class LitUploaderBlock extends LitActivityBlock {
   public static extSrcList: Readonly<typeof ExternalUploadSource>;
   public static sourceTypes: Readonly<typeof UploadSource>;
 
-  public override init$ = uploaderBlockCtx(this);
+  public override init$ = uploaderBlockCtx();
 
   public override initCallback(): void {
     super.initCallback();

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -55,6 +55,13 @@ export class LitUploaderBlock extends LitActivityBlock {
     // idempotent (first uploader block to connect wins, matching the old
     // `_addSharedContextInstance` first-write-wins semantics). This element
     // only supplies the callbacks that must stay DOM/PubSub-side.
+    //
+    // The 9 v1 shared-state (`*`-key) read/write bridges validation +
+    // uploadEvents need (`setCollectionErrors` and the 8 below it) are NOT
+    // supplied here (M9n, Task 3) — they're built at controller-creation time
+    // in `PubSubCompat._uploader()`, closing over that ctx, and handed to
+    // `new UploaderController({ stateBridges })`. They live from the
+    // controller's birth, not from this element's `initCallback`.
     const uploader = this.sharedCtx.uploaderController();
     const ctx = this._sharedInstancesBag.ctx;
     uploader.attachUploaderScope({
@@ -64,9 +71,6 @@ export class LitUploaderBlock extends LitActivityBlock {
       getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>
         this._sharedInstancesBag.api.getOutputItem<TStatus>(uid),
       getApi: () => this._sharedInstancesBag.api,
-      setCollectionErrors: (errors) => {
-        this.$['*collectionErrors'] = errors;
-      },
       emitCommonUploadFailed: () => {
         this._sharedInstancesBag.eventEmitter.emit(
           EventType.COMMON_UPLOAD_FAILED,
@@ -94,14 +98,6 @@ export class LitUploaderBlock extends LitActivityBlock {
       getOutputData: () => getOutputData(this._sharedInstancesBag),
       runOnAddHooks: (entry) =>
         void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
-      uploadTrigger: () => ctx.read('*uploadTrigger'),
-      setUploadList: (list) => ctx.pub('*uploadList', list),
-      getCollectionState: () => ctx.read('*collectionState'),
-      setCollectionState: (state) => ctx.pub('*collectionState', state),
-      getCommonProgress: () => ctx.read('*commonProgress'),
-      setCommonProgress: (progress) => ctx.pub('*commonProgress', progress),
-      setGroupInfo: (group) => ctx.pub('*groupInfo', group),
-      getCollectionErrors: () => ctx.read('*collectionErrors'),
     });
 
     // The four are now controller-owned identity — these re-exposers just

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -217,6 +217,27 @@ describe('PubSub (additional coverage)', () => {
     expect(ctx.read('extra')).toBe('two');
   });
 
+  it('add() rewrite semantics pin what ctxOwner buys: first-write-wins normally, force-overwrite when rewrite=true (CloudImageEditorBlock/EditorImageCropper init$ seeding path)', () => {
+    // `SymbioteCompatMixin._initSharedContext` calls `add(key, defaultValue,
+    // this.ctxOwner)` for every `init$` key on connect (src/lit/SymbioteCompatMixin.ts).
+    // `CloudImageEditorBlock` (16 keys via `initState()`, CloudImageEditorBlock.ts:120-123)
+    // and `EditorImageCropper` (4 keys seeded in its constructor, EditorImageCropper.ts:65-85)
+    // are the only two classes that set `ctxOwner = true`, so for their real
+    // seeded keys `add` is called with `rewrite=true` instead of the default
+    // `false`. This pins that the two rewrite values genuinely differ — not
+    // that a collision currently exists (none does; no other co-resident
+    // block seeds the same keys today, so the rewrite is presently inert in
+    // practice, just live in mechanism).
+    const ctx = freshCtx();
+
+    ctx.add('*imageBox', 'v1'); // non-owner seeding: rewrite=false (default)
+    ctx.add('*imageBox', 'v2'); // a second non-owner seed — first-write-wins
+    expect(ctx.read('*imageBox')).toBe('v1');
+
+    ctx.add('*imageBox', 'v3', true); // ctxOwner=true path — forces overwrite
+    expect(ctx.read('*imageBox')).toBe('v3');
+  });
+
   it('pub warns for an unknown non-facade key', () => {
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const ctx = freshCtx();

--- a/src/lit/PubSubCompat.ts
+++ b/src/lit/PubSubCompat.ts
@@ -53,7 +53,34 @@ export class PubSub<T extends Record<string, unknown>> {
   private _uploader(): UploaderController {
     let controller = PubSub._controllers.get(this._ctxId);
     if (!controller) {
-      controller = new UploaderController();
+      // The 9 v1 shared-state (`*`-key) read/write bridges the upload stack
+      // needs (validation's `setCollectionErrors`, uploadEvents' 8) — built
+      // here, at controller-creation time, closing over THIS ctx via the
+      // same `pub`/`read` this class already routes cfg/locale/nanostores
+      // keys through. None of these 9 keys are `*cfg/`- or `*l10n/`-prefixed,
+      // so `pub`/`read` fall straight through to the nanostores map — same
+      // shape as the v1 closures moved here verbatim (see the M9n Task 3
+      // report). `pub`/`read` are generic over this instance's own `T`; these
+      // keys aren't statically known to be `keyof T` (they're only ever
+      // touched by the uploader stack, not declared per-ctx-shape), hence the
+      // casts — behaviorally identical to the untyped `ctx.pub`/`ctx.read`
+      // calls this replaces.
+      const pub = <V>(key: string, value: V): void => this.pub(key as keyof T, value as T[keyof T]);
+      const read = <V>(key: string): V => this.read(key as keyof T) as V;
+
+      controller = new UploaderController({
+        stateBridges: {
+          setCollectionErrors: (errors) => pub('*collectionErrors', errors),
+          uploadTrigger: () => read('*uploadTrigger'),
+          setUploadList: (list) => pub('*uploadList', list),
+          getCollectionState: () => read('*collectionState'),
+          setCollectionState: (state) => pub('*collectionState', state),
+          getCommonProgress: () => read('*commonProgress'),
+          setCommonProgress: (progress) => pub('*commonProgress', progress),
+          setGroupInfo: (group) => pub('*groupInfo', group),
+          getCollectionErrors: () => read('*collectionErrors'),
+        },
+      });
       PubSub._controllers.set(this._ctxId, controller);
       UploaderRegistry.register(this._ctxId, controller);
     }

--- a/src/lit/SymbioteCompatMixin.ts
+++ b/src/lit/SymbioteCompatMixin.ts
@@ -3,7 +3,8 @@ import type { LitElement, PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { debounce } from '../utils/debounce';
 import type { Constructor } from './Constructor';
-import { PubSub } from './PubSubCompat';
+import { ensureUploaderCtx } from './ensureUploaderCtx';
+import type { PubSub } from './PubSubCompat';
 
 type SymbioteStateBag<T extends Record<string, unknown>> = T;
 
@@ -194,7 +195,6 @@ export function SymbioteMixin<TState extends Record<string, unknown> = Record<st
        * Initialize shared context after ctxName is available
        */
       private _initSharedContext() {
-        const initialValue = this.init$;
         const ctxName = this._effectiveCtxName;
 
         if (!ctxName) {
@@ -203,9 +203,20 @@ export function SymbioteMixin<TState extends Record<string, unknown> = Record<st
         }
 
         if (!this._symbioteSharedPubSub) {
-          this._symbioteSharedPubSub =
-            PubSub.getCtx<TState>(ctxName) ?? PubSub.registerCtx<TState>(initialValue, ctxName);
+          // Map acquisition (idempotent: creates + seeds + forces the
+          // controller into existence on first call for this ctx name, or
+          // returns the existing map untouched) — see `ensureUploaderCtx`.
+          // `TState` is always `SharedState` in practice (the only
+          // production `SymbioteMixin<TState>()` instantiation, in
+          // `LitBlock.ts`); this bridges the seam's concrete `SharedState`
+          // typing to this class's generic `TState`, the same "generic
+          // param assumed to equal the real runtime shape" contract
+          // `init$: TState = {} as TState` already relies on above.
+          this._symbioteSharedPubSub = ensureUploaderCtx(ctxName) as unknown as PubSub<TState>;
 
+          // v1 extras on top of the seam's base seed: this element's OWN
+          // `init$` keys (e.g. `Config`'s `*cfg/*` defaults, CIE's
+          // `ctxOwner`-rewritten keys) — unchanged rewrite semantics.
           for (const [key, defaultValue] of Object.entries(this.init$) as [keyof TState, TState[keyof TState]][]) {
             this._symbioteSharedPubSub.add(key, defaultValue, this.ctxOwner);
           }

--- a/src/lit/ensureUploaderCtx.test.ts
+++ b/src/lit/ensureUploaderCtx.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { UploaderController } from '../abstract/controllers/UploaderController';
+import { UploaderRegistry } from '../abstract/UploaderRegistry';
+import { ensureUploaderCtx } from './ensureUploaderCtx';
+import { PubSub } from './PubSubCompat';
+
+// Each test uses a unique ctx id and tears it down so the module-level
+// context/controller maps and the global UploaderRegistry don't leak.
+let seq = 0;
+const ids: string[] = [];
+const freshCtxName = () => {
+  const id = `ensure-uploader-ctx-test-${seq++}`;
+  ids.push(id);
+  return id;
+};
+
+afterEach(() => {
+  for (const id of ids.splice(0)) PubSub.deleteCtx(id);
+});
+
+describe('ensureUploaderCtx', () => {
+  it('creates the ctx map pre-any-element, with no DOM/Lit block ever having touched it', () => {
+    const ctxName = freshCtxName();
+    expect(PubSub.hasCtx(ctxName)).toBe(false);
+
+    const ctx = ensureUploaderCtx(ctxName);
+
+    expect(PubSub.hasCtx(ctxName)).toBe(true);
+    expect(ctx.id).toBe(ctxName);
+  });
+
+  it('seeds the full plain uploader/solution state set (blockCtx + uploaderBlockCtx + solutionBlockCtx)', () => {
+    const ctxName = freshCtxName();
+    const ctx = ensureUploaderCtx(ctxName);
+
+    expect(ctx.read('*commonProgress')).toBe(0);
+    expect(ctx.read('*uploadList')).toEqual([]);
+    expect(ctx.read('*collectionErrors')).toEqual([]);
+    expect(ctx.read('*collectionState')).toBeNull();
+    expect(ctx.read('*groupInfo')).toBeNull();
+    expect(ctx.read('*uploadTrigger')).toEqual(new Set());
+    expect(ctx.read('*lazyPlugins')).toBeNull();
+  });
+
+  it('does NOT seed any instance key — those stay element-gated (re-exposer registration)', () => {
+    const ctxName = freshCtxName();
+    const ctx = ensureUploaderCtx(ctxName);
+
+    expect(ctx.has('*uploadCollection')).toBe(false);
+    expect(ctx.has('*eventEmitter')).toBe(false);
+    expect(ctx.has('*a11y')).toBe(false);
+  });
+
+  it('forces the UploaderController into existence immediately, not lazily on first *cfg/*l10n touch', () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+
+    const controller = UploaderRegistry.get(ctxName);
+    expect(controller).toBeInstanceOf(UploaderController);
+  });
+
+  it('is idempotent: a second call against an existing ctx returns the same ctx/controller, untouched', () => {
+    const ctxName = freshCtxName();
+    const first = ensureUploaderCtx(ctxName);
+    const firstController = UploaderRegistry.get(ctxName);
+
+    // Mutate a seeded value to prove idempotency doesn't re-seed over it.
+    first.pub('*commonProgress', 42);
+
+    const second = ensureUploaderCtx(ctxName);
+    const secondController = UploaderRegistry.get(ctxName);
+
+    expect(second.id).toBe(first.id);
+    expect(secondController).toBe(firstController);
+    // No re-seed clobber of the live value set above.
+    expect(second.read('*commonProgress')).toBe(42);
+  });
+
+  it('gives each ctx its own fresh mutable seed instances (no shared Set across ctxs)', () => {
+    const ctxNameA = freshCtxName();
+    const ctxNameB = freshCtxName();
+    const ctxA = ensureUploaderCtx(ctxNameA);
+    const ctxB = ensureUploaderCtx(ctxNameB);
+
+    expect(ctxA.read('*uploadTrigger')).not.toBe(ctxB.read('*uploadTrigger'));
+
+    ctxA.read('*uploadTrigger').add('abc' as never);
+    expect(ctxB.read('*uploadTrigger').size).toBe(0);
+  });
+
+  it('when a ctx already exists (e.g. registered by a plain nanostores caller), reuses it as-is without forcing a re-seed', () => {
+    const ctxName = freshCtxName();
+    const preexisting = PubSub.registerCtx<Record<string, unknown>>({ plain: 'seed' }, ctxName);
+
+    const ctx = ensureUploaderCtx(ctxName);
+
+    expect(ctx.id).toBe(preexisting.id);
+    expect(ctx.read('plain' as never)).toBe('seed');
+    // The full uploader/solution seed set was NOT retroactively injected —
+    // the seam only seeds on first creation, never on an existing map.
+    expect(ctx.has('*commonProgress')).toBe(false);
+  });
+});

--- a/src/lit/ensureUploaderCtx.ts
+++ b/src/lit/ensureUploaderCtx.ts
@@ -33,18 +33,21 @@ import type { SharedState } from './SharedState';
  * unchanged by this seam.
  */
 export function ensureUploaderCtx(ctxName: string): PubSub<SharedState> {
-  const existing = PubSub.getCtx<SharedState>(ctxName);
-  if (existing) {
-    return existing;
-  }
-
   // `solutionBlockCtx()` returns only the plain uploader/solution seed keys
   // (a small subset of `SharedState`, which also covers `*cfg/*`, `*l10n/*`,
   // and every controller-owned instance key) — the same "seed value typed as
   // the full shared-state shape" contract every v1 block's `init$` field
   // already relies on (e.g. `LitBlock.init$ = blockCtx()` for `TState`).
-  const seed = solutionBlockCtx() as unknown as SharedState;
-  const ctx = PubSub.registerCtx<SharedState>(seed, ctxName);
+  const existing = PubSub.getCtx<SharedState>(ctxName);
+  const ctx = existing ?? PubSub.registerCtx<SharedState>(solutionBlockCtx() as unknown as SharedState, ctxName);
+
+  // Force the controller into existence on EVERY path, not just first
+  // creation. A map can pre-exist without a controller — created by a v1
+  // element's raw `PubSub.registerCtx`, a test harness, or a future ported
+  // ctx-creator — and this function's contract is that the controller exists
+  // the moment the ctx does (so `ChildBlock`s never wait forever on
+  // `UploaderRegistry`). `uploaderController()` is idempotent: it returns the
+  // registered controller or creates+registers one.
   ctx.uploaderController();
   return ctx;
 }

--- a/src/lit/ensureUploaderCtx.ts
+++ b/src/lit/ensureUploaderCtx.ts
@@ -1,0 +1,50 @@
+import { solutionBlockCtx } from '../abstract/CTX';
+import { PubSub } from './PubSubCompat';
+import type { SharedState } from './SharedState';
+
+/**
+ * The one controller-side entry point that creates a per-ctx nanostores map.
+ *
+ * Idempotent: if `ctxName` already has a map (created by this function, by a
+ * v1 element's own `PubSub.registerCtx` call, or by a plain test harness),
+ * that map is returned untouched — no re-seed, no second controller.
+ *
+ * On first creation it seeds the map with the full *plain* uploader/solution
+ * state (`blockCtx` + `uploaderBlockCtx` + `solutionBlockCtx` from
+ * `abstract/CTX.ts` — `*commonProgress`, `*uploadList`, `*collectionErrors`,
+ * `*collectionState`, `*groupInfo`, `*uploadTrigger`, `*lazyPlugins`) and
+ * nothing else: no instance keys (`*eventEmitter`, `*uploadCollection`, …) —
+ * those stay element-gated, registered by `LitBlock`/`LitUploaderBlock`
+ * `initCallback` re-exposers, same as before this seam existed. It then
+ * forces the ctx's `UploaderController` into existence immediately, instead
+ * of lazily on first `*cfg/*`/`*l10n/*` touch (`PubSubCompat`'s previous
+ * sole creation path) — this is the whole point of the seam: the controller
+ * now exists the moment the ctx does, even pre-any-element.
+ *
+ * A fresh seed object is built per call (not hoisted to a module constant):
+ * `uploaderBlockCtx`'s `*uploadTrigger` is a `Set` instance, so a shared seed
+ * object would leak that Set across unrelated ctxs.
+ *
+ * `SymbioteCompatMixin._initSharedContext` delegates map acquisition to this
+ * function; it still runs its own per-key `add(key, value, this.ctxOwner)`
+ * loop over the connecting element's OWN `init$` on top (v1 extras — e.g.
+ * `Config`'s `*cfg/*` keys, `CloudImageEditorBlock`/`EditorImageCropper`'s
+ * `ctxOwner`-rewritten keys) — that loop, and its rewrite semantics, are
+ * unchanged by this seam.
+ */
+export function ensureUploaderCtx(ctxName: string): PubSub<SharedState> {
+  const existing = PubSub.getCtx<SharedState>(ctxName);
+  if (existing) {
+    return existing;
+  }
+
+  // `solutionBlockCtx()` returns only the plain uploader/solution seed keys
+  // (a small subset of `SharedState`, which also covers `*cfg/*`, `*l10n/*`,
+  // and every controller-owned instance key) — the same "seed value typed as
+  // the full shared-state shape" contract every v1 block's `init$` field
+  // already relies on (e.g. `LitBlock.init$ = blockCtx()` for `TState`).
+  const seed = solutionBlockCtx() as unknown as SharedState;
+  const ctx = PubSub.registerCtx<SharedState>(seed, ctxName);
+  ctx.uploaderController();
+  return ctx;
+}

--- a/tests/api.e2e.test.tsx
+++ b/tests/api.e2e.test.tsx
@@ -23,6 +23,41 @@ beforeEach(() => {
 });
 
 describe('API', () => {
+  // M9n Task 1 — gap-fill ahead of the ctx-creation-seam move (map creation +
+  // upload-state seeds move controller-side). Pins the documented idle
+  // default shape `getOutputCollectionState()` returns on a fresh
+  // composition, before any file is added — i.e. the seeded
+  // `*commonProgress`/`*collectionErrors`/`*groupInfo`/`*uploadList` values
+  // from `uploaderBlockCtx` (src/abstract/CTX.ts), read via the plain
+  // getters in `buildOutputCollectionState`. Nothing in the existing suite
+  // asserts this pre-upload shape — every other `getOutputCollectionState()`
+  // read happens after at least one `addFile*` call.
+  it('getOutputCollectionState() returns the idle default shape on a fresh composition, before any upload activity', () => {
+    const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+    const api = uploadCtxProvider.api;
+
+    const state = api.getOutputCollectionState();
+
+    expect(state).toMatchObject({
+      status: 'idle',
+      totalCount: 0,
+      successCount: 0,
+      failedCount: 0,
+      uploadingCount: 0,
+      progress: 0,
+      errors: [],
+      group: null,
+      isFailed: false,
+      isUploading: false,
+      isSuccess: false,
+      allEntries: [],
+      successEntries: [],
+      failedEntries: [],
+      uploadingEntries: [],
+      idleEntries: [],
+    });
+  });
+
   it('should emit events', async () => {
     const uploadCtxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
     const api = uploadCtxProvider.api;

--- a/tests/blocks/upload-events-wiring.e2e.test.tsx
+++ b/tests/blocks/upload-events-wiring.e2e.test.tsx
@@ -145,6 +145,55 @@ describe('upload events wiring', () => {
     );
   }, 30_000);
 
+  it('stops dispatching DOM events on a ctx-provider once it disconnects, while a sibling on the same ctx keeps receiving them', async () => {
+    // M9n Task 1 — gap-fill ahead of the ctx-creation-seam move. Pins
+    // `EventBridgeController.hostDisconnected` (src/lit/EventBridgeController.ts):
+    // once a `<uc-upload-ctx-provider>` disconnects, it must stop re-dispatching
+    // the per-ctx `EventBus` as DOM CustomEvents on itself — the bus keeps
+    // running (a sibling provider on the same ctx still gets every event).
+    // Nothing in the existing suite disconnects the ctx-provider element
+    // itself and observes the bridge stop; the "owner-candidate removal" test
+    // above only removes an unrelated block.
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+
+    const survivingProvider = page.getByTestId('uc-upload-ctx-provider').nth(0).query()! as UploadCtxProvider;
+    const disconnectingProvider = page.getByTestId('uc-upload-ctx-provider').nth(1).query()! as UploadCtxProvider;
+    const api = survivingProvider.api;
+
+    const survivingHandler = vi.fn<(e: CustomEvent<EventPayload['file-added']>) => void>();
+    const disconnectingHandler = vi.fn<(e: CustomEvent<EventPayload['file-added']>) => void>();
+    survivingProvider.addEventListener('file-added', survivingHandler);
+    disconnectingProvider.addEventListener('file-added', disconnectingHandler);
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+
+    // Both providers bridge the same ctx's EventBus before either disconnects.
+    await vi.waitFor(() => {
+      expect(survivingHandler).toHaveBeenCalledOnce();
+      expect(disconnectingHandler).toHaveBeenCalledOnce();
+    });
+
+    disconnectingProvider.remove();
+
+    api.addFileFromUrl(TEST_IMAGE_URL);
+
+    // Waiting on the surviving provider's second call proves the ctx's event
+    // bus has ticked past the point where the removed provider would have
+    // re-dispatched too, had its bridge not unsubscribed on disconnect.
+    await vi.waitFor(() => {
+      expect(survivingHandler).toHaveBeenCalledTimes(2);
+    });
+    expect(disconnectingHandler).toHaveBeenCalledOnce();
+  }, 30_000);
+
   it('keeps deriving upload events after an owner-candidate block is removed', async () => {
     const ctxName = getCtxName();
     page.render(


### PR DESCRIPTION
## What

Part 4 of the instance-creation migration — gives ctx creation a single controller-side seam and ports the first ctx-adjacent element off `SymbioteCompatMixin`.

- **`ensureUploaderCtx(ctxName)`** (new, `src/lit/ensureUploaderCtx.ts`): one idempotent entry point that creates the nanostores map with the full plain-state seeds, forces the `UploaderController` into existence, and registers it. `SymbioteCompatMixin._initSharedContext` now delegates to it — there is one map-creation path, reached from v1 blocks today and (later) from ported ctx-creators. The per-element `init$` first-write-wins loop stays for v1 extras (CIE's `ctxOwner` rewrite keys).
- **Upload-state write bridges moved to controller creation**: the 9 `*`-key read/write closures (`setCollectionErrors` + uploadEvents' 8) are now built in `PubSubCompat._uploader()`, closing over that ctx, and handed to `new UploaderController({ stateBridges })` — live from the controller's birth. `attachUploaderScope`'s deps shrink accordingly; `LitUploaderBlock.initCallback` no longer wires them.
- **`UploadCtxProvider` → `ChildBlock`**: event bridge fed by the adopted controller's EventBus (re-entrant-safe teardown), `getAPI()`/`.api` via `bag`.

## Design: the seam

The seeds are seeded uniformly for every ctx (the plain `*`-state keys are undocumented internals; instance-key presence — e.g. `ctx.has('*uploadCollection')` — is still element-gated, so the config-only pins are unaffected). `ctxOwner` rewrite semantics are preserved and now pinned (`PubSub.add` first-write-wins + force-overwrite). The controller is a per-ctx singleton, so forcing it earlier can only make it exist sooner, never mint a duplicate.

## Design: UCP's attach is load-bearing, not belt-and-suspenders

The plan assumed UCP could drop the uploader-scope attach because a solution is always co-mounted. That is **wrong**, and the port keeps the attach: the solution's own attach defers to its *first Lit render* (a microtask), while `getAPI()`/`.api` are documented to work right after mount. Stripping the attach was tried and **fails** the two-provider `upload-events-wiring` net with `*publicApi not available`. UCP's synchronous attach (idempotent, guarded — a no-op once a solution or sibling attaches first) preserves the exact v1 guarantee, where UCP was itself a `LitUploaderBlock`.

**Known follow-up (flagged in code + ledger):** UCP's `attachUploaderScope` deps mirror `LitUploaderBlock.initCallback`'s by hand (~40 lines). A shared `buildUploaderScopeDeps` extraction is queued; deferred here to keep this round tight.

## What still gates the rest of M9

Teardown ownership stays on `*blocksRegistry`-emptiness this slice (every composition still has a v1 block). Config, the solutions, and DropArea port in follow-on slices; the CloudImageEditor inner block family is a separate milestone (its own 16-key nanostores state needs an editor controller).

## Review process

Per-task reviews (opus on the seam + write-side); the UCP port was reconstructed and driven to green by the controller after the task implementer hit a spend limit mid-verification, and verified by counterfactual (strip → fail, restore → pass). A final whole-branch review follows.

## Gate

tsc:app clean · tsc (app+test+e2e+node) "No errors found" · build green (all size budgets held) · test:specs pass · test:locales clean (all locales) · test:e2e 49 files / 321 tests passed (no retries) · lint 0 errors (17 pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic creation and idempotent reuse of uploader/solution contexts with fully initialized shared state.
  * Enhanced the upload context provider’s public API and tied event/context wiring to the controller adoption lifecycle.
* **Bug Fixes**
  * Ensured `getOutputCollectionState()` returns the correct “idle” default immediately after composition.
  * Prevented disconnected upload context providers from receiving further upload events.
* **Tests**
  * Expanded coverage for context initialization, shared-state bridging, API idle-state behavior, and upload event cleanup after disconnect.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->