### PR TITLE
refactor(m9n): extract buildUploaderScopeDeps + fix AGENTS.md hierarchy (review follow-ups)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,8 +126,10 @@ tests/             Browser e2e (*.e2e.test.tsx)
 - **State:** one nanostores `MapStore` per `ctx-name` (`PubSubCompat`), reached
   through the `$` proxy and `sub`/`pub`/`read`/`cfg` on `SymbioteCompatMixin`.
   Flat string keys (`*cfg/<key>`, `*currentActivity`, `*uploadList`, …).
-- **Base classes:** `LitBlock` → `LitActivityBlock` → `LitUploaderBlock` →
-  `LitSolutionBlock`. Singleton managers (`ModalManager`, `EventEmitter`,
+- **Base classes:** `LitBlock` → `LitActivityBlock` → `LitUploaderBlock`;
+  `LitSolutionBlock` extends `LitBlock` directly (NOT `LitUploaderBlock`), so a
+  solution tag does not itself attach the uploader scope — the `<uc-drop-area>`
+  in its template does. Singleton managers (`ModalManager`, `EventEmitter`,
   `PluginManager`, `ValidationManager`, …) live in the shared store.
 - **Public JS API:** `element.getAPI()` → `UploaderPublicApi`. Events dispatch
   on `<uc-upload-ctx-provider>` (`EventType` in `EventEmitter.ts`).

--- a/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
+++ b/src/blocks/UploadCtxProvider/UploadCtxProvider.ts
@@ -1,16 +1,10 @@
-import { SecureUploadsController } from '../../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
-import { UploadController } from '../../abstract/controllers/UploadController';
-import { UploadEventsController } from '../../abstract/controllers/UploadEventsController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
-import { ValidationController } from '../../abstract/controllers/ValidationController';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
+import { buildUploaderScopeDeps } from '../../lit/buildUploaderScopeDeps';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { createDebugPrinter } from '../../lit/createDebugPrinter';
 import { EventBridgeController } from '../../lit/EventBridgeController';
-import { getOutputData } from '../../lit/getOutputData';
-import type { Uid } from '../../lit/Uid';
-import type { OutputCollectionState, OutputFileStatus } from '../../types/index';
 import { type EventPayload, EventType } from './EventEmitter';
 
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: This is intentional interface merging, used to add event listener types
@@ -71,9 +65,9 @@ export class UploadCtxProvider extends ChildBlock {
    * (first-write-wins + `attachUploaderScope`'s own gate), so this is a no-op
    * once a solution or a sibling provider has already attached.
    *
-   * NOTE: the `attachUploaderScope(...)` deps below intentionally mirror
-   * `LitUploaderBlock.initCallback`'s — the two are kept in sync by hand.
-   * Extracting a shared builder is a queued follow-up (see the M9n ledger).
+   * The `attachUploaderScope` deps come from the shared `buildUploaderScopeDeps`
+   * (one source of truth with `LitUploaderBlock.initCallback`); only `debug`
+   * and `emit` are host-specific.
    */
   private _attachUploaderScopeIfNeeded(ctrl: UploaderController): void {
     const ctx = this.bag.ctx;
@@ -88,27 +82,15 @@ export class UploadCtxProvider extends ChildBlock {
       ctx.add('*publicApi', api, true);
     }
 
-    ctrl.attachUploaderScope({
-      controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
-      debug: (...args) => this._debugPrint(...args),
-      getFileHooks: () => this.bag.pluginManager?.snapshot().fileHooks ?? [],
-      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => this.bag.api.getOutputItem<TStatus>(uid),
-      getApi: () => this.bag.api,
-      emitCommonUploadFailed: () => {
-        this.bag.eventEmitter.emit(
-          EventType.COMMON_UPLOAD_FAILED,
-          () => this.bag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-          { debounce: true },
-        );
-      },
-      // Same contract as `ChildBlock.emit`: EventEmitter dispatch + telemetry
-      // mirror, guarded for teardown races.
-      emit: (type, payload, options) => this.emit(type, payload, options),
-      getOutputCollectionState: () => this.bag.api.getOutputCollectionState(),
-      getOutputData: () => getOutputData(this.bag),
-      runOnAddHooks: (entry) =>
-        void this.bag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
-    });
+    ctrl.attachUploaderScope(
+      buildUploaderScopeDeps(
+        this.bag,
+        (...args) => this._debugPrint(...args),
+        // Same contract as `ChildBlock.emit`: EventEmitter dispatch + telemetry
+        // mirror, guarded for teardown races.
+        (type, payload, options) => this.emit(type, payload, options),
+      ),
+    );
 
     // Re-expose the controller-owned instances under their v1 shared-instance
     // keys (readers like `FileItem.bag.uploadController` expect them there).

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -1,22 +1,21 @@
 // @ts-check
 
 import { uploaderBlockCtx } from '../abstract/CTX';
-// Value imports on purpose: this element hands the four upload-stack
-// constructors to `UploaderController.attachUploaderScope` — the controller
-// itself only type-imports them, keeping editor-only bundles (which have no
-// `LitUploaderBlock`) free of `@uploadcare/upload-client` and friends.
-import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
+// The four upload-stack controllers are type-only here — the value imports (and
+// the bundle-size rationale) live in `buildUploaderScopeDeps`, which hands the
+// constructors to `attachUploaderScope`. These types are still needed for the
+// re-exposer getters below.
+import type { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
 import type { UploadCollectionController } from '../abstract/controllers/UploadCollectionController';
-import { UploadController } from '../abstract/controllers/UploadController';
-import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
-import { ValidationController } from '../abstract/controllers/ValidationController';
+import type { UploadController } from '../abstract/controllers/UploadController';
+import type { UploadEventsController } from '../abstract/controllers/UploadEventsController';
+import type { ValidationController } from '../abstract/controllers/ValidationController';
 import { UploaderPublicApi } from '../abstract/UploaderPublicApi';
-import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
-import type { OutputCollectionState, OutputFileEntry, OutputFileStatus } from '../types/index';
+import type { OutputFileEntry } from '../types/index';
 import { ExternalUploadSource, UploadSource } from '../utils/UploadSource';
+import { buildUploaderScopeDeps } from './buildUploaderScopeDeps';
 import { getOutputData } from './getOutputData';
 import { LitActivityBlock } from './LitActivityBlock';
-import type { Uid } from './Uid';
 
 export class LitUploaderBlock extends LitActivityBlock {
   public static extSrcList: Readonly<typeof ExternalUploadSource>;
@@ -64,41 +63,28 @@ export class LitUploaderBlock extends LitActivityBlock {
     // controller's birth, not from this element's `initCallback`.
     const uploader = this.sharedCtx.uploaderController();
     const ctx = this._sharedInstancesBag.ctx;
-    uploader.attachUploaderScope({
-      controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
-      debug: (...args) => this.debugPrint(...args),
-      getFileHooks: () => this._sharedInstancesBag.pluginManager?.snapshot().fileHooks ?? [],
-      getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) =>
-        this._sharedInstancesBag.api.getOutputItem<TStatus>(uid),
-      getApi: () => this._sharedInstancesBag.api,
-      emitCommonUploadFailed: () => {
-        this._sharedInstancesBag.eventEmitter.emit(
-          EventType.COMMON_UPLOAD_FAILED,
-          () => this._sharedInstancesBag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-          { debounce: true },
-        );
-      },
-      // Emit parity with LitBlock.emit: EventEmitter dispatch + telemetry
-      // mirror, guarded for teardown (emissions can race ctx destruction).
-      emit: (type, payload, options) => {
-        const eventEmitter = ctx.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
-        if (!eventEmitter) return;
-        eventEmitter.emit(type, payload, options);
-        const resolvedPayload = typeof payload === 'function' ? payload() : payload;
-        try {
-          this._sharedInstancesBag.telemetryManager.sendEvent({
-            eventType: type,
-            payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
-          });
-        } catch (err) {
-          this.debugPrint('telemetry unavailable for an upload event report', err);
-        }
-      },
-      getOutputCollectionState: () => this._sharedInstancesBag.api.getOutputCollectionState(),
-      getOutputData: () => getOutputData(this._sharedInstancesBag),
-      runOnAddHooks: (entry) =>
-        void this._sharedInstancesBag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
-    });
+    uploader.attachUploaderScope(
+      buildUploaderScopeDeps(
+        this._sharedInstancesBag,
+        (...args) => this.debugPrint(...args),
+        // Emit parity with LitBlock.emit: EventEmitter dispatch + telemetry
+        // mirror, guarded for teardown (emissions can race ctx destruction).
+        (type, payload, options) => {
+          const eventEmitter = ctx.has('*eventEmitter') ? ctx.read('*eventEmitter') : undefined;
+          if (!eventEmitter) return;
+          eventEmitter.emit(type, payload, options);
+          const resolvedPayload = typeof payload === 'function' ? payload() : payload;
+          try {
+            this._sharedInstancesBag.telemetryManager.sendEvent({
+              eventType: type,
+              payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
+            });
+          } catch (err) {
+            this.debugPrint('telemetry unavailable for an upload event report', err);
+          }
+        },
+      ),
+    );
 
     // The four are now controller-owned identity — these re-exposers just
     // let existing shared-instance readers (`this.secureUploadsManager`, …)

--- a/src/lit/buildUploaderScopeDeps.ts
+++ b/src/lit/buildUploaderScopeDeps.ts
@@ -1,0 +1,50 @@
+// Value imports on purpose: this builder hands the four upload-stack
+// constructors to `UploaderController.attachUploaderScope` — the controller
+// itself only type-imports them, keeping editor-only bundles (which import
+// neither this builder nor `LitUploaderBlock`) free of
+// `@uploadcare/upload-client` and friends.
+import { SecureUploadsController } from '../abstract/controllers/SecureUploadsController';
+import { UploadController } from '../abstract/controllers/UploadController';
+import { UploadEventsController } from '../abstract/controllers/UploadEventsController';
+import type { UploaderScopeDeps } from '../abstract/controllers/UploaderController';
+import { ValidationController } from '../abstract/controllers/ValidationController';
+import { EventType } from '../blocks/UploadCtxProvider/EventEmitter';
+import type { OutputCollectionState, OutputFileStatus } from '../types/index';
+import { getOutputData } from './getOutputData';
+import type { SharedInstancesBag } from './shared-instances';
+import type { Uid } from './Uid';
+
+/**
+ * Single source of truth for the `attachUploaderScope` deps that live on the
+ * DOM/PubSub side (resolved from the shared-instances `bag`). Both the v1
+ * `LitUploaderBlock` and the ported `UploadCtxProvider` build the identical
+ * bag-derived callbacks; only `debug` and `emit` differ per host and stay
+ * caller-supplied — `emit` in particular must keep each host's exact
+ * teardown-guard semantics (see `UploaderScopeDeps.emit`), so it is never
+ * derived here.
+ */
+export function buildUploaderScopeDeps(
+  bag: SharedInstancesBag,
+  debug: UploaderScopeDeps['debug'],
+  emit: UploaderScopeDeps['emit'],
+): UploaderScopeDeps {
+  return {
+    controllers: { SecureUploadsController, UploadController, ValidationController, UploadEventsController },
+    debug,
+    getFileHooks: () => bag.pluginManager?.snapshot().fileHooks ?? [],
+    getOutputItem: <TStatus extends OutputFileStatus>(uid: Uid) => bag.api.getOutputItem<TStatus>(uid),
+    getApi: () => bag.api,
+    emitCommonUploadFailed: () => {
+      bag.eventEmitter.emit(
+        EventType.COMMON_UPLOAD_FAILED,
+        () => bag.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
+        { debounce: true },
+      );
+    },
+    emit,
+    getOutputCollectionState: () => bag.api.getOutputCollectionState(),
+    getOutputData: () => getOutputData(bag),
+    runOnAddHooks: (entry) =>
+      void bag.wait('pluginManager').then((pluginManager) => pluginManager.runOnAddHooks(entry)),
+  };
+}


### PR DESCRIPTION
Two follow-ups flagged in the M9n whole-branch review (#1018), now cleared.

## `buildUploaderScopeDeps` extraction

`UploadCtxProvider._attachUploaderScopeIfNeeded` and `LitUploaderBlock.initCallback` built the **identical** bag-derived `attachUploaderScope` deps by hand (~40 lines each) — flagged as drift risk (two places to keep in sync). Extracted into `src/lit/buildUploaderScopeDeps.ts` as the single source of truth:

- `buildUploaderScopeDeps(bag, debug, emit)` returns the full `UploaderScopeDeps`.
- `debug` and `emit` stay **caller-supplied** — `emit` especially must keep each host's exact teardown-guard semantics (UCP delegates to `ChildBlock.emit`; `LitUploaderBlock` keeps its inline `ctx.has('*eventEmitter')`-guarded closure), so it is never derived in the builder.
- The four upload-stack controller **value imports move into the builder**. It's imported only by UCP + `LitUploaderBlock` (both uploader-bundle), so `@uploadcare/upload-client` still never reaches editor-only bundles — verified: `uc-cloud-image-editor.min.js` = **47.44 kB**, under the 50 kB budget (was 47.22). `LitUploaderBlock`'s own controller imports become type-only (still needed for the re-exposer getters).

## AGENTS.md hierarchy fix

The base-class note said `LitBlock → LitActivityBlock → LitUploaderBlock → LitSolutionBlock`, implying `LitSolutionBlock extends LitUploaderBlock`. It actually **extends `LitBlock` directly** — which is precisely why a solution tag doesn't attach the uploader scope itself (its `<uc-drop-area>` does), the timing the M9n UCP port depends on. Corrected.

## Gate

tsc:app · build (all size budgets held, editor bundle 47.44 kB) · tsc "No errors found" · test:types · test:specs · test:locales · e2e (upload-events-wiring, api, validation, instance-lifecycle, dynamic-btn-upload-list, file-uploader-regular — 69 tests) · lint — all green. Behavior-preserving refactor (no test changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected architecture documentation to clarify how solution blocks attach uploader functionality.

* **Refactor**
  * Unified uploader-scope setup across supported upload components.
  * Improved consistency of upload events, hooks, output handling, and error reporting.
  * Preserved existing uploader behavior while simplifying internal configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->