### PR TITLE
feat(m9q): register controller-owned ctx-scope keys in the ctx seam

### DIFF
--- a/src/lit/ensureUploaderCtx.test.ts
+++ b/src/lit/ensureUploaderCtx.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { UploaderController } from '../abstract/controllers/UploaderController';
+import { localeStateKey } from '../abstract/managers/LocaleManager';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import { ensureUploaderCtx } from './ensureUploaderCtx';
 import { PubSub } from './PubSubCompat';
@@ -42,13 +43,33 @@ describe('ensureUploaderCtx', () => {
     expect(ctx.read('*lazyPlugins')).toBeNull();
   });
 
-  it('does NOT seed any instance key — those stay element-gated (re-exposer registration)', () => {
+  it('seeds the six controller-owned re-exposer keys, but not the v1-element-gated ones (M9q Task 2)', () => {
+    const ctxName = freshCtxName();
+    const ctx = ensureUploaderCtx(ctxName);
+    const controller = UploaderRegistry.get(ctxName)!;
+
+    // The six keys this seam now registers itself — identity-pinned against
+    // the controller's own instances, same recipe as `LitBlock`'s re-exposers.
+    expect(ctx.read('*eventEmitter')).toBe(controller.eventEmitter);
+    expect(ctx.read('*localeManager')).toBe(controller.localeManager);
+    expect(ctx.read('*a11y')).toBe(controller.a11y);
+    expect(ctx.read('*router')).toBe(controller.router);
+    expect(ctx.read('*clipboard')).toBe(controller.clipboard);
+    expect(ctx.read('*telemetryManager')).toBe(controller.telemetryManager);
+
+    // Still v1-element-gated — never registered by this v1-free seam.
+    expect(ctx.has('*pluginManager')).toBe(false);
+    expect(ctx.has('*blocksRegistry')).toBe(false);
+    expect(ctx.has('*uploadCollection')).toBe(false);
+  });
+
+  it('activates LocaleManager with a null plugin manager (no *pluginManager registered in this v1-free seam)', () => {
     const ctxName = freshCtxName();
     const ctx = ensureUploaderCtx(ctxName);
 
-    expect(ctx.has('*uploadCollection')).toBe(false);
-    expect(ctx.has('*eventEmitter')).toBe(false);
-    expect(ctx.has('*a11y')).toBe(false);
+    // `LocaleManager.activate` seeds the `en` dictionary unconditionally —
+    // proves `activate` actually ran, not just that the manager exists.
+    expect(ctx.read(localeStateKey('upload-file'))).toBe('Upload file');
   });
 
   it('forces the UploaderController into existence immediately, not lazily on first *cfg/*l10n touch', () => {

--- a/src/lit/ensureUploaderCtx.ts
+++ b/src/lit/ensureUploaderCtx.ts
@@ -1,6 +1,7 @@
 import { solutionBlockCtx } from '../abstract/CTX';
 import { PubSub } from './PubSubCompat';
 import type { SharedState } from './SharedState';
+import { addCtxSharedInstance } from './shared-instances';
 
 /**
  * The one controller-side entry point that creates a per-ctx nanostores map.
@@ -13,10 +14,12 @@ import type { SharedState } from './SharedState';
  * state (`blockCtx` + `uploaderBlockCtx` + `solutionBlockCtx` from
  * `abstract/CTX.ts` — `*commonProgress`, `*uploadList`, `*collectionErrors`,
  * `*collectionState`, `*groupInfo`, `*uploadTrigger`, `*lazyPlugins`) and
- * nothing else: no instance keys (`*eventEmitter`, `*uploadCollection`, …) —
- * those stay element-gated, registered by `LitBlock`/`LitUploaderBlock`
- * `initCallback` re-exposers, same as before this seam existed. It then
- * forces the ctx's `UploaderController` into existence immediately, instead
+ * nothing else instance-wise beyond the six controller-owned keys documented
+ * below: `*pluginManager`/`*blocksRegistry`/the uploader-scope keys
+ * (`*uploadCollection`, …) stay element-gated, registered by
+ * `LitBlock`/`LitUploaderBlock` `initCallback` re-exposers, same as before
+ * this seam existed. It then forces the ctx's `UploaderController` into
+ * existence immediately, instead
  * of lazily on first `*cfg/*`/`*l10n/*` touch (`PubSubCompat`'s previous
  * sole creation path) — this is the whole point of the seam: the controller
  * now exists the moment the ctx does, even pre-any-element.
@@ -24,6 +27,17 @@ import type { SharedState } from './SharedState';
  * A fresh seed object is built per call (not hoisted to a module constant):
  * `uploaderBlockCtx`'s `*uploadTrigger` is a `Set` instance, so a shared seed
  * object would leak that Set across unrelated ctxs.
+ *
+ * It also registers the six controller-owned ctx-scope re-exposer keys
+ * (`*eventEmitter`, `*localeManager`, `*a11y`, `*router`, `*clipboard`,
+ * `*telemetryManager`) and activates `LocaleManager` (M9q Task 2) — the same
+ * work `LitBlock.initCallback` does, but reachable with no `LitBlock` in the
+ * composition at all (a pure `ChildBlock` tree). `addCtxSharedInstance` is
+ * first-write-wins, so a `LitBlock` sharing the same ctx later is a no-op for
+ * these six keys (both resolvers produce the identical `controller.X`
+ * instance). `*pluginManager`/`*blocksRegistry`/the uploader-scope keys
+ * (`*publicApi`/`*uploadCollection`/upload stack) stay v1-element-gated, not
+ * registered here.
  *
  * `SymbioteCompatMixin._initSharedContext` delegates map acquisition to this
  * function; it still runs its own per-key `add(key, value, this.ctxOwner)`
@@ -48,6 +62,30 @@ export function ensureUploaderCtx(ctxName: string): PubSub<SharedState> {
   // the moment the ctx does (so `ChildBlock`s never wait forever on
   // `UploaderRegistry`). `uploaderController()` is idempotent: it returns the
   // registered controller or creates+registers one.
-  ctx.uploaderController();
+  const controller = ctx.uploaderController();
+
+  // Re-expose the six controller-owned managers under their v1 shared-
+  // instance keys — first-write-wins (see `addCtxSharedInstance`'s doc), so
+  // this is a no-op on every subsequent call, and inert once/if a `LitBlock`
+  // sharing this ctx runs its own (identical) `initCallback` registrations.
+  addCtxSharedInstance(ctx, '*eventEmitter', () => controller.eventEmitter);
+  addCtxSharedInstance(ctx, '*localeManager', () => controller.localeManager);
+  addCtxSharedInstance(ctx, '*a11y', () => controller.a11y);
+  addCtxSharedInstance(ctx, '*router', () => controller.router);
+  addCtxSharedInstance(ctx, '*clipboard', () => controller.clipboard);
+  addCtxSharedInstance(ctx, '*telemetryManager', () => controller.telemetryManager);
+
+  // Run `LocaleManager`'s deferred construction-time work (seed the `en`
+  // dictionary, subscribe to `localeName`/`localeDefinitionOverride`) here,
+  // same as `LitBlock.initCallback` does for the v1 path. No `*pluginManager`
+  // is registered by this v1-free seam, so pass `null` — `LocaleManager.
+  // activate` tolerates a null plugin manager (seeds the dictionary + core
+  // subscriptions unconditionally, just skips the plugin-locale coupling).
+  // If a v1 `LitBlock` later joins this ctx and constructs a real
+  // `*pluginManager`, its own `initCallback` calls `activate` again with it —
+  // idempotent re-coupling, same recipe `LocaleManager.activate` already
+  // guarantees for a second v1 block sharing a ctx.
+  controller.localeManager.activate(ctx.has('*pluginManager') ? ctx.read('*pluginManager') : null);
+
   return ctx;
 }

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -167,6 +167,51 @@ export const getSharedInstance = <TKey extends keyof SharedInstancesState, TRequ
   throw new Error(`Unexpected error: shared instance for key "${String(key)}" is not available`);
 };
 
+/**
+ * Ctx-scope equivalent of `LitBlock._addSharedContextInstance` (M9q Task 2).
+ *
+ * `_addSharedContextInstance` is a `LitBlock` instance method — it needs an
+ * element to call `this.add`/`this.has`/`this.$` on. `ensureUploaderCtx` (the
+ * `ChildBlock` self-bootstrap seam) has no element, only the ctx itself — but
+ * `PubSub`'s `add`/`has`/`read` are the exact same primitives `this.add`/
+ * `this.has`/`this.$[key]` write through to (see `ctx-lifecycle.ts`'s doc on
+ * `*sharedContextInstances` being ctx-scoped, not element-instance-scoped), so
+ * this helper reimplements the identical first-write-wins recipe directly
+ * against a `PubSub<SharedState>` ctx, with no element/bag required.
+ *
+ * Registering into the SAME `*sharedContextInstances` map is what makes this
+ * compose with teardown for free: `destroyCtx` (`ctx-lifecycle.ts`) already
+ * pub-nulls every entry in that map and skips `.destroy()` for
+ * `controllerOwnedInstanceKeys` members — it has no idea (and needs no idea)
+ * whether an entry was registered by a `LitBlock` or by this helper.
+ *
+ * First-write-wins (via the `instances.has(key)` check) also means calling
+ * this from `ensureUploaderCtx` on every ctx access, and later from a v1
+ * `LitBlock.initCallback` sharing the same ctx, is inert after the first
+ * call — both resolvers produce the exact same `controller.X` instance
+ * anyway, so which one "wins" is irrelevant.
+ */
+export function addCtxSharedInstance<TKey extends keyof SharedInstancesState>(
+  ctx: PubSub<SharedState>,
+  key: TKey,
+  resolver: (ctx: PubSub<SharedState>) => NonNullable<SharedInstancesState[TKey]>,
+): void {
+  const instancesKey = '*sharedContextInstances';
+  let instances: Map<string, ISharedInstance> | undefined = ctx.has(instancesKey) ? ctx.read(instancesKey) : undefined;
+  if (!instances) {
+    instances = new Map<string, ISharedInstance>();
+    ctx.add(instancesKey, instances, true);
+  }
+  if (instances.has(key)) {
+    return;
+  }
+  if (!ctx.has(key) || !ctx.read(key)) {
+    const instance = resolver(ctx);
+    ctx.add(key, instance, true);
+    instances.set(key, instance as ISharedInstance);
+  }
+}
+
 export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
   return {
     get ctx(): PubSub<SharedState> {

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -1,6 +1,7 @@
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { UploadEventsController } from '@/abstract/controllers/UploadEventsController';
+import { localeStateKey } from '@/abstract/managers/LocaleManager';
 import { TelemetryManager } from '@/abstract/managers/TelemetryManager';
 import type { Config, UploadCtxProvider } from '@/index.js';
 import { PubSub } from '@/lit/PubSubCompat';
@@ -331,6 +332,103 @@ describe('instance lifecycle (attachUploaderScope idempotency across two LitUplo
     } finally {
       observeSpy.mockRestore();
     }
+  });
+});
+
+/**
+ * M9q pins (RED ahead of the seam fix). M9k/M9l moved six managers'
+ * *construction* onto `UploaderController`, but their ctx-scope KEY
+ * registration (`_addSharedContextInstance('*router', …)` etc.) plus
+ * `LocaleManager.activate` still live on `LitBlock.initCallback` only.
+ * `ensureUploaderCtx` (the `ChildBlock` self-bootstrap path, M9o) forces the
+ * controller into existence but registers NO instance keys — so a
+ * ChildBlock-only composition (no v1 block anywhere) has a controller with
+ * all six managers constructed, yet `bag.router`/`ctx.read('*router')`/etc.
+ * still throw "shared instance … not available", and the locale dictionary
+ * is never seeded (`LocaleManager.activate` never runs). These pins fail
+ * RED today and must go green once M9q registers the keys (+ runs
+ * `activate`) from the ctx-scope seam itself, not `LitBlock`.
+ */
+describe('instance lifecycle (M9q ChildBlock-only ctx-scope keys)', () => {
+  it('a ChildBlock-only ctx (no v1 block anywhere) resolves all six controller-owned ctx-scope keys after adoption', async () => {
+    const ctxName = getCtxName();
+    // `uc-copyright` is a pure-consumer ported `ChildBlock` — no `uc-config`,
+    // no solution tag, no `uc-drop-area`: nothing v1 in this composition.
+    page.render(<uc-copyright ctx-name={ctxName}></uc-copyright>);
+
+    await expect.element(page.getByText('Powered by Uploadcare', { exact: true })).toBeVisible();
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+
+    const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+    const controller = ctx.uploaderController();
+
+    // RED today: none of these keys were ever registered by anything in a
+    // v1-free composition — `ensureUploaderCtx` only forces the controller,
+    // it registers no `*`-keys, and no `LitBlock.initCallback` ran.
+    expect(ctx.has('*router')).toBe(true);
+    expect(ctx.has('*eventEmitter')).toBe(true);
+    expect(ctx.has('*localeManager')).toBe(true);
+    expect(ctx.has('*a11y')).toBe(true);
+    expect(ctx.has('*clipboard')).toBe(true);
+    expect(ctx.has('*telemetryManager')).toBe(true);
+
+    // Identity, not just presence: the re-exposed key must be the exact
+    // instance the controller itself owns (same recipe as the M9l
+    // identity-pin test above), not some re-shadowed duplicate.
+    expect(ctx.read('*router')).toBe(controller.router);
+    expect(ctx.read('*eventEmitter')).toBe(controller.eventEmitter);
+    expect(ctx.read('*localeManager')).toBe(controller.localeManager);
+    expect(ctx.read('*a11y')).toBe(controller.a11y);
+    expect(ctx.read('*clipboard')).toBe(controller.clipboard);
+    expect(ctx.read('*telemetryManager')).toBe(controller.telemetryManager);
+
+    // `l10n` resolves a real dictionary entry — proves `LocaleManager.
+    // activate` actually ran (seeded the `en` dictionary), not just that the
+    // manager instance exists. RED today: `activate` is only ever called
+    // from `LitBlock.initCallback`, which never runs here.
+    expect(ctx.read(localeStateKey('upload-file'))).toBe('Upload file');
+  });
+
+  it('the same ChildBlock-only ctx tears down cleanly once the block disconnects (M9o refcount, no double-destroy)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-copyright ctx-name={ctxName}></uc-copyright>);
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+
+    const errors: string[] = [];
+    const onError = (event: ErrorEvent) => {
+      errors.push(String(event.error?.message ?? event.message));
+      event.preventDefault();
+    };
+    window.addEventListener('error', onError);
+    try {
+      cleanup();
+      // The deferred (`setTimeout(0)`) consumer-refcount check needs a real
+      // macrotask flush before `isCtxUnreferenced` re-evaluates.
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+    } finally {
+      window.removeEventListener('error', onError);
+    }
+    expect(errors).toEqual([]);
+  });
+
+  it('inert under v1: a normal composition is unchanged — one `*router` instance, identical to the controller’s', async () => {
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+        <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+      </>,
+    );
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+    const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+    const controller = ctx.uploaderController();
+
+    expect(ctx.read('*router')).toBe(controller.router);
+    expect(ctx.read(localeStateKey('upload-file'))).toBe('Upload file');
+
+    cleanup();
+    await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
   });
 });
 


### PR DESCRIPTION
Prerequisite that unblocks the ctx-creator ports (M9p Config, then solutions/DropArea): makes a ChildBlock-only composition (no v1 `LitBlock`) able to resolve the controller-owned ctx-scope shared-instance keys.

## The gap
M9k/M9l moved the six managers' *instances* onto `UploaderController` but left their ctx-scope *key registration* (`_addSharedContextInstance('*router', () => ctx.uploaderController().router)` re-exposers) on `LitBlock.initCallback`. `ensureUploaderCtx` forces the controller but registered no instance keys — so a ChildBlock-only ctx had the controller (with all six managers) yet none of the `*`-keys, and `bag.router`/`emit`/`l10n` threw `shared instance … not available`. Surfaced by the M9p Config port (many ChildBlock unit-e2e fixtures render `<uc-config>` alone).

## What
`ensureUploaderCtx` now, after forcing the controller, registers the six controller-owned re-exposer keys — `*eventEmitter`, `*localeManager`, `*a11y`, `*router`, `*clipboard`, `*telemetryManager` (→ `controller.X`) — via a new `addCtxSharedInstance` (the `_addSharedContextInstance` first-write-wins recipe reimplemented against `PubSub`, no element needed), and calls `controller.localeManager.activate(null)` to seed the locale. `LitBlock.initCallback` keeps its registrations (transitional dual-path): registration is first-write-wins, and the instance is `controller.X` either way, so every existing v1 composition is byte-identical (inert-under-v1).

## Not moved (by design)
`*pluginManager` (LitBlock-constructed — needs PubSub ctx/`*publicApi`; a config-only composition genuinely has no plugins), `*blocksRegistry` (M9o consumer-refcount handles ChildBlock-only teardown), and the uploader-scope keys (`*publicApi`/`*uploadCollection`/upload stack — need an uploader block, as always).

## Teardown composition (verified)
The six keys register into the same `*sharedContextInstances` map `destroyCtx` consults; being in `controllerOwnedInstanceKeys` they're pub-nulled once but skipped from `.destroy()` — `controller.destroy()` destroys them once. `deleteCtx`'s sync ordering is untouched (zero changes to `ctx-lifecycle.ts`/`LitBlock.ts`/`LocaleManager.ts`). `activate(null)` seeds core l10n and is idempotent when a LitBlock later calls `activate(realPluginManager)`.

## Verification
Coverage-first (RED pin → green); opus-reviewed (teardown no-double-destroy, first-write-wins/inert-under-v1, activate idempotency, contract-change test all confirmed). Gate: tsc:app · build · tsc "No errors found" · test:types · test:specs 57f/673t · test:locales · **full test:e2e 49f/335t (0 failed)** · lint 0 errors.

## Unblocks
M9p Config port rebases on top (its config-only fixtures now pass); then solutions/DropArea. The last ctx-creator retires the v1 `blocksRegistry`/`LitBlock.initCallback` path (M11), when `*pluginManager` construction must also move controller-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LXrEHLXS2T9pPAoWLGcQgC


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Shared controller services are now available in contexts without a traditional v1 block.
  * Locale data is activated and seeded earlier, including the “Upload file” translation.
  * Context setup preserves the controller-owned instances for routing, events, accessibility, clipboard, telemetry, and localization.

* **Bug Fixes**
  * Improved cleanup when child-only compositions disconnect.
  * Prevented duplicate shared service instances during composition setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->