### PR TITLE
refactor(m9p): port uc-config off SymbioteCompatMixin to ChildBlock

### DIFF
--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -1,12 +1,13 @@
 // @ts-check
+import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { CustomConfig } from '../../abstract/customConfigOptions';
 import type { PluginController } from '../../abstract/managers/plugin';
-import { sharedConfigKey } from '../../abstract/sharedConfigKey';
 import type { ConfigComplexType, ConfigPlainType, ConfigType } from '../../types';
 import { toKebabCase } from '../../utils/toKebabCase';
 import { runAssertions } from './assertions';
 import './config.css';
-import { LitBlock } from '../../lit/LitBlock';
+import { ChildBlock } from '../../lit/ChildBlock';
+import { createDebugPrinter } from '../../lit/createDebugPrinter';
 import { type ComputedPropertyControllers, computeProperty } from './computed-properties';
 import { initialConfig } from './initialConfig';
 import { normalizeConfigValue } from './normalizeConfigValue';
@@ -49,17 +50,13 @@ const builtinAttrKeyMapping: Record<string, keyof ConfigPlainType> = {
 const getLocalPropName = (key: string) => `__${key}`;
 
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: This is intentional interface merging, used to add configuration setters/getters
-export class Config extends LitBlock {
+export class Config extends ChildBlock {
   public declare attributesMeta: Partial<ConfigPlainType> & {
     'ctx-name': string;
   };
 
-  public override init$ = {
-    ...this.init$,
-    ...Object.fromEntries(
-      Object.entries(initialConfig).map(([key, value]) => [sharedConfigKey(key as keyof ConfigType), value]),
-    ),
-  } as unknown as LitBlock['init$'] & ConfigType;
+  /** Same contract as v1 `LitBlock.debugPrint` (`createDebugPrinter`), scoped to this ctx. */
+  private _debugPrint = createDebugPrinter(() => this.bag.ctx, this.constructor.name);
 
   private _computationControllers: ComputedPropertyControllers = new Map();
   private _pluginChangeUnsubscribe?: () => void;
@@ -92,7 +89,7 @@ export class Config extends LitBlock {
    * Get the custom config definition for a key
    */
   private _getCustomConfigDefinition(key: string) {
-    const pluginManager = this._sharedInstancesBag.pluginManager;
+    const pluginManager = this.bag.pluginManager;
     if (!pluginManager) return undefined;
     return pluginManager.configRegistry.get(key);
   }
@@ -131,16 +128,26 @@ export class Config extends LitBlock {
   }
 
   private _flushValueToState(key: string, value: unknown) {
-    const stateKey = sharedConfigKey(key as keyof ConfigType);
-    if (this.$[stateKey] !== value) {
+    const isCustom = this._isCustomConfig(key);
+    const configKey = key as keyof ConfigType;
+    const currentValue = isCustom ? this.uploader.config.getCustom(key) : this.uploader.config.get(configKey);
+
+    if (currentValue !== value) {
       if (typeof value === 'undefined' || value === null) {
         // For built-in configs, use initial value; for custom configs, keep undefined
-        const defaultValue = initialConfig[key as keyof ConfigType];
-        // @ts-expect-error
-        this.$[stateKey] = defaultValue !== undefined ? defaultValue : value;
+        const defaultValue = initialConfig[configKey];
+        const nextValue = defaultValue !== undefined ? defaultValue : value;
+        if (isCustom) {
+          this.uploader.config.setCustom(key, nextValue);
+        } else {
+          this.uploader.config.set(configKey, nextValue as ConfigType[typeof configKey]);
+        }
       } else {
-        // @ts-expect-error
-        this.$[stateKey] = value;
+        if (isCustom) {
+          this.uploader.config.setCustom(key, value);
+        } else {
+          this.uploader.config.set(configKey, value as ConfigType[typeof configKey]);
+        }
       }
     }
   }
@@ -177,22 +184,27 @@ export class Config extends LitBlock {
     this._flushValueToAttribute(key, normalizedValue);
     this._flushValueToState(key, normalizedValue);
 
-    this.debugPrint(`"${key}"`, normalizedValue);
+    this._debugPrint(`"${key}"`, normalizedValue);
 
     // Only run assertions for built-in configs
     if (!this._isCustomConfig(key)) {
-      runAssertions(this.cfg);
+      runAssertions(this.uploader.config.values);
     }
   }
 
   private _getValue(key: string) {
     const anyThis = this as any;
     const localPropName = getLocalPropName(key);
-    return anyThis[localPropName] ?? this.$[sharedConfigKey(key as keyof ConfigType)];
+    return (
+      anyThis[localPropName] ??
+      (this._isCustomConfig(key)
+        ? this.uploader.config.getCustom(key)
+        : this.uploader.config.get(key as keyof ConfigType))
+    );
   }
 
   private _assertSameValueDifferentReference(key: string, previousValue: unknown, nextValue: unknown) {
-    if (this.cfg.debug) {
+    if (this.uploader.config.values.debug) {
       if (
         nextValue !== previousValue &&
         typeof nextValue === 'object' &&
@@ -227,9 +239,6 @@ export class Config extends LitBlock {
     }
 
     for (const [name, definition] of customConfigs) {
-      const configKey = name as keyof CustomConfig;
-      const stateKey = sharedConfigKey(configKey as keyof ConfigType);
-
       // Build attribute name mappings (kebab-case and lowercase)
       // Add to mapping unless attribute is explicitly disabled (default is true)
       if (definition.attribute) {
@@ -268,10 +277,12 @@ export class Config extends LitBlock {
         }
       }
 
-      // Set initial value in state if not already set
-      if (!this.sharedCtx.has(stateKey)) {
-        this.sharedCtx.add(stateKey, definition.defaultValue);
-      }
+      // No separate state seeding here: `buildPluginApi`'s `registerConfig`
+      // already seeded this key on the ctx's `ConfigController` (via
+      // `ConfigController.register`) at plugin-setup time, before this
+      // definition could ever appear in `configRegistry.getAll()`. The
+      // registry lookup below is used only for adapter metadata (attribute
+      // mapping, `fromAttribute`/`normalize`), not to re-seed state.
 
       // Create property accessor (getter/setter) if not already defined
       const descriptor = Object.getOwnPropertyDescriptor(this, name);
@@ -292,27 +303,36 @@ export class Config extends LitBlock {
 
       // Subscribe to state changes (only if not already subscribed)
       if (!this._customConfigSubscriptions.has(name)) {
-        const unsub = this.sub(
-          stateKey,
-          (value) => {
+        // Manual per-key dedup over the coarse `ConfigController.subscribe`
+        // notification — same contract as v1's `this.sub(stateKey, cb, false)`
+        // (init=false: no immediate call, only on subsequent changes).
+        let lastValue = this.uploader.config.getCustom(name);
+        const unsub = this.uploader.config.subscribe(() => {
+          const nextValue = this.uploader.config.getCustom(name);
+          if (!Object.is(nextValue, lastValue)) {
+            lastValue = nextValue;
             // Use _setValue for consistent handling (matches built-in config pattern)
             // The early return guard in _setValue prevents circular updates
-            this._setValue(name, value);
-          },
-          false,
-        );
+            this._setValue(name, nextValue);
+          }
+        });
         this._customConfigSubscriptions.set(name, unsub);
+        this.trackSub(unsub);
       }
 
       if (hasPreExistingValue) {
         this._setValue(name, preExistingValue);
+        // Same re-adoption hazard as the built-in `allConfigKeys` loop above:
+        // force the flush through in case `_setValue`'s local-cache dedup
+        // no-op'd against a value already cached from a previous ctx.
+        this._flushValueToState(name, this._getValue(name));
       }
     }
   }
 
   private _setupCustomConfigs(): void {
     // Use when API to ensure pluginManager is available before setting up custom configs
-    this._sharedInstancesBag.when('pluginManager', (pluginManager) => {
+    this.bag.when('pluginManager', (pluginManager) => {
       // Initial setup
       this._processCustomConfigs(pluginManager);
 
@@ -361,26 +381,56 @@ export class Config extends LitBlock {
     });
   }
 
-  public override initCallback(): void {
-    super.initCallback();
+  /**
+   * Fires on every controller adoption — the initial one and any re-adoption
+   * (ctx-name switch, or ctx death + re-adopt on a v1-managed ctx). All
+   * subscriptions below route through `trackSub` (or the manual
+   * `ConfigController.subscribe` + dedup, tracked the same way) so a
+   * re-adoption tears the previous cycle's subscriptions down instead of
+   * stacking a second set on top. The plugin-change listener and the
+   * MutationObserver are host/DOM-level and not covered by `trackSub` — see
+   * the teardown-before-resubscribe below and the idempotent guard,
+   * respectively.
+   */
+  protected override controllerReady(_ctrl: UploaderController): void {
     const anyThis = this as any;
 
-    // Setup custom configs first
+    // Setup custom configs first. Tear down the previous cycle's
+    // plugin-change subscription before resubscribing — otherwise a
+    // re-adoption would stack a second `onPluginsChange` listener on top of
+    // one still bound to the previously-adopted controller's plugin manager
+    // (mirrors `UploadCtxProvider`'s `EventBridgeController` teardown-first
+    // pattern for the same re-adoption hazard).
+    if (this._pluginChangeUnsubscribe) {
+      this._pluginChangeUnsubscribe();
+      this._pluginChangeUnsubscribe = undefined;
+    }
     this._setupCustomConfigs();
 
-    // Setup MutationObserver to detect dynamic attribute changes
-    this._setupMutationObserver();
+    // Setup MutationObserver to detect dynamic attribute changes. This
+    // observes the DOM node itself, not the controller/ctx, so it must only
+    // be created once per element lifetime — re-adoption must not stack a
+    // second observer on the same node.
+    if (!this._mutationObserver) {
+      this._setupMutationObserver();
+    }
 
     // Subscribe to the state changes and update the local properties and attributes.
     // Initial callback call is disabled to prevent the initial value to be set here.
     // Initial value will be set below, skipping the default values.
+    // `trackSub` (not `subConfigValue`, which fires init=true) preserves the
+    // manual per-key dedup over the coarse `ConfigController.subscribe`
+    // notification, and ties teardown to controller release/re-adoption.
     for (const key of plainConfigKeys) {
-      this.sub(
-        sharedConfigKey(key),
-        (value) => {
-          this._setValue(key, value);
-        },
-        false,
+      let lastValue = this.uploader.config.get(key);
+      this.trackSub(
+        this.uploader.config.subscribe(() => {
+          const nextValue = this.uploader.config.get(key);
+          if (!Object.is(nextValue, lastValue)) {
+            lastValue = nextValue;
+            this._setValue(key, nextValue);
+          }
+        }),
       );
     }
 
@@ -388,9 +438,17 @@ export class Config extends LitBlock {
       // Flush the initial value to the state.
       // Initial value is taken from the DOM property if it was set before the element was initialized.
       // If no DOM property was set, the initial value is taken from the initialConfig.
-      const initialValue = anyThis[key] ?? this.$[sharedConfigKey(key)];
+      const initialValue = anyThis[key] ?? this.uploader.config.get(key);
       if (initialValue !== initialConfig[key]) {
         this._setValue(key, initialValue);
+        // `_setValue`'s no-op guard (skip when the local property cache
+        // already equals the normalized value) exists to avoid redundant
+        // local writes — it must not also skip seeding a *freshly-adopted*
+        // controller's state on re-adoption (ctx-name switch), whose
+        // `ConfigController` starts from `initialConfig` regardless of what
+        // this element's local cache already holds. Force the flush using
+        // the now-current (possibly already-cached) normalized value.
+        this._flushValueToState(key, anyThis[getLocalPropName(key)]);
       }
 
       // Define DOM property setters and getters
@@ -419,8 +477,27 @@ export class Config extends LitBlock {
     };
 
     for (const key of allConfigKeys) {
-      this.sub(sharedConfigKey(key), () => runComputeProperty(key));
+      this.subConfigValue(key, () => runComputeProperty(key));
     }
+  }
+
+  /**
+   * Release counterpart of `controllerReady` (disconnect, or a scope switch
+   * that drops the controller ahead of a re-adopt). Tears down the
+   * plugin-change subscription (idempotent — already-cleared is a no-op) and
+   * clears the custom-config bookkeeping so a subsequent `controllerReady`
+   * (re-adoption onto a different ctx) starts subscribing fresh instead of
+   * skipping names it thinks are already subscribed on a now-defunct
+   * controller's `ConfigController`. The `trackSub`-registered subscriptions
+   * themselves are already torn down by `ChildBlock._releaseController`
+   * before this hook runs.
+   */
+  protected override controllerReleased(): void {
+    if (this._pluginChangeUnsubscribe) {
+      this._pluginChangeUnsubscribe();
+      this._pluginChangeUnsubscribe = undefined;
+    }
+    this._customConfigSubscriptions.clear();
   }
 
   public override attributeChangedCallback(name: string, oldVal: string, newVal: string) {
@@ -433,7 +510,7 @@ export class Config extends LitBlock {
 
     // Handle built-in config attributes
     if (builtInKey) {
-      // attributeChangedCallback could be called before the initCallback
+      // attributeChangedCallback could be called before the controller is adopted
       // so we set the DOM property instead of calling this._setValue.
       // If the block was initialized, the value will be handled by the setter.
       // If the block was not initialized, the value will be set to the DOM property
@@ -442,7 +519,7 @@ export class Config extends LitBlock {
     } else {
       // Handle custom config attributes (registered by plugins)
       // This runs asynchronously once pluginManager is available
-      this._sharedInstancesBag.when('pluginManager', (pluginManager) => {
+      this.bag.when('pluginManager', (pluginManager) => {
         const currentAttrValue = this.getAttribute(name);
         if (currentAttrValue && currentAttrValue !== newVal) {
           return;
@@ -463,7 +540,8 @@ export class Config extends LitBlock {
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
 
-    // Clean up plugin change subscription
+    // Clean up plugin change subscription (already cleared in most cases by
+    // `controllerReleased`, above — this is a defensive no-op then).
     if (this._pluginChangeUnsubscribe) {
       this._pluginChangeUnsubscribe();
       this._pluginChangeUnsubscribe = undefined;

--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -8,6 +8,7 @@ import { runAssertions } from './assertions';
 import './config.css';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { createDebugPrinter } from '../../lit/createDebugPrinter';
+import { PubSub } from '../../lit/PubSubCompat';
 import { type ComputedPropertyControllers, computeProperty } from './computed-properties';
 import { initialConfig } from './initialConfig';
 import { normalizeConfigValue } from './normalizeConfigValue';
@@ -517,8 +518,22 @@ export class Config extends ChildBlock {
       // and handled on initialization.
       anyThis[builtInKey] = newVal;
     } else {
-      // Handle custom config attributes (registered by plugins)
-      // This runs asynchronously once pluginManager is available
+      // Handle custom config attributes (registered by plugins).
+      //
+      // `attributeChangedCallback` can fire before the ctx `this.bag` resolves
+      // against exists — during custom-element upgrade (no ctx yet), OR on a
+      // live `ctx-name` switch (still adopted to the OLD controller, but `bag`
+      // now targets the NEW `effectiveCtxName` whose ctx isn't created yet).
+      // In either case touching `this.bag` throws synchronously (`bag.when` →
+      // `_requireCtx` → "shared context is not initialized yet") and aborts
+      // init. Guard on the EXACT condition `_requireCtx` checks —
+      // `PubSub.getCtx(effectiveCtxName)` — not adoption state, and defer: the
+      // value is on the DOM attribute and `controllerReady` →
+      // `_setupCustomConfigs` → `_processCustomConfigs` reads pre-existing
+      // attribute values on adoption (matching v1's deferral).
+      if (!this.effectiveCtxName || !PubSub.getCtx(this.effectiveCtxName)) {
+        return;
+      }
       this.bag.when('pluginManager', (pluginManager) => {
         const currentAttrValue = this.getAttribute(name);
         if (currentAttrValue && currentAttrValue !== newVal) {

--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -90,7 +90,13 @@ export class Config extends ChildBlock {
    * Get the custom config definition for a key
    */
   private _getCustomConfigDefinition(key: string) {
-    const pluginManager = this.bag.pluginManager;
+    // Read null-tolerantly: `bag.pluginManager` throws when `*pluginManager`
+    // is absent (config-only / plugin-less ctx), and this helper is reachable
+    // with a stale `_customConfigKeys`/`_customAttrKeyMapping` — e.g. the
+    // MutationObserver forwards a custom attribute during a live `ctx-name`
+    // switch, before `attributeChangedCallback` reaches its own guard, or after
+    // a re-adoption into a ctx that has no plugin manager.
+    const pluginManager = this.bag.pluginManagerOrNull;
     if (!pluginManager) return undefined;
     return pluginManager.configRegistry.get(key);
   }
@@ -332,16 +338,24 @@ export class Config extends ChildBlock {
   }
 
   private _setupCustomConfigs(): void {
-    // Use when API to ensure pluginManager is available before setting up custom configs
-    this.bag.when('pluginManager', (pluginManager) => {
-      // Initial setup
-      this._processCustomConfigs(pluginManager);
-
-      // Subscribe to plugin changes to reload custom configs dynamically
-      this._pluginChangeUnsubscribe = pluginManager.onPluginsChange(() => {
+    // Use the `when` API to ensure pluginManager is available before setting up
+    // custom configs. When `*pluginManager` isn't present yet, `when` subscribes
+    // to the CURRENT ctx and returns a real unsubscriber — track it so a
+    // re-adoption (ctx-name switch) tears down the previous ctx's pending
+    // subscription instead of leaving it to fire against the wrong controller.
+    // (A `when` that resolves synchronously returns a no-op unsub; tracking it
+    // is harmless.)
+    this.trackSub(
+      this.bag.when('pluginManager', (pluginManager) => {
+        // Initial setup
         this._processCustomConfigs(pluginManager);
-      });
-    });
+
+        // Subscribe to plugin changes to reload custom configs dynamically
+        this._pluginChangeUnsubscribe = pluginManager.onPluginsChange(() => {
+          this._processCustomConfigs(pluginManager);
+        });
+      }),
+    );
   }
 
   private _setupMutationObserver(): void {

--- a/src/lit/shared-instances.ts
+++ b/src/lit/shared-instances.ts
@@ -286,6 +286,17 @@ export const createSharedInstancesBag = (getCtx: () => PubSub<SharedState>) => {
         return null;
       }
     },
+    get pluginManagerOrNull(): PluginController | null {
+      // `*pluginManager` is absent in a config-only / plugin-less ctx (it is
+      // constructed by `LitBlock`, and never registered by the ChildBlock
+      // self-bootstrap seam). Read it without throwing for blocks that touch
+      // custom-config paths but may run outside an uploader/plugin scope.
+      try {
+        return getSharedInstance(getCtx(), '*pluginManager', false) ?? null;
+      } catch {
+        return null;
+      }
+    },
 
     when<TName extends InstanceName>(
       name: TName,

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -62,16 +62,27 @@ describe('instance lifecycle (config-only ctx)', () => {
     expect(controller.clipboard).toBeTruthy();
     expect(controller.telemetryManager).toBeTruthy();
 
-    // No v1 `LitBlock` ever ran `initCallback`'s bootstrap, so none of these
-    // legacy re-exposer keys (or the DOM-constructed plugin manager) exist.
+    // M9q: the ctx-creation seam (`ensureUploaderCtx`) registers the six
+    // controller-owned re-exposer keys the moment the controller exists — no
+    // v1 `LitBlock` required — each pointing at the matching `controller.X`.
+    expect(ctx.has('*eventEmitter')).toBe(true);
+    expect(ctx.has('*localeManager')).toBe(true);
+    expect(ctx.has('*a11y')).toBe(true);
+    expect(ctx.has('*router')).toBe(true);
+    expect(ctx.has('*clipboard')).toBe(true);
+    expect(ctx.has('*telemetryManager')).toBe(true);
+    expect(ctx.read('*eventEmitter')).toBe(controller.eventEmitter);
+    expect(ctx.read('*localeManager')).toBe(controller.localeManager);
+    expect(ctx.read('*a11y')).toBe(controller.a11y);
+    expect(ctx.read('*router')).toBe(controller.router);
+    expect(ctx.read('*clipboard')).toBe(controller.clipboard);
+    expect(ctx.read('*telemetryManager')).toBe(controller.telemetryManager);
+
+    // But `*blocksRegistry` (LitBlock-owned) and `*pluginManager`
+    // (LitBlock-constructed, needs plugins) are NOT seam-registered — a
+    // config-only ctx never runs `LitBlock.initCallback`, so neither exists.
     expect(ctx.has('*blocksRegistry')).toBe(false);
     expect(ctx.has('*pluginManager')).toBe(false);
-    expect(ctx.has('*eventEmitter')).toBe(false);
-    expect(ctx.has('*localeManager')).toBe(false);
-    expect(ctx.has('*a11y')).toBe(false);
-    expect(ctx.has('*router')).toBe(false);
-    expect(ctx.has('*clipboard')).toBe(false);
-    expect(ctx.has('*telemetryManager')).toBe(false);
 
     // `*uploadCollection` is added by `LitUploaderBlock`, not `LitBlock` —
     // `<uc-config>` alone must not create it.

--- a/tests/blocks/instance-lifecycle.e2e.test.tsx
+++ b/tests/blocks/instance-lifecycle.e2e.test.tsx
@@ -23,25 +23,55 @@ beforeAll(async () => {
  * `LitBlock.initCallback` onto `UploaderController`). Pins instance-lifecycle
  * behavior nothing else currently exercises, so the construction move has a
  * regression net.
+ *
+ * UPDATED at the M9p `<uc-config>` port: `<uc-config>` stopped being a v1
+ * `LitBlock` (it's now a `ChildBlock`), so it no longer runs
+ * `LitBlock.initCallback`'s unconditional bootstrap of `*blocksRegistry`,
+ * `*pluginManager`, and the re-exposed `*eventEmitter`/`*localeManager`/
+ * `*a11y`/`*router`/`*clipboard`/`*telemetryManager` legacy ctx keys — that
+ * bootstrap is tied to an actual v1 `LitBlock` instance existing somewhere in
+ * the composition (e.g. a solution block), which a config-only composition no
+ * longer has. `ensureUploaderCtx` still forces the `UploaderController` (and
+ * therefore `ConfigController`, `EventBus`, `LocaleController`,
+ * `RouterController`, `A11y`, `ClipboardController`, `TelemetryManager`) into
+ * existence the moment the ctx exists — those six are readable directly off
+ * the controller, just not re-exposed under their legacy `*`-prefixed ctx
+ * keys without a v1 block to do the re-exposing. `*pluginManager` has no
+ * controller equivalent at all (it stays DOM/`LitBlock`-constructed by
+ * design — see `PluginController`'s and `LitBlock.initCallback`'s own
+ * comments) so a config-only ctx genuinely has no plugin manager; custom
+ * (plugin-registered) configs are unavailable in that composition, same as
+ * before this port for any other ChildBlock-only scope.
  */
 describe('instance lifecycle (config-only ctx)', () => {
-  it('a config-only ctx (no uploader block) still builds every LitBlock-scope instance, and tears down cleanly', async () => {
+  it('a config-only ctx (no v1 LitBlock) still builds the controller and its owned instances, and tears down cleanly', async () => {
     const ctxName = getCtxName();
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" qualityInsights={false} testMode></uc-config>);
 
     await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
     const ctx = PubSub.getCtx<SharedState>(ctxName)!;
+    const controller = ctx.uploaderController();
 
-    // Every instance `LitBlock.initCallback` adds unconditionally, even with
-    // no uploader block in the tree.
-    expect(ctx.has('*blocksRegistry')).toBe(true);
-    expect(ctx.has('*pluginManager')).toBe(true);
-    expect(ctx.has('*eventEmitter')).toBe(true);
-    expect(ctx.has('*localeManager')).toBe(true);
-    expect(ctx.has('*a11y')).toBe(true);
-    expect(ctx.has('*router')).toBe(true);
-    expect(ctx.has('*clipboard')).toBe(true);
-    expect(ctx.has('*telemetryManager')).toBe(true);
+    // The controller and its own six always-constructed members exist —
+    // `ensureUploaderCtx` forces the controller into existence the moment the
+    // ctx does, with no v1 block required.
+    expect(controller.eventEmitter).toBeTruthy();
+    expect(controller.localeManager).toBeTruthy();
+    expect(controller.a11y).toBeTruthy();
+    expect(controller.router).toBeTruthy();
+    expect(controller.clipboard).toBeTruthy();
+    expect(controller.telemetryManager).toBeTruthy();
+
+    // No v1 `LitBlock` ever ran `initCallback`'s bootstrap, so none of these
+    // legacy re-exposer keys (or the DOM-constructed plugin manager) exist.
+    expect(ctx.has('*blocksRegistry')).toBe(false);
+    expect(ctx.has('*pluginManager')).toBe(false);
+    expect(ctx.has('*eventEmitter')).toBe(false);
+    expect(ctx.has('*localeManager')).toBe(false);
+    expect(ctx.has('*a11y')).toBe(false);
+    expect(ctx.has('*router')).toBe(false);
+    expect(ctx.has('*clipboard')).toBe(false);
+    expect(ctx.has('*telemetryManager')).toBe(false);
 
     // `*uploadCollection` is added by `LitUploaderBlock`, not `LitBlock` —
     // `<uc-config>` alone must not create it.
@@ -58,7 +88,6 @@ describe('instance lifecycle (config-only ctx)', () => {
     // And `attachUploaderScope` itself was never called — the controller's
     // upload-stack getters still throw the pre-attach error, same as a
     // freshly-constructed `UploaderController`.
-    const controller = ctx.uploaderController();
     expect(() => controller.secureUploadsManager).toThrow(/attachUploaderScope/);
     expect(() => controller.uploadController).toThrow(/attachUploaderScope/);
     expect(() => controller.validationManager).toThrow(/attachUploaderScope/);

--- a/tests/config.e2e.test.tsx
+++ b/tests/config.e2e.test.tsx
@@ -70,13 +70,16 @@ describe('Config', () => {
   });
 
   /**
-   * Coverage gap-fill for the M9p ChildBlock port: pinning CURRENT `<uc-config>`
-   * (v1 `LitBlock`) behavior in three scenarios the neither `config.e2e.test.tsx`
-   * nor `plugins/custom-config.e2e.test.tsx` net covers, but the port could
+   * Coverage gap-fill for the M9p ChildBlock port: exercising `<uc-config>`
+   * (now a `ChildBlock`) in four scenarios neither `config.e2e.test.tsx` nor
+   * `plugins/custom-config.e2e.test.tsx` net covers, but the port could
    * plausibly change:
    *  - a standalone `<uc-config>` with no solution/provider ever present
    *    (self-bootstrap + M9o refcount teardown on its own);
    *  - `ctx-name` reassignment on an already-initialized, live element;
+   *  - a custom-config attribute mutated DURING a live `ctx-name` switch —
+   *    the exact case the pre-ctx guard (`PubSub.getCtx(effectiveCtxName)`)
+   *    covers and `uploaderOrNull` did not;
    *  - an attribute set on a freshly-created (unconnected) element, before any
    *    ctx/controller exists at all.
    * These are additive only — no existing test is modified.
@@ -93,14 +96,15 @@ describe('Config', () => {
       page.render(<uc-config ctx-name={ctxName} testMode></uc-config>);
       const config = page.getByTestId('uc-config').query()! as Config;
 
-      // The ctx now exists purely because this one v1 block bootstrapped it.
+      // The ctx now exists purely because this one ChildBlock self-bootstrapped
+      // it (`_watchRegistry` → `ensureUploaderCtx`), with no v1 block present.
       expect(PubSub.hasCtx(ctxName)).toBe(true);
       // Plain ConfigController default, readable with no other block present.
       expect(config.cdnCname).toBe('https://ucarecdn.com');
 
-      // Removing the sole consumer must tear the self-bootstrapped ctx down
-      // (mirrors the ChildBlock-only M9o teardown path, driven here by
-      // `LitBlock.disconnectedCallback`'s `*blocksRegistry`-empty check).
+      // Removing the sole consumer must tear the self-bootstrapped ctx down,
+      // driven by `ChildBlock.disconnectedCallback`'s deferred M9o refcount
+      // check (`isCtxUnreferenced` → `!UploaderRegistry.hasConsumers`).
       cleanup();
       await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
     });
@@ -142,6 +146,43 @@ describe('Config', () => {
     });
   });
 
+  describe('custom-config attribute mutated mid ctx-name switch', () => {
+    it('does not throw when a custom-config attr fires while pointing at a not-yet-created ctx — the PubSub.getCtx guard uploaderOrNull did not cover', async () => {
+      cleanup();
+      const ctxNameA = getCtxName();
+      const ctxNameB = getCtxName();
+      const { PubSub } = await import('@/lit/PubSubCompat.js');
+
+      page.render(<uc-config ctx-name={ctxNameA} testMode></uc-config>);
+      const config = page.getByTestId('uc-config').query()! as Config;
+      await config.updateComplete;
+      expect(PubSub.hasCtx(ctxNameA)).toBe(true);
+
+      // Point the element at a brand-new ctx name. `super.attributeChangedCallback`
+      // updates `effectiveCtxName` to B synchronously, but `ChildBlock`'s adoption
+      // (`_watchRegistry` → `ensureUploaderCtx`) runs in a later microtask, so B's
+      // ctx does NOT exist yet — this is the guard's window.
+      config.setAttribute('ctx-name', ctxNameB);
+      expect(PubSub.hasCtx(ctxNameB)).toBe(false);
+
+      // In that window a custom-config attribute mutation reaches
+      // `attributeChangedCallback`'s else-branch — exactly how the
+      // `_bindObservedCustomAttributes` MutationObserver forwards custom attrs
+      // (`this.attributeChangedCallback(attrName, …)`, `Config.ts`). The element
+      // is still adopted to controller A while `this.bag` now targets nonexistent
+      // ctx B: the case the rejected `uploaderOrNull` guard did NOT cover (it
+      // stayed truthy = A and let `bag.when` → `_requireCtx(B)` throw "shared
+      // context is not initialized yet", aborting init — the M9p regression that
+      // spawned M9q). The shipped `PubSub.getCtx(effectiveCtxName)` guard returns
+      // early instead of touching the bag.
+      expect(() => config.attributeChangedCallback('a-custom-plugin-config', '', 'mid-switch')).not.toThrow();
+
+      // ...and the switch still resolves cleanly afterwards.
+      await config.updateComplete;
+      await expect.poll(() => PubSub.hasCtx(ctxNameB)).toBe(true);
+    });
+  });
+
   describe('pre-adoption attribute set (no controller yet)', () => {
     it('an attribute set on a freshly-created, unconnected uc-config (before any ctx/controller exists) is applied once the element connects and initializes', async () => {
       cleanup();
@@ -152,8 +193,8 @@ describe('Config', () => {
       // PubSub map, no controller exists for `ctxName` at this point.
       el.setAttribute('pubkey', 'pre-connect-key');
       // No setter/getter has been installed yet (that happens in
-      // `initCallback`, which only runs once connected) — the value must
-      // still be readable as a plain instance property.
+      // `controllerReady`, which only runs once connected + adopted) — the
+      // value must still be readable as a plain instance property.
       expect(el.pubkey).toBe('pre-connect-key');
 
       el.setAttribute('ctx-name', ctxName);
@@ -161,8 +202,8 @@ describe('Config', () => {
       try {
         await el.updateComplete;
         // The pre-connection attribute value must have been picked up by
-        // `initCallback`'s `anyThis[key] ?? this.$[...]` read and applied to
-        // the now-initialized shared config state.
+        // `controllerReady`'s `anyThis[key] ?? this.uploader.config.get(key)`
+        // read and applied to the now-initialized shared config state.
         expect(el.pubkey).toBe('pre-connect-key');
       } finally {
         el.remove();

--- a/tests/config.e2e.test.tsx
+++ b/tests/config.e2e.test.tsx
@@ -120,16 +120,20 @@ describe('Config', () => {
       expect(PubSub.hasCtx(ctxNameB)).toBe(false);
 
       config.setAttribute('ctx-name', ctxNameB);
-      await new Promise((resolve) => setTimeout(resolve, 20));
+      await config.updateComplete;
 
       // The DOM attribute switched...
       expect(config.getAttribute('ctx-name')).toBe(ctxNameB);
       // ...but `_symbioteFirstUpdated` gates `_performInitialization` to a
       // single call per element lifetime: the shared PubSub binding never
       // moves. Values keep reading/writing through the original ctx, and no
-      // second ctx is ever created for this reassignment. A future port must
-      // preserve this (not silently start re-adopting like `ChildBlock` does)
-      // unless the migration explicitly decides to change it.
+      // second ctx is ever created for this reassignment.
+      //
+      // INTENDED CHANGE at the M9p port: `ChildBlock` re-adopts on ctx-name
+      // switch (M9o), so the ported `<uc-config>` WILL rebind to ctxNameB and
+      // (refcount-)tear down ctxNameA. The Task-2 port must UPDATE this test to
+      // the re-adopt behavior — not preserve the v1 quirk below (mirrors the
+      // M9o "gates forever" child-block pin that was likewise inverted).
       expect(config.pubkey).toBe('demopublickey');
       expect(PubSub.hasCtx(ctxNameA)).toBe(true);
       expect(PubSub.hasCtx(ctxNameB)).toBe(false);

--- a/tests/config.e2e.test.tsx
+++ b/tests/config.e2e.test.tsx
@@ -68,4 +68,99 @@ describe('Config', () => {
       expect(config.cdnCname).toBe('https://cdn.example.com');
     });
   });
+
+  /**
+   * Coverage gap-fill for the M9p ChildBlock port: pinning CURRENT `<uc-config>`
+   * (v1 `LitBlock`) behavior in three scenarios the neither `config.e2e.test.tsx`
+   * nor `plugins/custom-config.e2e.test.tsx` net covers, but the port could
+   * plausibly change:
+   *  - a standalone `<uc-config>` with no solution/provider ever present
+   *    (self-bootstrap + M9o refcount teardown on its own);
+   *  - `ctx-name` reassignment on an already-initialized, live element;
+   *  - an attribute set on a freshly-created (unconnected) element, before any
+   *    ctx/controller exists at all.
+   * These are additive only — no existing test is modified.
+   */
+  describe('standalone lifecycle (no solution/provider)', () => {
+    it('self-bootstraps its own ctx, exposes readable config defaults, and tears the ctx down once removed (M9o refcount)', async () => {
+      cleanup();
+      const ctxName = getCtxName();
+      const { PubSub } = await import('@/lit/PubSubCompat.js');
+      expect(PubSub.hasCtx(ctxName)).toBe(false);
+
+      // No uc-file-uploader-*, no uc-upload-ctx-provider: `<uc-config>` is the
+      // only block in the composition.
+      page.render(<uc-config ctx-name={ctxName} testMode></uc-config>);
+      const config = page.getByTestId('uc-config').query()! as Config;
+
+      // The ctx now exists purely because this one v1 block bootstrapped it.
+      expect(PubSub.hasCtx(ctxName)).toBe(true);
+      // Plain ConfigController default, readable with no other block present.
+      expect(config.cdnCname).toBe('https://ucarecdn.com');
+
+      // Removing the sole consumer must tear the self-bootstrapped ctx down
+      // (mirrors the ChildBlock-only M9o teardown path, driven here by
+      // `LitBlock.disconnectedCallback`'s `*blocksRegistry`-empty check).
+      cleanup();
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(false);
+    });
+  });
+
+  describe('ctx-name reassignment on a live element', () => {
+    it('current v1 behavior: reassigning ctx-name on an already-initialized element updates the attribute/state but stays bound to the original ctx (SymbioteCompatMixin never re-initializes)', async () => {
+      cleanup();
+      const ctxNameA = getCtxName();
+      const ctxNameB = getCtxName();
+      const { PubSub } = await import('@/lit/PubSubCompat.js');
+
+      page.render(<uc-config ctx-name={ctxNameA} pubkey="demopublickey" testMode></uc-config>);
+      const config = page.getByTestId('uc-config').query()! as Config;
+      expect(config.pubkey).toBe('demopublickey');
+      expect(PubSub.hasCtx(ctxNameA)).toBe(true);
+      expect(PubSub.hasCtx(ctxNameB)).toBe(false);
+
+      config.setAttribute('ctx-name', ctxNameB);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      // The DOM attribute switched...
+      expect(config.getAttribute('ctx-name')).toBe(ctxNameB);
+      // ...but `_symbioteFirstUpdated` gates `_performInitialization` to a
+      // single call per element lifetime: the shared PubSub binding never
+      // moves. Values keep reading/writing through the original ctx, and no
+      // second ctx is ever created for this reassignment. A future port must
+      // preserve this (not silently start re-adopting like `ChildBlock` does)
+      // unless the migration explicitly decides to change it.
+      expect(config.pubkey).toBe('demopublickey');
+      expect(PubSub.hasCtx(ctxNameA)).toBe(true);
+      expect(PubSub.hasCtx(ctxNameB)).toBe(false);
+    });
+  });
+
+  describe('pre-adoption attribute set (no controller yet)', () => {
+    it('an attribute set on a freshly-created, unconnected uc-config (before any ctx/controller exists) is applied once the element connects and initializes', async () => {
+      cleanup();
+      const ctxName = getCtxName();
+      const el = document.createElement('uc-config') as Config;
+
+      // Set the attribute before the element is ever connected: no ctx, no
+      // PubSub map, no controller exists for `ctxName` at this point.
+      el.setAttribute('pubkey', 'pre-connect-key');
+      // No setter/getter has been installed yet (that happens in
+      // `initCallback`, which only runs once connected) — the value must
+      // still be readable as a plain instance property.
+      expect(el.pubkey).toBe('pre-connect-key');
+
+      el.setAttribute('ctx-name', ctxName);
+      document.body.appendChild(el);
+      try {
+        await el.updateComplete;
+        // The pre-connection attribute value must have been picked up by
+        // `initCallback`'s `anyThis[key] ?? this.$[...]` read and applied to
+        // the now-initialized shared config state.
+        expect(el.pubkey).toBe('pre-connect-key');
+      } finally {
+        el.remove();
+      }
+    });
+  });
 });

--- a/tests/config.e2e.test.tsx
+++ b/tests/config.e2e.test.tsx
@@ -187,7 +187,11 @@ describe('Config', () => {
     it('an attribute set on a freshly-created, unconnected uc-config (before any ctx/controller exists) is applied once the element connects and initializes', async () => {
       cleanup();
       const ctxName = getCtxName();
-      const el = document.createElement('uc-config') as Config;
+      // `document.createElement('uc-config')` resolves to the src `Config`
+      // class, while the ambient `Config` (from `../types/jsx`) is the built
+      // `dist` declaration; a direct cast trips TS2352 on their separate
+      // private `_debugPrint`. Bridge through `unknown` (test-only boundary).
+      const el = document.createElement('uc-config') as unknown as Config;
 
       // Set the attribute before the element is ever connected: no ctx, no
       // PubSub map, no controller exists for `ctxName` at this point.

--- a/tests/config.e2e.test.tsx
+++ b/tests/config.e2e.test.tsx
@@ -107,7 +107,7 @@ describe('Config', () => {
   });
 
   describe('ctx-name reassignment on a live element', () => {
-    it('current v1 behavior: reassigning ctx-name on an already-initialized element updates the attribute/state but stays bound to the original ctx (SymbioteCompatMixin never re-initializes)', async () => {
+    it('M9p port behavior: reassigning ctx-name on an already-initialized element rebinds to the new ctx (ChildBlock re-adopts) and refcount-tears-down the abandoned ctx', async () => {
       cleanup();
       const ctxNameA = getCtxName();
       const ctxNameB = getCtxName();
@@ -124,19 +124,21 @@ describe('Config', () => {
 
       // The DOM attribute switched...
       expect(config.getAttribute('ctx-name')).toBe(ctxNameB);
-      // ...but `_symbioteFirstUpdated` gates `_performInitialization` to a
-      // single call per element lifetime: the shared PubSub binding never
-      // moves. Values keep reading/writing through the original ctx, and no
-      // second ctx is ever created for this reassignment.
-      //
-      // INTENDED CHANGE at the M9p port: `ChildBlock` re-adopts on ctx-name
-      // switch (M9o), so the ported `<uc-config>` WILL rebind to ctxNameB and
-      // (refcount-)tear down ctxNameA. The Task-2 port must UPDATE this test to
-      // the re-adopt behavior — not preserve the v1 quirk below (mirrors the
-      // M9o "gates forever" child-block pin that was likewise inverted).
+      // ...and — INTENDED CHANGE at the M9p port — `ChildBlock` re-adopts on
+      // ctx-name switch (M9o): the ported `<uc-config>` rebinds to ctxNameB
+      // (the new ctx now exists, seeded with the value carried over from the
+      // element's local property cache) and, once nothing else references it,
+      // the abandoned ctxNameA is refcount-torn-down (M9o). This inverts the
+      // v1 quirk above — `SymbioteCompatMixin` never re-initialized and the
+      // binding stayed on the original ctx forever.
       expect(config.pubkey).toBe('demopublickey');
-      expect(PubSub.hasCtx(ctxNameA)).toBe(true);
-      expect(PubSub.hasCtx(ctxNameB)).toBe(false);
+      await expect.poll(() => PubSub.hasCtx(ctxNameB)).toBe(true);
+      await expect.poll(() => PubSub.hasCtx(ctxNameA)).toBe(false);
+
+      // The value did move to the new ctx's `ConfigController` — not just the
+      // element's local cache — confirming reads/writes now go through ctxB.
+      const configApi = PubSub.getCtx(ctxNameB)!.uploaderController().config;
+      expect(configApi.get('pubkey')).toBe('demopublickey');
     });
   });
 

--- a/tests/plugins/custom-config.e2e.test.tsx
+++ b/tests/plugins/custom-config.e2e.test.tsx
@@ -486,6 +486,34 @@ describe('Custom Config', () => {
 
     warnSpy.mockRestore();
   });
+
+  it('re-adopting <uc-config> into a plugin-less ctx does not throw when a now-stale custom-config setter is written (pluginManagerOrNull guard)', async () => {
+    const plugin = createTestPlugin({
+      id: 'cfg-readopt',
+      setup: ({ pluginApi }) => {
+        pluginApi.registry.registerConfig({ name: 'readoptOption', defaultValue: 'a' });
+      },
+    });
+    const { config } = await renderUploader([plugin]);
+    await expect.poll(() => config.readoptOption).toBe('a');
+
+    // Re-adopt the `<uc-config>` alone into a brand-new, plugin-less ctx (the
+    // solution/provider stay on the original ctx). `*pluginManager` is absent
+    // there, but the `readoptOption` accessor defined during the original
+    // adoption survives on the instance and `_customConfigKeys` stays stale
+    // (the new ctx never runs `_processCustomConfigs`). Writing the property
+    // therefore routes `_setValue` -> `_getCustomConfigDefinition`, which reads
+    // the plugin manager: before the fix `bag.pluginManager` threw
+    // synchronously here; `pluginManagerOrNull` returns null so the write is a
+    // tolerated no-op.
+    const ctxNameB = getCtxName();
+    config.setAttribute('ctx-name', ctxNameB);
+    await config.updateComplete;
+
+    expect(() => {
+      config.readoptOption = 'b';
+    }).not.toThrow();
+  });
 });
 
 declare module '@/types/index' {
@@ -506,5 +534,6 @@ declare module '@/types/index' {
     preAssignedProp: string;
     lateAssignedProp: string;
     preAttrOption: string;
+    readoptOption: string;
   }
 }


### PR DESCRIPTION
## M9p — Port `<uc-config>` off `SymbioteCompatMixin` onto `ChildBlock`

Part of the v2 strangler migration (`MIGRATION-PLAN.md` §M9). Ports the
`<uc-config>` custom element from the v1 compat layer (`$` proxy, `init$`,
star-key `sharedCtx.add`, `initCallback`) onto the v2 `ChildBlock` base:
config reads/writes now route through `controller.config`; the element
adopts its ctx via `UploaderRegistry.whenAvailable` and initializes in
`controllerReady`. All DOM/attribute machinery (attribute reflection,
`cdnCname` computation, secure-delivery proxy resolver, custom-config
MutationObserver, accessors) is preserved verbatim, re-sourced onto the
controller.

### Why this needed M9q first
`<uc-config>` is the common ctx-bootstrapper for many ChildBlock unit-e2e
fixtures (they render `<uc-config>` alone). As a v1 `LitBlock` it registered
the controller-owned ctx-scope keys (`*eventEmitter`/`*localeManager`/`*a11y`/
`*router`/`*clipboard`/`*telemetryManager`) via `initCallback`. Porting it to
`ChildBlock` removed the only `LitBlock` in those fixtures, so the keys never
registered → `bag.router`/`emit`/`l10n` threw. **M9q** (merged) moved that key
registration into the ctx-creation seam (`ensureUploaderCtx`); this branch
rebases on top and the config-only fixtures now resolve.

### Behavior changes (intentional, documented in tests)
- **`ctx-name` reassignment now re-adopts.** A live `ctx-name` switch rebinds
  the element to the new ctx (carrying its value over) and refcount-tears-down
  the abandoned ctx (M9o). v1 `SymbioteCompatMixin` never re-initialized and
  stayed bound to the original ctx forever. Pinned in `config.e2e.test.tsx`.

### Correctness guard (the M9p→M9q regression, now pinned)
`attributeChangedCallback`'s custom-config branch reached `bag.when` →
`_requireCtx`, which threw when no ctx existed — during element upgrade
(pre-connect custom attr) or a live `ctx-name` switch (adopted to the OLD
controller while `bag` targets the NEW, not-yet-created ctx). Guarded on the
exact condition `_requireCtx` checks: `PubSub.getCtx(effectiveCtxName)` — NOT
`uploaderOrNull`, which was found insufficient (stays truthy = old controller
while the bag targets the new ctx). A regression test now drives the
custom-attr-during-switch case directly.

### Verification
Full green gate: `tsc:app` ✅ · `build` ✅ · `tsc` ✅ · `test:types` ✅ ·
`test:specs` (673) ✅ · `test:locales` ✅ · `test:e2e` (49 files / 339) ✅ ·
`lint` ✅. Final whole-branch review (opus): **APPROVED** — all four critical
concerns (guard correctness/completeness, self-bootstrap + refcount teardown
preservation, dual-path safety, notification-bridge parity) verified sound;
only comment-rot Minors, all fixed in the final commit.

### Not in this PR
Solutions + DropArea ports (the last ctx-creator retires the v1
`blocksRegistry`/`LitBlock.initCallback` path in M11, at which point
`*pluginManager` construction moves controller-side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - `<uc-config>` now supports config-only use by creating/using its own ctx when uploader/solution/provider aren’t present.
  - Values set on a disconnected `<uc-config>` are preserved and applied after initialization.
  - Custom configuration updates are applied correctly across live `ctx-name` changes.

- **Bug Fixes**
  - Improved synchronization between element properties/attributes and the active controller values (including correct default restoration when cleared).
  - Safer handling of custom-config and attribute updates during context switches; stale custom setters no longer throw.
  - Added null-tolerant access when the plugin manager isn’t available.

- **Tests**
  - Updated lifecycle expectations for config-only composition and added new e2e coverage for standalone init, ctx switching, and custom-config re-adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->