### PR TITLE
refactor(m12): extract CloudImageEditorState type out of SharedState

### DIFF
--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -20,7 +20,7 @@ import { classNames } from './lib/classNames.js';
 import { getClosestAspectRatio, parseCropPreset } from './lib/parseCropPreset.js';
 import { parseTabs } from './lib/parseTabs.js';
 import { operationsToTransformations, transformationsToOperations } from './lib/transformationUtils.js';
-import { initState } from './state.js';
+import { createCloudImageEditorState } from './state.js';
 import svgIconsSprite from './svg-sprite';
 import { ALL_TABS, TabId } from './toolbar-constants.js';
 import type { ApplyResult, CropPresetList, ImageSize, Transformations } from './types';
@@ -119,8 +119,8 @@ export class CloudImageEditorBlock extends LitBlock {
 
   public override init$ = {
     ...this.init$,
-    ...initState(this),
-  } as ReturnType<typeof initState>;
+    ...createCloudImageEditorState(this),
+  } as ReturnType<typeof createCloudImageEditorState>;
 
   public override initCallback(): void {
     super.initCallback();

--- a/src/blocks/CloudImageEditor/src/state.ts
+++ b/src/blocks/CloudImageEditor/src/state.ts
@@ -1,11 +1,66 @@
 import { createCdnUrl, createCdnUrlModifiers } from '../../../utils/cdn-utils';
 import { TRANSPARENT_PIXEL_SRC } from '../../../utils/transparentPixelSrc';
 import type { CloudImageEditorBlock } from './CloudImageEditorBlock';
+import type { EditorImageCropper } from './EditorImageCropper';
+import type { EditorImageFader } from './EditorImageFader';
+import type { EditorSlider } from './EditorSlider';
 import { transformationsToOperations } from './lib/transformationUtils';
+import type { TabIdValue } from './toolbar-constants';
 import { ALL_TABS, TabId } from './toolbar-constants';
-import type { ApplyResult, LoadingOperations, Transformations } from './types';
+import type { ApplyResult, CropAspectRatio, CropPresetList, LoadingOperations, Transformations } from './types';
 
-export function initState(fnCtx: CloudImageEditorBlock) {
+/**
+ * State for the top-level cloud image editor block.
+ */
+type CloudImageEditorBlockState = {
+  '*originalUrl': string | null;
+  '*loadingOperations': LoadingOperations;
+  '*faderEl': EditorImageFader | null;
+  '*cropperEl': EditorImageCropper | null;
+  '*imgEl': HTMLImageElement | null;
+  '*imgContainerEl': HTMLElement | null;
+  '*networkProblems': boolean;
+  '*imageSize': { width: number; height: number } | null;
+  '*editorTransformations': Transformations;
+  '*cropPresetList': CropPresetList;
+  '*currentAspectRatio': CropAspectRatio | null;
+  '*tabList': readonly TabIdValue[];
+  '*tabId': TabIdValue;
+  '*on.retryNetwork': () => void;
+  '*on.apply': (transformations: Transformations) => void;
+  '*on.cancel': () => void;
+};
+
+/**
+ * State for the image cropper sub-block.
+ */
+type EditorImageCropperState = {
+  '*padding': number;
+  '*operations': { rotate: number; mirror: boolean; flip: boolean };
+  '*imageBox': { x: number; y: number; width: number; height: number };
+  '*cropBox': { x: number; y: number; width: number; height: number };
+};
+
+/**
+ * State for the editor toolbar sub-block.
+ */
+type EditorToolbarState = {
+  '*showListAspectRatio': boolean;
+  '*sliderEl': EditorSlider | null;
+  '*showSlider': boolean;
+  '*currentFilter': string;
+  '*currentOperation': string | null;
+  '*operationTooltip': string | null;
+};
+
+/**
+ * Full set of ctx keys owned by the cloud image editor and its sub-blocks
+ * (cropper, toolbar). Still lives in the shared uploader ctx (`SharedState`)
+ * — this is a type-only relocation, not a new state container.
+ */
+export type CloudImageEditorState = CloudImageEditorBlockState & EditorImageCropperState & EditorToolbarState;
+
+export function createCloudImageEditorState(fnCtx: CloudImageEditorBlock) {
   return {
     '*originalUrl': null,
     '*loadingOperations': new Map() as LoadingOperations,

--- a/src/lit/PubSubCompat.test.ts
+++ b/src/lit/PubSubCompat.test.ts
@@ -220,7 +220,7 @@ describe('PubSub (additional coverage)', () => {
   it('add() rewrite semantics pin what ctxOwner buys: first-write-wins normally, force-overwrite when rewrite=true (CloudImageEditorBlock/EditorImageCropper init$ seeding path)', () => {
     // `SymbioteCompatMixin._initSharedContext` calls `add(key, defaultValue,
     // this.ctxOwner)` for every `init$` key on connect (src/lit/SymbioteCompatMixin.ts).
-    // `CloudImageEditorBlock` (16 keys via `initState()`, CloudImageEditorBlock.ts:120-123)
+    // `CloudImageEditorBlock` (16 keys via `createCloudImageEditorState()`, CloudImageEditorBlock.ts:120-123)
     // and `EditorImageCropper` (4 keys seeded in its constructor, EditorImageCropper.ts:65-85)
     // are the only two classes that set `ctxOwner = true`, so for their real
     // seeded keys `add` is called with `rewrite=true` instead of the default

--- a/src/lit/SharedState.ts
+++ b/src/lit/SharedState.ts
@@ -13,14 +13,7 @@ import type { PluginController } from '../abstract/managers/plugin';
 import type { LazyPluginEntry } from '../abstract/managers/plugin/LazyPluginLoader';
 import type { TelemetryManager } from '../abstract/managers/TelemetryManager';
 import type { UploaderPublicApi } from '../abstract/UploaderPublicApi';
-import type { EditorImageCropper, EditorImageFader, EditorSlider } from '../blocks/CloudImageEditor';
-import type { TabIdValue } from '../blocks/CloudImageEditor/src/toolbar-constants';
-import type {
-  CropAspectRatio,
-  CropPresetList,
-  LoadingOperations,
-  Transformations,
-} from '../blocks/CloudImageEditor/src/types';
+import type { CloudImageEditorState } from '../blocks/CloudImageEditor/src/state';
 import type { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
 import type { ConfigType, CustomConfig, OutputCollectionState, OutputErrorCollection } from '../types';
 import type { LitBlock } from './LitBlock';
@@ -48,41 +41,6 @@ type UploaderBlockCtxState = {
 
 type SolutionBlockCtxState = UploaderBlockCtxState & {
   '*lazyPlugins': LazyPluginEntry[] | null;
-};
-
-type CloudImageEditorState = {
-  '*originalUrl': string | null;
-  '*loadingOperations': LoadingOperations;
-  '*faderEl': EditorImageFader | null;
-  '*cropperEl': EditorImageCropper | null;
-  '*imgEl': HTMLImageElement | null;
-  '*imgContainerEl': HTMLElement | null;
-  '*networkProblems': boolean;
-  '*imageSize': { width: number; height: number } | null;
-  '*editorTransformations': Transformations;
-  '*cropPresetList': CropPresetList;
-  '*currentAspectRatio': CropAspectRatio | null;
-  '*tabList': readonly TabIdValue[];
-  '*tabId': TabIdValue;
-  '*on.retryNetwork': () => void;
-  '*on.apply': (transformations: Transformations) => void;
-  '*on.cancel': () => void;
-};
-
-type EditorImageCropperState = {
-  '*padding': number;
-  '*operations': { rotate: number; mirror: boolean; flip: boolean };
-  '*imageBox': { x: number; y: number; width: number; height: number };
-  '*cropBox': { x: number; y: number; width: number; height: number };
-};
-
-type EditorToolbarState = {
-  '*showListAspectRatio': boolean;
-  '*sliderEl': EditorSlider | null;
-  '*showSlider': boolean;
-  '*currentFilter': string;
-  '*currentOperation': string | null;
-  '*operationTooltip': string | null;
 };
 
 type SharedContextInstances = Map<string, ISharedInstance>;
@@ -116,8 +74,6 @@ export type SharedState = SolutionBlockCtxState &
   SharedConfigState &
   SharedCustomConfigState &
   CloudImageEditorState &
-  EditorImageCropperState &
-  EditorToolbarState &
   DynamicBlockState &
   DynamicUploaderBlockState &
   LocaleState;


### PR DESCRIPTION
## M12 P2 — Extract `CloudImageEditorState` out of `SharedState`

First code phase of the CloudImageEditor v2 port (M12). **Pure type-relocation, no behavior change** — the editor state still lives in the uploader `PubSub<SharedState>` map exactly as before; this only moves the type definitions so a later phase can register that state into a dedicated `CloudImageEditorController`.

- `src/lit/SharedState.ts` — removed the three inline editor types (`CloudImageEditorState`/`EditorImageCropperState`/`EditorToolbarState`, ~46 lines) + their now-unused imports; now `import type { CloudImageEditorState }` from the editor and unions that single type in (net key set unchanged).
- `src/blocks/CloudImageEditor/src/state.ts` — the three shapes now live here, merged into an exported `CloudImageEditorState`; `initState` → `createCloudImageEditorState` (identical body/signature; DOM callbacks untouched — callback separation is a later phase).
- No circular import: the `SharedState` import is `import type` (erased at compile time).

### Verification
`tsc:app` · `tsc` (incl. `tsc:e2e`) · `test:types` · `test:specs` (673) · `test:locales` · `lint` green. Editor e2e (`cloud-image-editor` + `plugins/cloud-image-editor`, 13 tests) green — proves no behavior change. Full e2e on CI.

### Context
Plan: `docs/superpowers/plans/2026-07-15-v2-m12-cloud-image-editor-port.md`. P1 PoC validated the DOM-free-controller-via-`@lit/context`-over-`ChildBlock` architecture. Next: P3 builds the real `CloudImageEditorController` + editor `@lit/context` + `EditorChildBlock` base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal state management for the cloud image editor.
  * Consolidated image editor state definitions for more consistent behavior across components.
  * Updated related references and documentation comments to reflect the revised state initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->