### PR TITLE
feat(m12): CloudImageEditorController + editor @lit/context + EditorChildBlock base

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     },
     {
       "path": "web/uc-cloud-image-editor.min.js",
-      "limit": "50 KB"
+      "limit": "53 KB"
     },
     {
       "path": "web/uc-file-uploader-regular.min.js",

--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     },
     {
       "path": "web/uc-cloud-image-editor.min.js",
-      "limit": "53 KB"
+      "limit": "50 KB"
     },
     {
       "path": "web/uc-file-uploader-regular.min.js",

--- a/src/abstract/controllers/CloudImageEditorController.test.ts
+++ b/src/abstract/controllers/CloudImageEditorController.test.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it, vi } from 'vitest';
+import { TabId } from '../../blocks/CloudImageEditor/src/toolbar-constants';
+import { CloudImageEditorController } from './CloudImageEditorController';
+
+describe('CloudImageEditorController', () => {
+  it('seeds the cross-cutting defaults', () => {
+    const controller = new CloudImageEditorController();
+    expect(controller.get('*originalUrl')).toBeNull();
+    expect(controller.get('*networkProblems')).toBe(false);
+    expect(controller.get('*tabId')).toBe(TabId.CROP);
+    expect(controller.get('*editorTransformations')).toEqual({});
+    expect(controller.get('*cropPresetList')).toEqual([]);
+    expect(controller.get('*faderEl')).toBeNull();
+    expect(controller.get('*cropperEl')).toBeNull();
+    expect(controller.get('*imgContainerEl')).toBeNull();
+    expect(controller.state).toBe(controller.getState());
+  });
+
+  it('accepts a partial initial state overriding only the given keys', () => {
+    const controller = new CloudImageEditorController({ '*tabId': TabId.FILTERS, '*networkProblems': true });
+    expect(controller.get('*tabId')).toBe(TabId.FILTERS);
+    expect(controller.get('*networkProblems')).toBe(true);
+    // Untouched keys still get their default.
+    expect(controller.get('*originalUrl')).toBeNull();
+  });
+
+  it('set() stores the value and notifies, deduping unchanged writes (Object.is)', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('*originalUrl', 'https://example.com/a.png');
+    expect(controller.get('*originalUrl')).toBe('https://example.com/a.png');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    controller.set('*originalUrl', 'https://example.com/a.png'); // unchanged — no notify
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    controller.set('*originalUrl', 'https://example.com/b.png');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('set() dedup uses Object.is, so NaN written twice does not notify twice', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.set('*currentAspectRatio', { type: 'aspect-ratio', width: Number.NaN, height: 1, id: 'x' });
+    controller.subscribe(listener);
+    const nan = { type: 'aspect-ratio' as const, width: Number.NaN, height: 1, id: 'x' };
+    controller.set('*currentAspectRatio', nan);
+    expect(listener).toHaveBeenCalledTimes(1);
+    controller.set('*currentAspectRatio', nan); // same reference — unchanged
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe fires on every changed key, coarse (not per-key)', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('*tabId', TabId.TUNING);
+    controller.set('*networkProblems', true);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    const off = controller.subscribe(listener);
+    off();
+
+    controller.set('*tabId', TabId.TUNING);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('setHandlers wires apply/cancel/retryNetwork without notifying subscribers', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    const onApply = vi.fn();
+    const onCancel = vi.fn();
+    const onRetryNetwork = vi.fn();
+    controller.setHandlers({ onApply, onCancel, onRetryNetwork });
+    expect(listener).not.toHaveBeenCalled();
+
+    controller.apply({ rotate: 90 });
+    expect(onApply).toHaveBeenCalledWith({ rotate: 90 });
+
+    controller.cancel();
+    expect(onCancel).toHaveBeenCalledTimes(1);
+
+    controller.retryNetwork();
+    expect(onRetryNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it('setHandlers merges partial updates rather than replacing the whole set', () => {
+    const controller = new CloudImageEditorController();
+    const onApply = vi.fn();
+    const onCancel = vi.fn();
+    controller.setHandlers({ onApply, onCancel });
+    controller.setHandlers({ onCancel: vi.fn() });
+
+    controller.apply({});
+    expect(onApply).toHaveBeenCalledTimes(1); // still wired from the first call
+  });
+
+  it('action methods are no-ops when no handler is set', () => {
+    const controller = new CloudImageEditorController();
+    expect(() => controller.apply({})).not.toThrow();
+    expect(() => controller.cancel()).not.toThrow();
+    expect(() => controller.retryNetwork()).not.toThrow();
+  });
+
+  it('destroy() clears subscribers and handlers', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+    const onCancel = vi.fn();
+    controller.setHandlers({ onCancel });
+
+    controller.destroy();
+
+    controller.set('*tabId', TabId.TUNING);
+    expect(listener).not.toHaveBeenCalled();
+
+    controller.cancel();
+    expect(onCancel).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/controllers/CloudImageEditorController.test.ts
+++ b/src/abstract/controllers/CloudImageEditorController.test.ts
@@ -111,6 +111,59 @@ describe('CloudImageEditorController', () => {
     expect(() => controller.retryNetwork()).not.toThrow();
   });
 
+  it('falls back to inert default services until setServices is called', () => {
+    const controller = new CloudImageEditorController();
+    expect(controller.l10n('cancel')).toBe('cancel'); // identity fallback
+    expect(controller.getConfig('pubkey')).toBeUndefined();
+    expect(controller.telemetry.sendEvent({})).toBeUndefined(); // no-op, doesn't throw
+    expect(controller.telemetry.sendEventError(new Error('x'))).toBeUndefined();
+    return expect(controller.proxyUrl('https://example.com/a.png')).resolves.toBe('https://example.com/a.png');
+  });
+
+  it('setServices swaps in the injected l10n/getConfig/telemetry/proxyUrl', async () => {
+    const controller = new CloudImageEditorController();
+    const sendEvent = vi.fn();
+    const sendEventError = vi.fn();
+    controller.setServices({
+      l10n: (key, variables) => `${key}:${JSON.stringify(variables ?? {})}`,
+      getConfig: ((key: string) =>
+        key === 'pubkey' ? 'demopublickey' : undefined) as CloudImageEditorController['getConfig'],
+      telemetry: { sendEvent, sendEventError },
+      proxyUrl: async (url) => `https://proxy.example.com/?u=${url}`,
+    });
+
+    expect(controller.l10n('cancel', { n: 1 })).toBe('cancel:{"n":1}');
+    expect(controller.getConfig('pubkey')).toBe('demopublickey');
+    controller.telemetry.sendEvent({ type: 'x' });
+    expect(sendEvent).toHaveBeenCalledWith({ type: 'x' });
+    controller.telemetry.sendEventError('boom', 'ctx');
+    expect(sendEventError).toHaveBeenCalledWith('boom', 'ctx');
+    await expect(controller.proxyUrl('https://example.com/a.png')).resolves.toBe(
+      'https://proxy.example.com/?u=https://example.com/a.png',
+    );
+  });
+
+  it('constructor accepts services up front, equivalent to setServices', () => {
+    const controller = new CloudImageEditorController(undefined, {
+      l10n: (key) => `pre:${key}`,
+      getConfig: (() => undefined) as CloudImageEditorController['getConfig'],
+      telemetry: { sendEvent: () => {}, sendEventError: () => {} },
+      proxyUrl: async (url) => url,
+    });
+    expect(controller.l10n('cancel')).toBe('pre:cancel');
+  });
+
+  it('notify() fires subscribers with no state change (e.g. after a services swap)', () => {
+    const controller = new CloudImageEditorController();
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.notify();
+    expect(listener).toHaveBeenCalledTimes(1);
+    // No state mutated.
+    expect(controller.get('*tabId')).toBe(TabId.CROP);
+  });
+
   it('destroy() clears subscribers and handlers', () => {
     const controller = new CloudImageEditorController();
     const listener = vi.fn();

--- a/src/abstract/controllers/CloudImageEditorController.test.ts
+++ b/src/abstract/controllers/CloudImageEditorController.test.ts
@@ -40,15 +40,15 @@ describe('CloudImageEditorController', () => {
     expect(listener).toHaveBeenCalledTimes(2);
   });
 
-  it('set() dedup uses Object.is, so NaN written twice does not notify twice', () => {
+  it('set() dedups a re-written same-reference value (no notify)', () => {
     const controller = new CloudImageEditorController();
     const listener = vi.fn();
-    controller.set('*currentAspectRatio', { type: 'aspect-ratio', width: Number.NaN, height: 1, id: 'x' });
+    controller.set('*currentAspectRatio', { type: 'aspect-ratio', width: 16, height: 9, id: 'x' });
     controller.subscribe(listener);
-    const nan = { type: 'aspect-ratio' as const, width: Number.NaN, height: 1, id: 'x' };
-    controller.set('*currentAspectRatio', nan);
+    const ratio = { type: 'aspect-ratio' as const, width: 16, height: 9, id: 'y' };
+    controller.set('*currentAspectRatio', ratio); // new reference — notifies
     expect(listener).toHaveBeenCalledTimes(1);
-    controller.set('*currentAspectRatio', nan); // same reference — unchanged
+    controller.set('*currentAspectRatio', ratio); // same reference — Object.is dedup, no notify
     expect(listener).toHaveBeenCalledTimes(1);
   });
 

--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -1,6 +1,7 @@
 import type { CloudImageEditorState } from '../../blocks/CloudImageEditor/src/state';
 import { ALL_TABS, TabId } from '../../blocks/CloudImageEditor/src/toolbar-constants';
 import type { Transformations } from '../../blocks/CloudImageEditor/src/types';
+import type { ConfigType } from '../../types';
 import { Listeners } from '../host-subscription';
 
 /**
@@ -58,12 +59,43 @@ export type CloudImageEditorHandlers = {
 };
 
 /**
+ * Cross-cutting services the editor needs but does not own — injected by the
+ * root (from whatever it resolves them from: today's shared uploader ctx,
+ * later potentially a fully standalone config/locale). Descendants read them
+ * ALL through the controller (`controller.l10n(...)`, `controller.getConfig`,
+ * `controller.telemetry`, `controller.proxyUrl`) instead of reaching back
+ * into `ChildBlock`/the uploader ctx directly — this is what lets editor
+ * blocks be a plain Lit base with no `ensureUploaderCtx`/`UploaderRegistry`
+ * value-import (see `EditorBlock` in `editor-context.ts`).
+ */
+export interface EditorServices {
+  l10n: (key: string, variables?: Record<string, string | number>) => string;
+  getConfig: <K extends keyof ConfigType>(key: K) => ConfigType[K];
+  telemetry: { sendEvent: (e: unknown) => void; sendEventError: (err: unknown, ctx?: unknown) => void };
+  proxyUrl: (url: string) => Promise<string>;
+}
+
+/** Inert fallback services used until the root injects the real ones (`setServices`) — keeps the controller safely usable standalone (e.g. in unit tests) without throwing. */
+function createDefaultServices(): EditorServices {
+  return {
+    l10n: (key) => key,
+    // No real config to read yet — `undefined` as a stand-in until `setServices`
+    // injects the real accessor; narrow cast at this one boundary (default-only).
+    getConfig: <K extends keyof ConfigType>(_key: K) => undefined as unknown as ConfigType[K],
+    telemetry: { sendEvent: () => {}, sendEventError: () => {} },
+    proxyUrl: async (url) => url,
+  };
+}
+
+/**
  * DOM-free editor controller (the `UploaderController`/`ConfigController`
- * pattern — no `lit`, no DOM). Owns ONLY the cross-cutting editor state (see
- * `CloudImageEditorControllerState`) plus the editor's action callbacks.
+ * pattern — no `lit`, no DOM). Owns the cross-cutting editor state (see
+ * `CloudImageEditorControllerState`), the editor's action callbacks, and an
+ * injected `EditorServices` seam (l10n/config/telemetry/proxy) so descendants
+ * never need to reach back into `ChildBlock`/the uploader ctx directly.
  * Provided down the editor DOM tree via `cloudImageEditorContext`
  * (`@lit/context`) from the root `<uc-cloud-image-editor>`; consumed by
- * `EditorChildBlock` descendants.
+ * `EditorBlock` descendants.
  *
  * Block-coupled DOM-free logic (transformations, tab/filter/operation state
  * machine, image-URL/modifier computation) accretes here as each block ports
@@ -73,9 +105,54 @@ export class CloudImageEditorController {
   private _state: CloudImageEditorControllerState;
   private _listeners = new Listeners();
   private _handlers: Partial<CloudImageEditorHandlers> = {};
+  private _services: EditorServices;
 
-  public constructor(initial?: Partial<CloudImageEditorControllerState>) {
+  public constructor(initial?: Partial<CloudImageEditorControllerState>, services?: EditorServices) {
     this._state = { ...createDefaultState(), ...initial };
+    this._services = services ?? createDefaultServices();
+  }
+
+  /**
+   * Inject (or replace) the cross-cutting services. Called by the root once
+   * it has resolved the real l10n/config/telemetry/proxy sources. Does not
+   * itself notify subscribers — callers that want descendants to re-render
+   * on a services swap (e.g. a locale/config change) should follow up with
+   * `notify()`.
+   */
+  public setServices(services: EditorServices): void {
+    this._services = services;
+  }
+
+  /** Locale lookup — same contract as `ChildBlock.l10n`/`createL10n` (key fallback, template variables, pluralization upstream). */
+  public l10n(key: string, variables?: Record<string, string | number>): string {
+    return this._services.l10n(key, variables);
+  }
+
+  /** Read a config value from the injected services (today: the shared uploader ctx's config, resolved by the root). */
+  public getConfig<K extends keyof ConfigType>(key: K): ConfigType[K] {
+    return this._services.getConfig(key);
+  }
+
+  /** The injected telemetry sink. */
+  public get telemetry(): EditorServices['telemetry'] {
+    return this._services.telemetry;
+  }
+
+  /** Resolve a CDN url through the configured secure-delivery proxy, if any — delegates to the injected services. */
+  public proxyUrl(url: string): Promise<string> {
+    return this._services.proxyUrl(url);
+  }
+
+  /**
+   * Coarse notify with no state change — for the root to call after swapping
+   * services (`setServices`) or otherwise mutating something descendants
+   * read through the controller but that isn't itself a `CloudImageEditorControllerState`
+   * key (e.g. a locale dictionary load or a config change upstream). Reuses
+   * the same `Listeners` instance as `set()`, so `EditorBlock`'s automatic
+   * re-render subscription picks it up for free.
+   */
+  public notify(): void {
+    this._listeners.notify();
   }
 
   /** Current state snapshot (read-only reference — mutate via `set`). */

--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -1,0 +1,131 @@
+import type { CloudImageEditorState } from '../../blocks/CloudImageEditor/src/state';
+import { ALL_TABS, TabId } from '../../blocks/CloudImageEditor/src/toolbar-constants';
+import type { Transformations } from '../../blocks/CloudImageEditor/src/types';
+import { Listeners } from '../host-subscription';
+
+/**
+ * The cross-cutting subset of `CloudImageEditorState` (M12 "State scoping
+ * principle") — keys read/written across more than one component subtree of
+ * the editor. The cropper-local (`*padding`/`*operations`/`*imageBox`/
+ * `*cropBox`) and toolbar-local (`*showListAspectRatio`/`*sliderEl`/
+ * `*showSlider`/`*currentFilter`/`*currentOperation`/`*operationTooltip`) keys
+ * are deliberately excluded — they become plain Lit `@state` on their owning
+ * element when that subtree ports (P6), not controller state.
+ *
+ * `*faderEl`/`*cropperEl`/`*imgContainerEl` are cross-component coordination
+ * refs (a smell, flagged in the plan for a later refinement to controller
+ * methods) — the controller only stores/returns them, it never touches the
+ * DOM itself.
+ */
+export type CloudImageEditorControllerState = Pick<
+  CloudImageEditorState,
+  | '*originalUrl'
+  | '*loadingOperations'
+  | '*networkProblems'
+  | '*imageSize'
+  | '*editorTransformations'
+  | '*cropPresetList'
+  | '*currentAspectRatio'
+  | '*tabList'
+  | '*tabId'
+  | '*faderEl'
+  | '*cropperEl'
+  | '*imgContainerEl'
+>;
+
+function createDefaultState(): CloudImageEditorControllerState {
+  return {
+    '*originalUrl': null,
+    '*loadingOperations': new Map(),
+    '*networkProblems': false,
+    '*imageSize': null,
+    '*editorTransformations': {},
+    '*cropPresetList': [],
+    '*currentAspectRatio': null,
+    '*tabList': ALL_TABS,
+    '*tabId': TabId.CROP,
+    '*faderEl': null,
+    '*cropperEl': null,
+    '*imgContainerEl': null,
+  };
+}
+
+/** The editor's action callbacks — set by the root, invoked by descendants via the controller's methods. Not state: overwriting a handler does not notify subscribers. */
+export type CloudImageEditorHandlers = {
+  onApply: (transformations: Transformations) => void;
+  onCancel: () => void;
+  onRetryNetwork: () => void;
+};
+
+/**
+ * DOM-free editor controller (the `UploaderController`/`ConfigController`
+ * pattern — no `lit`, no DOM). Owns ONLY the cross-cutting editor state (see
+ * `CloudImageEditorControllerState`) plus the editor's action callbacks.
+ * Provided down the editor DOM tree via `cloudImageEditorContext`
+ * (`@lit/context`) from the root `<uc-cloud-image-editor>`; consumed by
+ * `EditorChildBlock` descendants.
+ *
+ * Block-coupled DOM-free logic (transformations, tab/filter/operation state
+ * machine, image-URL/modifier computation) accretes here as each block ports
+ * in P5/P6 (strangler) — kept minimal in this phase (state container only).
+ */
+export class CloudImageEditorController {
+  private _state: CloudImageEditorControllerState;
+  private _listeners = new Listeners();
+  private _handlers: Partial<CloudImageEditorHandlers> = {};
+
+  public constructor(initial?: Partial<CloudImageEditorControllerState>) {
+    this._state = { ...createDefaultState(), ...initial };
+  }
+
+  /** Current state snapshot (read-only reference — mutate via `set`). */
+  public get state(): Readonly<CloudImageEditorControllerState> {
+    return this._state;
+  }
+
+  public getState(): Readonly<CloudImageEditorControllerState> {
+    return this._state;
+  }
+
+  public get<K extends keyof CloudImageEditorControllerState>(key: K): CloudImageEditorControllerState[K] {
+    return this._state[key];
+  }
+
+  /** Notifies only when the value actually changes (`Object.is` dedup), same contract as `ConfigController.set`. */
+  public set<K extends keyof CloudImageEditorControllerState>(key: K, value: CloudImageEditorControllerState[K]): void {
+    if (Object.is(this._state[key], value)) return;
+    this._state[key] = value;
+    this._listeners.notify();
+  }
+
+  /** Coarse subscribe — fires on any state change, not per-key (mirrors `ConfigController.subscribe`). */
+  public subscribe(listener: () => void): () => void {
+    return this._listeners.subscribe(listener);
+  }
+
+  /**
+   * Set (or replace) the editor's action handlers. Called by the root once it
+   * has resolved the actual apply/cancel/retryNetwork behavior. Handlers are
+   * plain callbacks, not state — setting them does not notify subscribers.
+   */
+  public setHandlers(handlers: Partial<CloudImageEditorHandlers>): void {
+    this._handlers = { ...this._handlers, ...handlers };
+  }
+
+  public apply(transformations: Transformations): void {
+    this._handlers.onApply?.(transformations);
+  }
+
+  public cancel(): void {
+    this._handlers.onCancel?.();
+  }
+
+  public retryNetwork(): void {
+    this._handlers.onRetryNetwork?.();
+  }
+
+  public destroy(): void {
+    this._listeners.clear();
+    this._handlers = {};
+  }
+}

--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -118,6 +118,9 @@ export class CloudImageEditorController {
    * itself notify subscribers — callers that want descendants to re-render
    * on a services swap (e.g. a locale/config change) should follow up with
    * `notify()`.
+   *
+   * Replaces the whole set (unlike `setHandlers`, which merges) — `EditorServices`
+   * is a complete, non-partial interface, so a full object is always required.
    */
   public setServices(services: EditorServices): void {
     this._services = services;

--- a/src/blocks/CloudImageEditor/src/editor-context.ts
+++ b/src/blocks/CloudImageEditor/src/editor-context.ts
@@ -1,14 +1,15 @@
 import { ContextConsumer, createContext } from '@lit/context';
-import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { LitElement, type ReactiveController, type ReactiveControllerHost } from 'lit';
 import type { CloudImageEditorController } from '../../../abstract/controllers/CloudImageEditorController';
-import { ChildBlock } from '../../../lit/ChildBlock';
+import { LightDomMixin } from '../../../lit/LightDomMixin';
+import { RegisterableElementMixin } from '../../../lit/RegisterableElementMixin';
 
 /**
  * The editor's own `@lit/context` — resolved by DOM ancestry, distinct from
  * (and coexisting with) the uploader ctx's `ctxNameContext`. The root
  * `<uc-cloud-image-editor>` provides a `CloudImageEditorController` instance
  * here (`ContextProvider`, wired in a later phase); descendants consume it
- * through `CloudImageEditorContextController`/`EditorChildBlock` below.
+ * through `CloudImageEditorContextController`/`EditorBlock` below.
  */
 export const cloudImageEditorContext = createContext<CloudImageEditorController>('cloud-image-editor-controller');
 
@@ -24,7 +25,7 @@ export class CloudImageEditorContextController implements ReactiveController {
   private _controller?: CloudImageEditorController;
   private _subscriptions = new Set<() => void>();
   // Attach listeners are persistent (unlike the spike's one-shot `onAttach`,
-  // which existed only to gate a single `initCallback` run): `EditorChildBlock`
+  // which existed only to gate a single `initCallback` run): `EditorBlock`
   // needs its re-render subscription re-wired on every (re)attach, not just
   // the first, so a listener registered via `onAttach` fires immediately if a
   // controller is already adopted, and again on every later (re)attach.
@@ -46,8 +47,8 @@ export class CloudImageEditorContextController implements ReactiveController {
 
   public hostDisconnected(): void {
     this._cleanupSubscriptions();
-    // Forget the adopted controller (not just its subscriptions): `ChildBlock`
-    // is light-DOM (`LightDomMixin`), and re-rendering an ancestor that
+    // Forget the adopted controller (not just its subscriptions): the editor
+    // base is light-DOM (`LightDomMixin`), and re-rendering an ancestor that
     // `yield()`s this host can physically re-`insertBefore` the same DOM node
     // — which fires disconnectedCallback then connectedCallback back to back
     // for the *same* controller instance. Without this reset, `_attach`'s
@@ -112,23 +113,40 @@ export class CloudImageEditorContextController implements ReactiveController {
   }
 }
 
+// Light-DOM Lit base with NO ChildBlock coupling: no `ensureUploaderCtx`
+// (which value-imports the `UploaderController` graph), no `UploaderRegistry`
+// (adopt/registry machinery), no ctx-lifecycle, no upload stack. See the
+// "Bundle-independence constraints" section of the M12 plan
+// (`docs/superpowers/plans/2026-07-15-v2-m12-cloud-image-editor-port.md`):
+// editor blocks must not pull that machinery into the standalone editor
+// bundle. Only the two structural mixins ChildBlock itself is built on.
+const EditorBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
+
 /**
- * Base for editor descendants: the uploader surface (`l10n`, `bag`,
- * `proxyUrl`, `subConfigValue`, …) via `ChildBlock`, plus the editor
- * controller consumer. The ROOT *provides* the controller (via
- * `ContextProvider`, wired when `CloudImageEditorBlock` ports in P5) — this
- * base only *consumes*.
+ * Base for editor descendants. Deliberately NOT `ChildBlock` — see the
+ * "Bundle-independence constraints" in the M12 plan: `ChildBlock`
+ * value-imports `ensureUploaderCtx`/`UploaderRegistry` (the `UploaderController`
+ * adoption graph), which would bloat the standalone `<uc-cloud-image-editor>`
+ * bundle with uploader machinery it doesn't use today.
+ *
+ * Descendants get EVERYTHING — cross-cutting editor state AND the
+ * l10n/config/telemetry/proxy services — through `this.editorController`,
+ * which the root injects (`CloudImageEditorController.setServices`) from
+ * whatever it resolves them from (today: the shared uploader ctx read by the
+ * root only; see the plan for the deferred fully-standalone follow-up). No
+ * ctx-name resolution, no uploader ctx read, happens in this base or its
+ * descendants.
  */
-export abstract class EditorChildBlock extends ChildBlock {
+export abstract class EditorBlock extends EditorBlockBase {
   private readonly _editorCtx = new CloudImageEditorContextController(this);
   private _editorRerenderSub?: () => void;
 
   public constructor() {
     super();
-    // Re-render whenever the editor controller notifies — wired on every
-    // (re)attach so a controller swap (exotic, but symmetric with
-    // `ChildBlock`'s own controller re-adoption) doesn't leave a stale
-    // subscription behind.
+    // Re-render whenever the editor controller notifies (state change,
+    // `notify()` after a services swap, etc.) — wired on every (re)attach so
+    // a controller swap (exotic, but symmetric with `ChildBlock`'s own
+    // controller re-adoption) doesn't leave a stale subscription behind.
     this._editorCtx.onAttach(() => {
       this._editorRerenderSub?.();
       this._editorRerenderSub = this._editorCtx.subscribe(() => this.requestUpdate());

--- a/src/blocks/CloudImageEditor/src/editor-context.ts
+++ b/src/blocks/CloudImageEditor/src/editor-context.ts
@@ -1,0 +1,161 @@
+import { ContextConsumer, createContext } from '@lit/context';
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import type { CloudImageEditorController } from '../../../abstract/controllers/CloudImageEditorController';
+import { ChildBlock } from '../../../lit/ChildBlock';
+
+/**
+ * The editor's own `@lit/context` — resolved by DOM ancestry, distinct from
+ * (and coexisting with) the uploader ctx's `ctxNameContext`. The root
+ * `<uc-cloud-image-editor>` provides a `CloudImageEditorController` instance
+ * here (`ContextProvider`, wired in a later phase); descendants consume it
+ * through `CloudImageEditorContextController`/`EditorChildBlock` below.
+ */
+export const cloudImageEditorContext = createContext<CloudImageEditorController>('cloud-image-editor-controller');
+
+/**
+ * `ReactiveController` that adopts the `CloudImageEditorController` provided
+ * by the nearest ancestor `ContextProvider`. Adapted from the
+ * `refactor/editor-separate-state` spike's `CloudImageEditorContextController`
+ * (`git show 682d7172:.../context.ts`) for the v2 DOM-free-controller
+ * architecture: the spike wrapped a raw `PubSub` store, this wraps the real
+ * `CloudImageEditorController`.
+ */
+export class CloudImageEditorContextController implements ReactiveController {
+  private _controller?: CloudImageEditorController;
+  private _subscriptions = new Set<() => void>();
+  // Attach listeners are persistent (unlike the spike's one-shot `onAttach`,
+  // which existed only to gate a single `initCallback` run): `EditorChildBlock`
+  // needs its re-render subscription re-wired on every (re)attach, not just
+  // the first, so a listener registered via `onAttach` fires immediately if a
+  // controller is already adopted, and again on every later (re)attach.
+  private _onAttachCallbacks = new Set<() => void>();
+  private readonly _consumer: ContextConsumer<typeof cloudImageEditorContext, ReactiveControllerHost & HTMLElement>;
+
+  public constructor(host: ReactiveControllerHost & HTMLElement) {
+    host.addController(this);
+    this._consumer = new ContextConsumer(host, {
+      context: cloudImageEditorContext,
+      subscribe: true,
+      callback: (value) => this._attach(value),
+    });
+  }
+
+  public hostConnected(): void {
+    this._attach(this._consumer.value);
+  }
+
+  public hostDisconnected(): void {
+    this._cleanupSubscriptions();
+    // Forget the adopted controller (not just its subscriptions): `ChildBlock`
+    // is light-DOM (`LightDomMixin`), and re-rendering an ancestor that
+    // `yield()`s this host can physically re-`insertBefore` the same DOM node
+    // — which fires disconnectedCallback then connectedCallback back to back
+    // for the *same* controller instance. Without this reset, `_attach`'s
+    // `controller === this._controller` dedup would treat that reconnect as a
+    // no-op and never re-run the attach callbacks, leaving the subscriptions
+    // just torn down above permanently dropped.
+    this._controller = undefined;
+  }
+
+  /** The adopted controller. Throws if no provider ancestor has resolved yet — read it from `controllerOrNull`, or defer to `onAttach`, when adoption timing isn't guaranteed. */
+  public get controller(): CloudImageEditorController {
+    if (!this._controller) {
+      throw new Error(
+        'CloudImageEditorController is not available yet — no cloudImageEditorContext provider ancestor.',
+      );
+    }
+    return this._controller;
+  }
+
+  public get controllerOrNull(): CloudImageEditorController | null {
+    return this._controller ?? null;
+  }
+
+  /** Subscribe to the adopted controller; auto-unsubscribes on host disconnect or controller re-attach. Throws if no controller is adopted yet (see `onAttach`). */
+  public subscribe(callback: () => void): () => void {
+    const unsubscribe = this.controller.subscribe(callback);
+    const tracked = () => {
+      unsubscribe();
+      this._subscriptions.delete(tracked);
+    };
+    this._subscriptions.add(tracked);
+    return tracked;
+  }
+
+  /** Runs `callback` once immediately if a controller is already adopted, then again on every later (re)attach. */
+  public onAttach(callback: () => void): void {
+    this._onAttachCallbacks.add(callback);
+    if (this._controller) {
+      callback();
+    }
+  }
+
+  private _attach(controller?: CloudImageEditorController): void {
+    if (!controller || controller === this._controller) {
+      return;
+    }
+    this._cleanupSubscriptions();
+    this._controller = controller;
+    for (const cb of this._onAttachCallbacks) {
+      cb();
+    }
+  }
+
+  private _cleanupSubscriptions(): void {
+    if (this._subscriptions.size === 0) {
+      return;
+    }
+    for (const unsubscribe of [...this._subscriptions]) {
+      unsubscribe();
+    }
+    this._subscriptions.clear();
+  }
+}
+
+/**
+ * Base for editor descendants: the uploader surface (`l10n`, `bag`,
+ * `proxyUrl`, `subConfigValue`, …) via `ChildBlock`, plus the editor
+ * controller consumer. The ROOT *provides* the controller (via
+ * `ContextProvider`, wired when `CloudImageEditorBlock` ports in P5) — this
+ * base only *consumes*.
+ */
+export abstract class EditorChildBlock extends ChildBlock {
+  private readonly _editorCtx = new CloudImageEditorContextController(this);
+  private _editorRerenderSub?: () => void;
+
+  public constructor() {
+    super();
+    // Re-render whenever the editor controller notifies — wired on every
+    // (re)attach so a controller swap (exotic, but symmetric with
+    // `ChildBlock`'s own controller re-adoption) doesn't leave a stale
+    // subscription behind.
+    this._editorCtx.onAttach(() => {
+      this._editorRerenderSub?.();
+      this._editorRerenderSub = this._editorCtx.subscribe(() => this.requestUpdate());
+    });
+  }
+
+  /** The adopted `CloudImageEditorController`. Throws if no provider ancestor exists yet. */
+  protected get editorController(): CloudImageEditorController {
+    return this._editorCtx.controller;
+  }
+
+  protected get editorControllerOrNull(): CloudImageEditorController | null {
+    return this._editorCtx.controllerOrNull;
+  }
+
+  /**
+   * Extra editor-controller subscription beyond the automatic re-render one
+   * above (e.g. to run side effects, not just `requestUpdate`). Auto-tracked
+   * with the editor context's lifecycle (unsubscribes on host disconnect or
+   * controller re-attach) — no manual teardown needed.
+   */
+  protected subscribeEditor(callback: () => void): () => void {
+    return this._editorCtx.subscribe(callback);
+  }
+
+  /** Run `callback` once the editor controller is available (immediately if already attached, else on first/next attach). */
+  protected onEditorAttach(callback: () => void): void {
+    this._editorCtx.onAttach(callback);
+  }
+}

--- a/tests/blocks/editor-child-block.e2e.test.tsx
+++ b/tests/blocks/editor-child-block.e2e.test.tsx
@@ -119,6 +119,31 @@ describe('EditorChildBlock / cloudImageEditorContext', () => {
     expect(requestUpdateSpy).not.toHaveBeenCalled();
   });
 
+  it('keeps re-rendering after a light-DOM reconnect of the same node (the reconnect-fix guard)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    root.id = 'test-editor-root-reconnect';
+    const child = document.createElement('uc-test-editor-child');
+    child.id = 'test-editor-child-reconnect';
+    root.append(child);
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
+
+    // Light-DOM reconnect: remove + re-append the SAME node — exactly what an
+    // ancestor re-render via `this.yield('')` does under the hood
+    // (`insertBefore` fires disconnectedCallback + connectedCallback
+    // back-to-back on the same element). The `CloudImageEditorContextController`
+    // must re-establish its re-render subscription; the reconnect fix (resetting
+    // `_controller` in `hostDisconnected`) exists precisely so `_attach`'s
+    // identity-dedup doesn't silently drop it. Without the fix this poll times
+    // out (child stays 'crop').
+    child.remove();
+    root.append(child);
+
+    root.controller.set('*tabId', 'tuning');
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('tuning');
+  });
+
   it('root teardown does not throw and leaves the controller usable (root does not own controller.destroy in this phase)', async () => {
     const ctxName = getCtxName();
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);

--- a/tests/blocks/editor-child-block.e2e.test.tsx
+++ b/tests/blocks/editor-child-block.e2e.test.tsx
@@ -1,0 +1,138 @@
+import { ContextProvider } from '@lit/context';
+import { html } from 'lit';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import { CloudImageEditorController } from '@/abstract/controllers/CloudImageEditorController';
+import { cloudImageEditorContext, EditorChildBlock } from '@/blocks/CloudImageEditor/src/editor-context';
+import { ChildBlock } from '@/lit/ChildBlock';
+import { getCtxName } from '../utils/getCtxName';
+import '../../types/jsx';
+
+/**
+ * Throwaway coverage tags for M12 P3 infrastructure: a `ChildBlock`-rooted
+ * provider (real editor blocks provide the controller from `P5` onward — this
+ * root stands in for that) and an `EditorChildBlock` consumer. Not real
+ * editor blocks — just enough to prove the context + base wiring.
+ */
+class TestEditorRoot extends ChildBlock {
+  public readonly controller = new CloudImageEditorController();
+  // biome-ignore lint/correctness/noUnusedPrivateClassMembers: `ContextProvider` provides by side effect — the field keeps it alive for the host's lifetime.
+  private readonly _provider = new ContextProvider(this, {
+    context: cloudImageEditorContext,
+    initialValue: this.controller,
+  });
+
+  public override render() {
+    // ChildBlock is light-DOM (LightDomMixin) — render via `this.yield('')`,
+    // NOT a literal `<slot>`, or projected children silently vanish (M12 PoC
+    // gotcha).
+    return html`${this.yield('')}`;
+  }
+}
+
+class TestEditorChild extends EditorChildBlock {
+  public override render() {
+    return html`<span class="tab-id">${this.editorControllerOrNull?.get('*tabId') ?? ''}</span
+      ><span class="l10n">${this.l10n('cancel')}</span>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'uc-test-editor-root': TestEditorRoot;
+    'uc-test-editor-child': TestEditorChild;
+  }
+}
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+  if (!customElements.get('uc-test-editor-root')) customElements.define('uc-test-editor-root', TestEditorRoot);
+  if (!customElements.get('uc-test-editor-child')) customElements.define('uc-test-editor-child', TestEditorChild);
+});
+
+const appended: HTMLElement[] = [];
+const append = <K extends keyof HTMLElementTagNameMap>(tag: K, attrs: Record<string, string> = {}) => {
+  const el = document.createElement(tag);
+  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  document.body.append(el);
+  appended.push(el);
+  return el;
+};
+
+afterEach(() => {
+  for (const el of appended) el.remove();
+  appended.length = 0;
+});
+
+describe('EditorChildBlock / cloudImageEditorContext', () => {
+  it('resolves the provided controller, renders its state, reads the uploader l10n surface, and re-renders on set()', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    root.id = 'test-editor-root-direct';
+    const child = document.createElement('uc-test-editor-child');
+    child.id = 'test-editor-child-direct';
+    root.append(child);
+
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
+    // Uploader surface (`l10n`) resolved alongside the editor context, on the
+    // same ChildBlock/EditorChildBlock.
+    await expect.poll(() => child.querySelector('.l10n')?.textContent).toBe('Cancel');
+
+    root.controller.set('*tabId', 'tuning');
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('tuning');
+  });
+
+  it('resolves the editor context through an intervening plain element, two levels deep', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    root.id = 'test-editor-root-nested';
+    const wrapper = document.createElement('div');
+    root.append(wrapper);
+    const child = document.createElement('uc-test-editor-child');
+    child.id = 'test-editor-child-nested';
+    wrapper.append(child);
+
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
+
+    root.controller.set('*tabId', 'filters');
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('filters');
+  });
+
+  it('stops re-rendering once the child disconnects (no dangling subscription)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    const child = document.createElement('uc-test-editor-child');
+    root.append(child);
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
+
+    const requestUpdateSpy = vi.spyOn(child, 'requestUpdate');
+    child.remove();
+    requestUpdateSpy.mockClear();
+
+    root.controller.set('*tabId', 'tuning');
+    // Give any (incorrect) surviving subscription a tick to fire.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(requestUpdateSpy).not.toHaveBeenCalled();
+  });
+
+  it('root teardown does not throw and leaves the controller usable (root does not own controller.destroy in this phase)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    const child = document.createElement('uc-test-editor-child');
+    root.append(child);
+    await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
+
+    const { controller } = root;
+    expect(() => root.remove()).not.toThrow();
+    // The controller itself outlives this throwaway root (its lifecycle is
+    // owned by whichever real element provides it — P5); it must still be a
+    // plain, usable object post-disconnect.
+    expect(() => controller.set('*tabId', 'tuning')).not.toThrow();
+    expect(controller.get('*tabId')).toBe('tuning');
+  });
+});

--- a/tests/blocks/editor-child-block.e2e.test.tsx
+++ b/tests/blocks/editor-child-block.e2e.test.tsx
@@ -1,21 +1,32 @@
 import { ContextProvider } from '@lit/context';
-import { html } from 'lit';
+import { html, LitElement } from 'lit';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
-import { page } from 'vitest/browser';
-import { CloudImageEditorController } from '@/abstract/controllers/CloudImageEditorController';
-import { cloudImageEditorContext, EditorChildBlock } from '@/blocks/CloudImageEditor/src/editor-context';
-import { ChildBlock } from '@/lit/ChildBlock';
-import { getCtxName } from '../utils/getCtxName';
+import { CloudImageEditorController, type EditorServices } from '@/abstract/controllers/CloudImageEditorController';
+import { cloudImageEditorContext, EditorBlock } from '@/blocks/CloudImageEditor/src/editor-context';
+import { LightDomMixin } from '@/lit/LightDomMixin';
+import { RegisterableElementMixin } from '@/lit/RegisterableElementMixin';
 import '../../types/jsx';
 
 /**
- * Throwaway coverage tags for M12 P3 infrastructure: a `ChildBlock`-rooted
- * provider (real editor blocks provide the controller from `P5` onward — this
- * root stands in for that) and an `EditorChildBlock` consumer. Not real
- * editor blocks — just enough to prove the context + base wiring.
+ * Throwaway coverage tags for M12 P3 (reworked) infrastructure: a light,
+ * non-`ChildBlock` root that constructs a `CloudImageEditorController` with
+ * simple inline services and provides it via `ContextProvider`, and an
+ * `EditorBlock` consumer. Not real editor blocks — just enough to prove the
+ * context + light-base wiring per the "Bundle-independence constraints" (the
+ * root here stands in for the real `CloudImageEditorBlock`, wired in P5).
  */
-class TestEditorRoot extends ChildBlock {
-  public readonly controller = new CloudImageEditorController();
+const TestEditorRootBase = RegisterableElementMixin(LightDomMixin(LitElement));
+
+class TestEditorRoot extends TestEditorRootBase {
+  public readonly telemetrySendEvent = vi.fn();
+  public readonly telemetrySendEventError = vi.fn();
+  public readonly controller = new CloudImageEditorController(undefined, {
+    l10n: (key) => (key === 'cancel' ? 'Cancel' : key),
+    getConfig: ((key: string) => (key === 'pubkey' ? 'demopublickey' : undefined)) as EditorServices['getConfig'],
+    telemetry: { sendEvent: this.telemetrySendEvent, sendEventError: this.telemetrySendEventError },
+    proxyUrl: async (url) => url,
+  });
+
   // biome-ignore lint/correctness/noUnusedPrivateClassMembers: `ContextProvider` provides by side effect — the field keeps it alive for the host's lifetime.
   private readonly _provider = new ContextProvider(this, {
     context: cloudImageEditorContext,
@@ -23,17 +34,16 @@ class TestEditorRoot extends ChildBlock {
   });
 
   public override render() {
-    // ChildBlock is light-DOM (LightDomMixin) — render via `this.yield('')`,
-    // NOT a literal `<slot>`, or projected children silently vanish (M12 PoC
-    // gotcha).
+    // Light-DOM — render via `this.yield('')`, NOT a literal `<slot>`, or
+    // projected children silently vanish (M12 PoC gotcha).
     return html`${this.yield('')}`;
   }
 }
 
-class TestEditorChild extends EditorChildBlock {
+class TestEditorChild extends EditorBlock {
   public override render() {
     return html`<span class="tab-id">${this.editorControllerOrNull?.get('*tabId') ?? ''}</span
-      ><span class="l10n">${this.l10n('cancel')}</span>`;
+      ><span class="l10n">${this.editorControllerOrNull?.l10n('cancel') ?? ''}</span>`;
   }
 }
 
@@ -44,17 +54,15 @@ declare global {
   }
 }
 
-beforeAll(async () => {
-  const UC = await import('@/index.js');
-  UC.defineComponents(UC);
+beforeAll(() => {
   if (!customElements.get('uc-test-editor-root')) customElements.define('uc-test-editor-root', TestEditorRoot);
   if (!customElements.get('uc-test-editor-child')) customElements.define('uc-test-editor-child', TestEditorChild);
 });
 
 const appended: HTMLElement[] = [];
-const append = <K extends keyof HTMLElementTagNameMap>(tag: K, attrs: Record<string, string> = {}) => {
+const append = <K extends keyof HTMLElementTagNameMap>(tag: K, id: string) => {
   const el = document.createElement(tag);
-  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  el.id = id;
   document.body.append(el);
   appended.push(el);
   return el;
@@ -65,19 +73,15 @@ afterEach(() => {
   appended.length = 0;
 });
 
-describe('EditorChildBlock / cloudImageEditorContext', () => {
-  it('resolves the provided controller, renders its state, reads the uploader l10n surface, and re-renders on set()', async () => {
-    const ctxName = getCtxName();
-    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
-    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
-    root.id = 'test-editor-root-direct';
+describe('EditorBlock / cloudImageEditorContext (light, non-ChildBlock base)', () => {
+  it('resolves the provided controller, renders its state, reads the injected l10n service, and re-renders on set()', async () => {
+    const root = append('uc-test-editor-root', 'test-editor-root-direct');
     const child = document.createElement('uc-test-editor-child');
     child.id = 'test-editor-child-direct';
     root.append(child);
 
     await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
-    // Uploader surface (`l10n`) resolved alongside the editor context, on the
-    // same ChildBlock/EditorChildBlock.
+    // Services surface (`l10n`), read through the controller — not ChildBlock.
     await expect.poll(() => child.querySelector('.l10n')?.textContent).toBe('Cancel');
 
     root.controller.set('*tabId', 'tuning');
@@ -85,10 +89,7 @@ describe('EditorChildBlock / cloudImageEditorContext', () => {
   });
 
   it('resolves the editor context through an intervening plain element, two levels deep', async () => {
-    const ctxName = getCtxName();
-    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
-    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
-    root.id = 'test-editor-root-nested';
+    const root = append('uc-test-editor-root', 'test-editor-root-nested');
     const wrapper = document.createElement('div');
     root.append(wrapper);
     const child = document.createElement('uc-test-editor-child');
@@ -102,10 +103,9 @@ describe('EditorChildBlock / cloudImageEditorContext', () => {
   });
 
   it('stops re-rendering once the child disconnects (no dangling subscription)', async () => {
-    const ctxName = getCtxName();
-    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
-    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    const root = append('uc-test-editor-root', 'test-editor-root-teardown');
     const child = document.createElement('uc-test-editor-child');
+    child.id = 'test-editor-child-teardown';
     root.append(child);
     await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');
 
@@ -120,10 +120,7 @@ describe('EditorChildBlock / cloudImageEditorContext', () => {
   });
 
   it('keeps re-rendering after a light-DOM reconnect of the same node (the reconnect-fix guard)', async () => {
-    const ctxName = getCtxName();
-    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
-    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
-    root.id = 'test-editor-root-reconnect';
+    const root = append('uc-test-editor-root', 'test-editor-root-reconnect');
     const child = document.createElement('uc-test-editor-child');
     child.id = 'test-editor-child-reconnect';
     root.append(child);
@@ -145,9 +142,7 @@ describe('EditorChildBlock / cloudImageEditorContext', () => {
   });
 
   it('root teardown does not throw and leaves the controller usable (root does not own controller.destroy in this phase)', async () => {
-    const ctxName = getCtxName();
-    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
-    const root = append('uc-test-editor-root', { 'ctx-name': ctxName });
+    const root = append('uc-test-editor-root', 'test-editor-root-remove');
     const child = document.createElement('uc-test-editor-child');
     root.append(child);
     await expect.poll(() => child.querySelector('.tab-id')?.textContent).toBe('crop');


### PR DESCRIPTION
## M12 P3 — `CloudImageEditorController` + editor `@lit/context` + light `EditorBlock` base

Infrastructure phase of the CloudImageEditor v2 port. Builds the DOM-free editor controller and the **bundle-independent** consumer base the block ports (P4–P6) sit on. No editor block ported yet — proven with unit + throwaway e2e.

**Bundle-independence (user directive):** editor blocks must NOT pull the uploader graph into the standalone editor bundle. `ChildBlock` value-imports `ensureUploaderCtx`(→`UploaderController`) + `UploaderRegistry`, so the base does **not** extend `ChildBlock`.

- **`CloudImageEditorController`** (`src/abstract/controllers/`) — DOM-free; owns the ~9 cross-cutting editor keys + coordination refs (`get`/`set`/`subscribe`/`notify`), `apply`/`cancel`/`retryNetwork` handlers, and an injected **`EditorServices`** seam (`l10n`/`getConfig`/`telemetry`/`proxyUrl`) with inert no-op defaults until `setServices`. So descendants get everything from the controller — never `ChildBlock`/ctx. 16 unit tests.
- **`editor-context.ts`** — `cloudImageEditorContext` (`@lit/context`), `CloudImageEditorContextController` (consumer + reconnect fix), and **`EditorBlock extends RegisterableElementMixin(LightDomMixin(LitElement))`** — a plain-Lit consumer base with **zero** `ChildBlock`/`ensureUploaderCtx`/`UploaderRegistry`/`bag`/`ctxNameContext` imports (verified: import-graph + built-bundle grep = 0).
- **`size-limit` budget** on `web/uc-cloud-image-editor.min.js` (50 KB; actual 47.81) — CI guardrail against uploader-code regression.

The editor ROOT's light shared-ctx reading (config/`l10n` from `<uc-config>`, documented, unchanged) + wiring services lands in P5.

### Verification
`tsc:app` · `tsc` · `build` · specs (controller unit 16) · editor e2e 5/5 (incl. light-DOM reconnect guard) · `lint` · `lint:size` (47.81/50 KB) green. Full e2e on CI. Design re-reviewed (opus).

### Context
Plan: `docs/superpowers/plans/2026-07-15-v2-m12-cloud-image-editor-port.md`. Adapts the `refactor/editor-separate-state` spike + PoC; deeper editor↔uploader isolation is a deferred future refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


> **Note (review M1):** the 50 KB budget is a *latent* guard until P5 wires `EditorBlock` into the editor bundle — 47.81 KB currently measures the untouched v1 baseline. Bundle-independence *today* is proven by the import-graph analysis + the ctx-less e2e; the budget backstops the regression once the real editor blocks land on `EditorBlock`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a DOM-free cloud image editor controller with scoped state, deduplicated change notifications, and editor actions (apply/cancel/retry).
  - Introduced editor context plumbing so components automatically react to controller updates across attach/re-attach.
  - Added a lifecycle-aware editor base for safe, managed subscriptions in child components.
- **Bug Fixes**
  - Improved stability for disconnect/reconnect flows to prevent stale updates and ensure updates resume correctly.
  - Improved teardown behavior so controller behavior remains predictable after removal.
- **Tests**
  - Added comprehensive unit and end-to-end coverage for controller state, subscriptions, handlers/services, context propagation, and reconnect/disconnect scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->