### PR TITLE
refactor(m12): extract shared StateController base

### DIFF
--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -2,7 +2,7 @@ import type { CloudImageEditorState } from '../../blocks/CloudImageEditor/src/st
 import { ALL_TABS, TabId } from '../../blocks/CloudImageEditor/src/toolbar-constants';
 import type { Transformations } from '../../blocks/CloudImageEditor/src/types';
 import type { ConfigType } from '../../types';
-import { Listeners } from '../host-subscription';
+import { StateController } from './StateController';
 
 /**
  * The cross-cutting subset of `CloudImageEditorState` (M12 "State scoping
@@ -101,14 +101,12 @@ function createDefaultServices(): EditorServices {
  * machine, image-URL/modifier computation) accretes here as each block ports
  * in P5/P6 (strangler) — kept minimal in this phase (state container only).
  */
-export class CloudImageEditorController {
-  private _state: CloudImageEditorControllerState;
-  private _listeners = new Listeners();
+export class CloudImageEditorController extends StateController<CloudImageEditorControllerState> {
   private _handlers: Partial<CloudImageEditorHandlers> = {};
   private _services: EditorServices;
 
   public constructor(initial?: Partial<CloudImageEditorControllerState>, services?: EditorServices) {
-    this._state = { ...createDefaultState(), ...initial };
+    super({ ...createDefaultState(), ...initial });
     this._services = services ?? createDefaultServices();
   }
 
@@ -147,40 +145,22 @@ export class CloudImageEditorController {
   }
 
   /**
-   * Coarse notify with no state change — for the root to call after swapping
-   * services (`setServices`) or otherwise mutating something descendants
-   * read through the controller but that isn't itself a `CloudImageEditorControllerState`
-   * key (e.g. a locale dictionary load or a config change upstream). Reuses
-   * the same `Listeners` instance as `set()`, so `EditorBlock`'s automatic
-   * re-render subscription picks it up for free.
+   * `notify()` is inherited from `StateController` — the root calls it after
+   * swapping services (`setServices`) or otherwise mutating something
+   * descendants read through the controller but that isn't itself a
+   * `CloudImageEditorControllerState` key (e.g. a locale dictionary load or a
+   * config change upstream). Reuses the same `Listeners` instance as `set()`,
+   * so `EditorBlock`'s automatic re-render subscription picks it up for free.
+   *
+   * Current state snapshot (read-only reference — mutate via `set`). Thin
+   * alias over the inherited `values`, kept for the editor's established naming.
    */
-  public notify(): void {
-    this._listeners.notify();
-  }
-
-  /** Current state snapshot (read-only reference — mutate via `set`). */
   public get state(): Readonly<CloudImageEditorControllerState> {
-    return this._state;
+    return this.values;
   }
 
   public getState(): Readonly<CloudImageEditorControllerState> {
-    return this._state;
-  }
-
-  public get<K extends keyof CloudImageEditorControllerState>(key: K): CloudImageEditorControllerState[K] {
-    return this._state[key];
-  }
-
-  /** Notifies only when the value actually changes (`Object.is` dedup), same contract as `ConfigController.set`. */
-  public set<K extends keyof CloudImageEditorControllerState>(key: K, value: CloudImageEditorControllerState[K]): void {
-    if (Object.is(this._state[key], value)) return;
-    this._state[key] = value;
-    this._listeners.notify();
-  }
-
-  /** Coarse subscribe — fires on any state change, not per-key (mirrors `ConfigController.subscribe`). */
-  public subscribe(listener: () => void): () => void {
-    return this._listeners.subscribe(listener);
+    return this.values;
   }
 
   /**
@@ -204,8 +184,8 @@ export class CloudImageEditorController {
     this._handlers.onRetryNetwork?.();
   }
 
-  public destroy(): void {
-    this._listeners.clear();
+  public override destroy(): void {
     this._handlers = {};
+    super.destroy();
   }
 }

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -1,7 +1,7 @@
 import type { CustomConfigDefinition } from '../../abstract/customConfigOptions';
 import { initialConfig } from '../../blocks/Config/initialConfig';
 import type { ConfigType } from '../../types/exported';
-import { Listeners } from '../host-subscription';
+import { StateController } from './StateController';
 
 /**
  * Pure-logic config store. Knows nothing about DOM, attributes, or Lit.
@@ -17,22 +17,19 @@ import { Listeners } from '../host-subscription';
  *
  * Custom (plugin-registered) keys live in the same backing object as built-ins
  * — `register()` adds them, `getCustom`/`setCustom` access them.
+ *
+ * Extends the shared `StateController` (get/set/subscribe/notify/destroy) and
+ * adds config-specific custom-key registration on top.
  */
-export class ConfigController {
-  // Null-prototype backing object: custom (plugin-registered) key names flow
-  // into `getCustom`/`setCustom`, so a key like `__proto__` must create a
-  // plain own property here rather than mutate the prototype chain.
-  private _values: ConfigType = Object.assign(Object.create(null), initialConfig);
+export class ConfigController extends StateController<ConfigType> {
   private _customKeys = new Set<string>();
   private _customDefs = new Map<string, CustomConfigDefinition<unknown>>();
-  private _listeners = new Listeners();
 
-  public get values(): Readonly<ConfigType> {
-    return this._values;
-  }
-
-  public subscribe(listener: () => void): () => void {
-    return this._listeners.subscribe(listener);
+  public constructor() {
+    // Null-prototype backing object: custom (plugin-registered) key names flow
+    // into `getCustom`/`setCustom`, so a key like `__proto__` must create a
+    // plain own property here rather than mutate the prototype chain.
+    super(Object.assign(Object.create(null), initialConfig));
   }
 
   /** True for any known key — a built-in default or a registered custom key. */
@@ -40,21 +37,6 @@ export class ConfigController {
     // Own-property check: `in` would walk the prototype chain and wrongly
     // report `toString`, `constructor`, `__proto__`, etc. as known keys.
     return Object.hasOwn(initialConfig, name) || this._customKeys.has(name);
-  }
-
-  public get<K extends keyof ConfigType>(key: K): ConfigType[K] {
-    return this._values[key];
-  }
-
-  /**
-   * Raw write — no coercion (v1 `PubSub.pub` parity; `<uc-config>` normalizes
-   * upstream). Notifies only when the value actually changes, matching the
-   * per-key change semantics of the nanostores map it replaces.
-   */
-  public set<K extends keyof ConfigType>(key: K, value: ConfigType[K]): void {
-    if (this._values[key] === value) return;
-    this._values[key] = value;
-    this._listeners.notify();
   }
 
   // ─── Custom (plugin-registered) keys ───────────────────────────────────
@@ -68,7 +50,7 @@ export class ConfigController {
     }
     this._customKeys.add(def.name);
     this._customDefs.set(def.name, def as CustomConfigDefinition<unknown>);
-    const bag = this._values as Record<string, unknown>;
+    const bag = this._state as Record<string, unknown>;
     // Keep any value set before the plugin registered (e.g. an attribute that
     // landed first), otherwise seed the registered default. Own-property check
     // (not `=== undefined`) mirrors the nanostores `key in store` semantics, so
@@ -76,7 +58,7 @@ export class ConfigController {
     if (!Object.hasOwn(bag, def.name)) {
       bag[def.name] = def.defaultValue;
     }
-    this._listeners.notify();
+    this.notify();
   }
 
   public customDefinition(name: string): CustomConfigDefinition<unknown> | undefined {
@@ -84,19 +66,19 @@ export class ConfigController {
   }
 
   public getCustom<T = unknown>(name: string): T {
-    return (this._values as Record<string, unknown>)[name] as T;
+    return (this._state as Record<string, unknown>)[name] as T;
   }
 
   public setCustom(name: string, value: unknown): void {
-    const bag = this._values as Record<string, unknown>;
+    const bag = this._state as Record<string, unknown>;
     if (bag[name] === value) return;
     bag[name] = value;
-    this._listeners.notify();
+    this.notify();
   }
 
-  public destroy(): void {
+  public override destroy(): void {
     this._customKeys.clear();
     this._customDefs.clear();
-    this._listeners.clear();
+    super.destroy();
   }
 }

--- a/src/abstract/controllers/StateController.test.ts
+++ b/src/abstract/controllers/StateController.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from 'vitest';
+import { StateController } from './StateController';
+
+type FixtureState = { a: number; b: string | null; ref: object | null };
+
+describe('StateController', () => {
+  it('exposes the seeded initial state via values/get', () => {
+    const initial: FixtureState = { a: 1, b: 'x', ref: null };
+    const controller = new StateController(initial);
+    expect(controller.values).toBe(initial);
+    expect(controller.get('a')).toBe(1);
+    expect(controller.get('b')).toBe('x');
+  });
+
+  it('set() stores the value and notifies, deduping unchanged writes (Object.is)', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('a', 2);
+    expect(controller.get('a')).toBe(2);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    controller.set('a', 2); // unchanged — no notify
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('set() treats NaN as equal to itself (Object.is semantics)', () => {
+    const controller = new StateController<{ n: number }>({ n: NaN });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('n', NaN); // Object.is(NaN, NaN) === true → no notify
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('set() treats +0 and -0 as distinct (Object.is semantics)', () => {
+    const controller = new StateController<{ n: number }>({ n: 0 });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('n', -0); // Object.is(0, -0) === false → notifies
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('subscribe fires on every changed key, coarse (not per-key)', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.set('a', 2);
+    controller.set('b', 'y');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    const listener = vi.fn();
+    const off = controller.subscribe(listener);
+    off();
+
+    controller.set('a', 2);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('notify() fires subscribers with no state change', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.notify();
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(controller.get('a')).toBe(1);
+  });
+
+  it('destroy() clears subscribers', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    const listener = vi.fn();
+    controller.subscribe(listener);
+
+    controller.destroy();
+
+    controller.set('a', 2);
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/controllers/StateController.ts
+++ b/src/abstract/controllers/StateController.ts
@@ -1,0 +1,49 @@
+import { Listeners } from '../host-subscription';
+
+/**
+ * Generic DOM-free reactive-state primitive, shared by the config
+ * (`ConfigController`) and editor (`CloudImageEditorController`) controllers
+ * (the M12 "State scoping principle"). Owns a flat state bag plus a coarse
+ * `Listeners` set: `set()` dedupes unchanged writes (`Object.is`) and fires
+ * all subscribers on change; `notify()` lets a subclass force a re-render for
+ * a change that isn't itself a keyed state write (e.g. an injected-services
+ * swap). No `lit`, no DOM — UI bridging belongs to the element/adapter layer.
+ */
+export class StateController<TState extends object> {
+  protected _state: TState;
+  private _listeners = new Listeners();
+
+  public constructor(initial: TState) {
+    this._state = initial;
+  }
+
+  /** Current state snapshot (read-only reference — mutate via `set`). */
+  public get values(): Readonly<TState> {
+    return this._state;
+  }
+
+  public get<K extends keyof TState>(key: K): TState[K] {
+    return this._state[key];
+  }
+
+  /** Notifies only when the value actually changes (`Object.is` dedup). */
+  public set<K extends keyof TState>(key: K, value: TState[K]): void {
+    if (Object.is(this._state[key], value)) return;
+    this._state[key] = value;
+    this._listeners.notify();
+  }
+
+  /** Coarse subscribe — fires on any state change, not per-key. */
+  public subscribe(listener: () => void): () => void {
+    return this._listeners.subscribe(listener);
+  }
+
+  /** Coarse notify with no state change — for a subclass to call after mutating something descendants read through it that isn't itself a state key. */
+  public notify(): void {
+    this._listeners.notify();
+  }
+
+  public destroy(): void {
+    this._listeners.clear();
+  }
+}


### PR DESCRIPTION
## refactor(m12): extract shared `StateController<T>` base

Consolidates the duplicated DOM-free reactive-state pattern that `ConfigController` and the M12 `CloudImageEditorController` both hand-rolled, into one shared primitive — the canonical reactive-state base for the v2 controller layer (and the eventual nanostores/`PubSub` replacement).

- **`src/abstract/controllers/StateController.ts`** (new) — `StateController<TState extends object>`: a flat state bag + coarse `Listeners`. `get`/`set` (`Object.is` dedup + notify), `subscribe`, `notify` (force re-render without a keyed write, e.g. a services swap), `values`, `destroy`. No `lit`/DOM. 8 unit tests.
- **`ConfigController extends StateController<ConfigType>`** — passes its null-prototype seed via `super()`; drops the duplicated `get`/`set`/`subscribe`/`values`/`_listeners`; keeps all config custom-key logic (`register`/`getCustom`/`setCustom`/`hasKey`). Behavior-preserving (the base's `Object.is` dedup ⊇ the old `===`; differs only on `NaN`/`-0`, irrelevant for config).
- **`CloudImageEditorController extends StateController<...>`** — drops the duplicated state plumbing; keeps its `EditorServices` + handlers; overrides `destroy()` to also clear handlers.

### Verification
`tsc:app` · `tsc` · `build` · unit (`StateController` + `ConfigController` + `CloudImageEditorController`, 35 tests) · config + custom-config + editor e2e (32) · `lint` green. Full e2e on CI (exercises `ConfigController` across every block).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
