### PR TITLE
refactor(editor-isolation): cropper self-activates from state; crop ops through *editorTransformations (2/N)

### DIFF
--- a/src/abstract/controllers/CloudImageEditorController.test.ts
+++ b/src/abstract/controllers/CloudImageEditorController.test.ts
@@ -10,7 +10,6 @@ describe('CloudImageEditorController', () => {
     expect(controller.get('*tabId')).toBe(TabId.CROP);
     expect(controller.get('*editorTransformations')).toEqual({});
     expect(controller.get('*faderEl')).toBeNull();
-    expect(controller.get('*cropperEl')).toBeNull();
     expect(controller.get('*imgContainerEl')).toBeNull();
     expect(controller.state).toBe(controller.getState());
   });

--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -1,4 +1,3 @@
-import type { EditorImageCropper } from '../../blocks/CloudImageEditor/src/EditorImageCropper';
 import type { EditorImageFader } from '../../blocks/CloudImageEditor/src/EditorImageFader';
 import { TabId, type TabIdValue } from '../../blocks/CloudImageEditor/src/toolbar-constants';
 import type { CropAspectRatio, LoadingOperations, Transformations } from '../../blocks/CloudImageEditor/src/types';
@@ -40,10 +39,12 @@ export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
  * which the root now passes to `<uc-editor-toolbar>` as plain Lit props (root →
  * single child, no cross-subtree sharing).
  *
- * `*faderEl`/`*cropperEl`/`*imgContainerEl` are cross-component coordination
- * refs (a smell, flagged in the plan for a later refinement to controller
- * methods) — the controller only stores/returns them, it never touches the
- * DOM itself.
+ * `*faderEl`/`*imgContainerEl` are cross-component coordination refs (a smell,
+ * flagged for a later refinement) — the controller only stores/returns them, it
+ * never touches the DOM. The cropper is no longer held in state: it
+ * self-activates from `*tabId`/`*originalUrl` + the root's `imageSize` prop, and
+ * crop ops arrive through `*editorTransformations` (the fader follows in a
+ * later stage).
  */
 export type CloudImageEditorControllerState = {
   '*originalUrl': string | null;
@@ -53,7 +54,6 @@ export type CloudImageEditorControllerState = {
   '*currentAspectRatio': CropAspectRatio | null;
   '*tabId': TabIdValue;
   '*faderEl': EditorImageFader | null;
-  '*cropperEl': EditorImageCropper | null;
   '*imgContainerEl': HTMLElement | null;
 };
 
@@ -66,7 +66,6 @@ function createDefaultState(): CloudImageEditorControllerState {
     '*currentAspectRatio': null,
     '*tabId': TabId.CROP,
     '*faderEl': null,
-    '*cropperEl': null,
     '*imgContainerEl': null,
   };
 }

--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -850,6 +850,12 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       throw new Error('No UUID nor CDN URL provided');
     }
 
+    // Clear the size until the new image's info loads below. The cropper takes
+    // `imageSize` as a prop and self-activates only once it's set, so this keeps
+    // it from reactivating with the *previous* image's dimensions (a null→value
+    // transition also re-triggers activation even when the new size matches).
+    this._imageSize = null;
+
     // The cropper resets itself when `*originalUrl` changes (see
     // EditorImageCropper); only the fader is reset here.
     if (editorController.get('*tabId') !== TabId.CROP) {

--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -255,10 +255,9 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       this._pendingInitUpdate = null;
       this._isInitialized = true;
       // `_isInitialized` renders the init-gated subtree (the cropper + toolbar);
-      // wait for that render to commit, then capture the now-live refs and
-      // activate the viewer. `firstUpdated`/`updateImage` ran before this flip,
-      // so `*cropperEl` was still null and its `activate()` no-oped — without
-      // this the cropper renders but never gets its `<img>`/crop frame.
+      // wait for that render to commit, then share the fader/container refs and
+      // activate the fader. The cropper self-activates once it mounts with its
+      // `imageSize` prop set on the crop tab, so it needs no external kick here.
       await this.updateComplete;
       if (!this.isConnected) {
         return;
@@ -276,13 +275,12 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
    */
   private _activateViewer(): void {
     const editorController = this._editorController;
-    const imageSize = this._imageSize;
-    if (!imageSize) {
+    if (!this._imageSize) {
       return;
     }
-    if (editorController.get('*tabId') === TabId.CROP) {
-      editorController.get('*cropperEl')?.activate(imageSize);
-    } else {
+    // The cropper self-activates from `*tabId`/`*originalUrl` + its `imageSize`
+    // prop (see EditorImageCropper); only the fader is activated here now.
+    if (editorController.get('*tabId') !== TabId.CROP) {
       const originalUrl = editorController.get('*originalUrl');
       if (originalUrl) {
         editorController.get('*faderEl')?.activate({ url: originalUrl });
@@ -526,11 +524,7 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       this._editorController.set('*faderEl', faderEl);
     }
 
-    const cropperEl = this._cropperRef.value;
-    if (cropperEl) {
-      this._editorController.set('*cropperEl', cropperEl);
-    }
-
+    // The cropper is no longer shared through the controller — it self-activates.
     const imgContainerEl = this._imgContainerRef.value;
     if (imgContainerEl) {
       this._editorController.set('*imgContainerEl', imgContainerEl);
@@ -677,7 +671,14 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
           </div>
           <div class="uc-image_container" ${ref(this._imgContainerRef)}>
             <img src=${src} class=${this._imageClassName} ${ref(this._imgRef)} />
-            ${when(this._isInitialized, () => html`<uc-editor-image-cropper ${ref(this._cropperRef)}></uc-editor-image-cropper>`)}
+            ${when(
+              this._isInitialized,
+              () =>
+                html`<uc-editor-image-cropper
+                  .imageSize=${this._imageSize}
+                  ${ref(this._cropperRef)}
+                ></uc-editor-image-cropper>`,
+            )}
             <uc-editor-image-fader ${ref(this._faderRef)}></uc-editor-image-fader>
           </div>
           <div class="uc-info_pan">${message}</div>
@@ -849,9 +850,9 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       throw new Error('No UUID nor CDN URL provided');
     }
 
-    if (editorController.get('*tabId') === TabId.CROP) {
-      editorController.get('*cropperEl')?.deactivate({ reset: true });
-    } else {
+    // The cropper resets itself when `*originalUrl` changes (see
+    // EditorImageCropper); only the fader is reset here.
+    if (editorController.get('*tabId') !== TabId.CROP) {
       editorController.get('*faderEl')?.deactivate();
     }
 

--- a/src/blocks/CloudImageEditor/src/EditorCropButtonControl.ts
+++ b/src/blocks/CloudImageEditor/src/EditorCropButtonControl.ts
@@ -10,17 +10,6 @@ function nextAngle(prev: number): number {
   return angle;
 }
 
-function nextValue(operation: CropOperation, prev: number | boolean): number | boolean {
-  if (operation === 'rotate') {
-    const angle = typeof prev === 'number' ? prev : 0;
-    return nextAngle(angle);
-  }
-  if (operation === 'mirror' || operation === 'flip') {
-    return !prev;
-  }
-  throw new Error(`Unsupported operation: ${operation}`);
-}
-
 export class EditorCropButtonControl extends EditorButtonControl {
   @property({ type: String })
   public operation: CropOperation | undefined = undefined;
@@ -47,9 +36,25 @@ export class EditorCropButtonControl extends EditorButtonControl {
     // Crop ops are modelled through state: write the next value to
     // `*editorTransformations`; the cropper reacts (applies + re-commits the
     // consistent crop). No element ref needed — see `EditorImageCropper`.
+    // Branch per operation so `patch` is a strongly-typed `Partial<Transformations>`
+    // (`rotate` is a number, `flip`/`mirror` are booleans) — no assertions.
     const transformations = this.editorController.get('*editorTransformations');
-    const prev = (transformations[this.operation] ?? (this.operation === 'rotate' ? 0 : false)) as number | boolean;
-    const next = nextValue(this.operation, prev);
+    let prev: number | boolean;
+    let next: number | boolean;
+    let patch: Partial<Transformations>;
+    if (this.operation === 'rotate') {
+      prev = transformations.rotate ?? 0;
+      next = nextAngle(prev);
+      patch = { rotate: next };
+    } else if (this.operation === 'flip') {
+      prev = transformations.flip ?? false;
+      next = !prev;
+      patch = { flip: next };
+    } else {
+      prev = transformations.mirror ?? false;
+      next = !prev;
+      patch = { mirror: next };
+    }
 
     this.editorController.telemetry.sendEventCloudImageEditor(e, this.editorController.get('*tabId'), {
       operation: this.operation,
@@ -57,10 +62,7 @@ export class EditorCropButtonControl extends EditorButtonControl {
       prev,
     });
 
-    this.editorController.set('*editorTransformations', {
-      ...transformations,
-      [this.operation]: next,
-    } as Transformations);
+    this.editorController.set('*editorTransformations', { ...transformations, ...patch });
   }
 }
 

--- a/src/blocks/CloudImageEditor/src/EditorCropButtonControl.ts
+++ b/src/blocks/CloudImageEditor/src/EditorCropButtonControl.ts
@@ -2,6 +2,7 @@ import type { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
 import { EditorButtonControl } from './EditorButtonControl.js';
 import type { CropOperation } from './toolbar-constants';
+import type { Transformations } from './types';
 
 function nextAngle(prev: number): number {
   let angle = prev + 90;
@@ -43,14 +44,11 @@ export class EditorCropButtonControl extends EditorButtonControl {
       return;
     }
 
-    // `*cropperEl` is null unless the cropper is the mounted/active tab — a
-    // crop op can be clicked before it registers (or from another tab). Guard
-    // rather than crash (matches the `?.` at the root's activate/deactivate).
-    const cropper = this.editorController.get('*cropperEl');
-    if (!cropper) {
-      return;
-    }
-    const prev = cropper.getValue(this.operation);
+    // Crop ops are modelled through state: write the next value to
+    // `*editorTransformations`; the cropper reacts (applies + re-commits the
+    // consistent crop). No element ref needed — see `EditorImageCropper`.
+    const transformations = this.editorController.get('*editorTransformations');
+    const prev = (transformations[this.operation] ?? (this.operation === 'rotate' ? 0 : false)) as number | boolean;
     const next = nextValue(this.operation, prev);
 
     this.editorController.telemetry.sendEventCloudImageEditor(e, this.editorController.get('*tabId'), {
@@ -59,7 +57,10 @@ export class EditorCropButtonControl extends EditorButtonControl {
       prev,
     });
 
-    cropper.setValue(this.operation, next);
+    this.editorController.set('*editorTransformations', {
+      ...transformations,
+      [this.operation]: next,
+    } as Transformations);
   }
 }
 

--- a/src/blocks/CloudImageEditor/src/EditorImageCropper.ts
+++ b/src/blocks/CloudImageEditor/src/EditorImageCropper.ts
@@ -1,6 +1,6 @@
 import type { PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
-import { state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import type { CloudImageEditorController } from '../../../abstract/controllers/CloudImageEditorController';
 import { debounce } from '../../../utils/debounce.js';
@@ -19,6 +19,7 @@ import { CROP_PADDING } from './cropper-constants.js';
 import { EditorBlock } from './editor-context';
 import { classNames } from './lib/classNames.js';
 import { pick } from './lib/pick.js';
+import { TabId } from './toolbar-constants';
 import type { CropAspectRatio, ImageSize, Rectangle, Transformations } from './types';
 import { viewerImageSrc } from './util.js';
 
@@ -75,6 +76,21 @@ export class EditorImageCropper extends EditorBlock {
   // `sub(key, cb)`).
   private _lastAspectRatio: CropAspectRatio | null = null;
   private _lastNetworkProblems = false;
+  private _lastOriginalUrl: string | null = null;
+  // Guards the coarse `subscribeEditor` reaction against re-entering itself: it
+  // writes state (`_commit`, `deactivate`→`_commit`) and `StateController.set`
+  // notifies synchronously, so without this a commit would re-fire the reaction
+  // (e.g. deactivate commits before flipping `_isActive`, recursing forever).
+  private _reacting = false;
+
+  /**
+   * Loaded image size, passed down from the root (`<uc-cloud-image-editor>`) as
+   * a plain Lit prop — it's DOM-derived, not editor-controller state. The
+   * cropper self-activates once this and `*originalUrl` are ready on the crop
+   * tab (see `_syncActivation`), so no external code drives `.activate()`.
+   */
+  @property({ attribute: false })
+  public imageSize: ImageSize | null = null;
 
   private _commitDebounced: ReturnType<typeof debounce>;
   private _handleResizeThrottled: ReturnType<typeof throttle>;
@@ -115,20 +131,48 @@ export class EditorImageCropper extends EditorBlock {
     this.onEditorAttach(() => {
       this._lastAspectRatio = this.editorController.get('*currentAspectRatio');
       this._lastNetworkProblems = this.editorController.get('*networkProblems');
+      this._lastOriginalUrl = this.editorController.get('*originalUrl');
 
       this.subscribeEditor(() => {
-        const aspectRatio = this.editorController.get('*currentAspectRatio');
-        if (aspectRatio !== this._lastAspectRatio) {
-          this._lastAspectRatio = aspectRatio;
-          this._alignCrop();
+        if (this._reacting) {
+          return;
         }
-
-        const networkProblems = this.editorController.get('*networkProblems');
-        if (networkProblems !== this._lastNetworkProblems) {
-          this._lastNetworkProblems = networkProblems;
-          if (!networkProblems && this._isActive && this._imageSize) {
-            void this.activate(this._imageSize, { fromViewer: false });
+        this._reacting = true;
+        try {
+          const aspectRatio = this.editorController.get('*currentAspectRatio');
+          if (aspectRatio !== this._lastAspectRatio) {
+            this._lastAspectRatio = aspectRatio;
+            this._alignCrop();
           }
+          this._lastNetworkProblems = this.editorController.get('*networkProblems');
+
+          // A new image (originalUrl change) invalidates the current crop —
+          // reset before the fresh `imageSize` prop arrives and re-activates us.
+          const originalUrl = this.editorController.get('*originalUrl');
+          if (originalUrl !== this._lastOriginalUrl) {
+            this._lastOriginalUrl = originalUrl;
+            if (this._isActive) {
+              this.deactivate({ reset: true });
+            }
+          }
+
+          // Self-activate/deactivate from controller state + the imageSize prop
+          // (replaces the root/toolbar calling `.activate()`/`.deactivate()`).
+          this._syncActivation();
+
+          // Crop ops (rotate/flip/mirror) now arrive through
+          // `*editorTransformations` — `EditorCropButtonControl` writes them
+          // instead of calling `setValue`. Apply + re-commit the consistent
+          // crop; the re-entrancy guard swallows our own commit's notify.
+          if (this._isActive && this._cropOpsDiffer(this.editorController.get('*editorTransformations'))) {
+            this._syncTransformations();
+            this._alignImage();
+            this._alignCrop();
+            this._draw();
+            this._commit();
+          }
+        } finally {
+          this._reacting = false;
         }
       });
     });
@@ -379,23 +423,32 @@ export class EditorImageCropper extends EditorBlock {
     this.editorController.set('*editorTransformations', transformations);
   }
 
-  public setValue<K extends keyof Operations>(operation: K, value: Operations[K]): void {
-    this._operations = {
-      ...this._operations,
-      [operation]: value,
-    };
-
-    if (!this._isActive) {
-      return;
-    }
-
-    this._alignImage();
-    this._alignCrop();
-    this._draw();
+  /** True when the committed crop ops differ from what the cropper has applied. */
+  private _cropOpsDiffer(transformations: Transformations): boolean {
+    return (
+      (transformations.rotate ?? 0) !== this._operations.rotate ||
+      (transformations.mirror ?? false) !== this._operations.mirror ||
+      (transformations.flip ?? false) !== this._operations.flip
+    );
   }
 
-  public getValue<K extends keyof Operations>(operation: K): Operations[K] {
-    return this._operations[operation];
+  /** Activate on the crop tab once the image + its size are ready; deactivate (committing) otherwise. */
+  private _syncActivation(): void {
+    const controller = this.editorControllerOrNull;
+    if (!controller) {
+      return;
+    }
+    const shouldBeActive =
+      controller.get('*tabId') === TabId.CROP &&
+      !!this.imageSize &&
+      !!controller.get('*originalUrl') &&
+      !controller.get('*networkProblems');
+
+    if (shouldBeActive && !this._isActive) {
+      void this.activate(this.imageSize as ImageSize);
+    } else if (!shouldBeActive && this._isActive) {
+      this.deactivate();
+    }
   }
 
   public async activate(imageSize: ImageSize, { fromViewer }: { fromViewer?: boolean } = {}): Promise<void> {
@@ -554,6 +607,12 @@ export class EditorImageCropper extends EditorBlock {
 
   protected override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
+
+    // The `imageSize` prop is not controller state, so `subscribeEditor` never
+    // fires for it — re-evaluate activation when the root updates it.
+    if (changedProperties.has('imageSize')) {
+      this._syncActivation();
+    }
 
     // `_imageBox`/`_cropBox` are private state, so their literal names can't
     // be used with `changedProperties.has(...)` (that requires a `keyof

--- a/src/blocks/CloudImageEditor/src/EditorImageCropper.ts
+++ b/src/blocks/CloudImageEditor/src/EditorImageCropper.ts
@@ -33,6 +33,9 @@ type Operations = {
   rotate: number;
 };
 
+const OPERATION_KEYS = ['rotate', 'mirror', 'flip'] as const satisfies readonly (keyof Operations)[];
+const DEFAULT_OPERATIONS: Readonly<Operations> = { rotate: 0, mirror: false, flip: false };
+
 function validateCrop(crop: Transformations['crop']): boolean {
   if (!crop) {
     return true;
@@ -54,11 +57,7 @@ export class EditorImageCropper extends EditorBlock {
   // as reactive props (`.imageBox`/`.cropBox`); `CropFrame` reports drag
   // changes back up via a `cropboxchange` event (see `_handleCropBoxChange`).
   @state()
-  private _operations: Operations = {
-    rotate: 0,
-    mirror: false,
-    flip: false,
-  };
+  private _operations: Operations = { ...DEFAULT_OPERATIONS };
 
   @state()
   private _imageBox: Rectangle = { x: 0, y: 0, width: 0, height: 0 };
@@ -82,6 +81,10 @@ export class EditorImageCropper extends EditorBlock {
   // notifies synchronously, so without this a commit would re-fire the reaction
   // (e.g. deactivate commits before flipping `_isActive`, recursing forever).
   private _reacting = false;
+  // Bumped on every deactivate (incl. the new-image reset). A fire-and-forget
+  // `activate()` captures the value at its start and bails after each `await` if
+  // it no longer matches, so a stale image load can't finish over a newer one.
+  private _activationGeneration = 0;
 
   /**
    * Loaded image size, passed down from the root (`<uc-cloud-image-editor>`) as
@@ -146,14 +149,21 @@ export class EditorImageCropper extends EditorBlock {
           }
           this._lastNetworkProblems = this.editorController.get('*networkProblems');
 
-          // A new image (originalUrl change) invalidates the current crop —
-          // reset before the fresh `imageSize` prop arrives and re-activates us.
+          // A new image (originalUrl change) invalidates the current crop.
+          // Reset the ops to a clean slate and stay INACTIVE until the root
+          // supplies the new image's `imageSize` prop — reactivation then
+          // happens in `updated`. Reactivating here would use the previous
+          // image's still-stale `imageSize` (the root clears it to null before
+          // the size fetch). `deactivate` also bumps the activation generation,
+          // aborting any in-flight activation of the old image.
           const originalUrl = this.editorController.get('*originalUrl');
           if (originalUrl !== this._lastOriginalUrl) {
             this._lastOriginalUrl = originalUrl;
+            this._operations = { ...DEFAULT_OPERATIONS };
             if (this._isActive) {
               this.deactivate({ reset: true });
             }
+            return;
           }
 
           // Self-activate/deactivate from controller state + the imageSize prop
@@ -185,10 +195,7 @@ export class EditorImageCropper extends EditorBlock {
 
   private _syncTransformations(): void {
     const transformations = this.editorController.get('*editorTransformations');
-    const pickedTransformations = pick(
-      transformations,
-      Object.keys(this._operations) as readonly (keyof Transformations)[],
-    ) as Partial<Operations>;
+    const pickedTransformations = pick(transformations, OPERATION_KEYS) as Partial<Operations>;
     const operations: Operations = { ...this._operations, ...pickedTransformations };
     this._operations = operations;
   }
@@ -425,11 +432,7 @@ export class EditorImageCropper extends EditorBlock {
 
   /** True when the committed crop ops differ from what the cropper has applied. */
   private _cropOpsDiffer(transformations: Transformations): boolean {
-    return (
-      (transformations.rotate ?? 0) !== this._operations.rotate ||
-      (transformations.mirror ?? false) !== this._operations.mirror ||
-      (transformations.flip ?? false) !== this._operations.flip
-    );
+    return OPERATION_KEYS.some((key) => (transformations[key] ?? DEFAULT_OPERATIONS[key]) !== this._operations[key]);
   }
 
   /** Activate on the crop tab once the image + its size are ready; deactivate (committing) otherwise. */
@@ -456,7 +459,14 @@ export class EditorImageCropper extends EditorBlock {
       return;
     }
     this._isActive = true;
+    // Snapshot the generation: a deactivate/new-image reset during the awaits
+    // below bumps it, so this fire-and-forget activation aborts instead of
+    // drawing a superseded image (see `_activationGeneration`).
+    const generation = this._activationGeneration;
     await this.updateComplete;
+    if (!this.isConnected || generation !== this._activationGeneration) {
+      return;
+    }
     this._initCanvas();
     this._imageSize = imageSize;
     this.removeEventListener('transitionend', this._reset);
@@ -475,7 +485,7 @@ export class EditorImageCropper extends EditorBlock {
       const originalUrl = controller.get('*originalUrl') as string;
       const transformations = controller.get('*editorTransformations');
       this._image = await this._waitForImage(controller, originalUrl, transformations);
-      if (!this.isConnected) {
+      if (!this.isConnected || generation !== this._activationGeneration) {
         return;
       }
       this._syncTransformations();
@@ -502,6 +512,8 @@ export class EditorImageCropper extends EditorBlock {
     if (!this._isActive) {
       return;
     }
+    // Invalidate any in-flight `activate()` (see `_activationGeneration`).
+    this._activationGeneration += 1;
     !reset && this._commit();
     this._isActive = false;
 

--- a/src/blocks/CloudImageEditor/src/EditorToolbar.ts
+++ b/src/blocks/CloudImageEditor/src/EditorToolbar.ts
@@ -242,21 +242,18 @@ export class EditorToolbar extends EditorBlock {
 
     this.activeTab = id;
 
+    // The cropper self-activates/deactivates from `*tabId`/`*originalUrl` + its
+    // `imageSize` prop (see `EditorImageCropper._syncActivation`); the toolbar
+    // no longer drives it. The fader is still driven imperatively here.
     const faderEl = this.editorController.get('*faderEl');
-    const cropperEl = this.editorController.get('*cropperEl');
 
     if (id === TabId.CROP) {
       faderEl?.deactivate();
-      const imageSize = this.imageSize;
-      if (imageSize) {
-        cropperEl?.activate(imageSize, { fromViewer });
-      }
     } else {
       faderEl?.activate({
         url: this.editorController.get('*originalUrl') as string,
         fromViewer,
       });
-      cropperEl?.deactivate();
     }
 
     for (const tabId of ALL_TABS) {

--- a/tests/cloud-image-editor.e2e.test.tsx
+++ b/tests/cloud-image-editor.e2e.test.tsx
@@ -92,6 +92,25 @@ describe('Cloud Image Editor', () => {
     await expect.element(freeform).toBeVisible();
   });
 
+  it('applies a crop operation through state (rotate/flip) without recursion', async () => {
+    // Regression guard (editor-isolation Task 5): crop ops are modelled through
+    // `*editorTransformations` — `EditorCropButtonControl` writes it and the
+    // cropper reacts + re-commits, instead of the button calling
+    // `cropper.setValue` via a `*cropperEl` state ref. The commit re-notifies
+    // synchronously, so the cropper's reaction has a re-entrancy guard; without
+    // it a deactivate→commit→notify cycle recursed to a RangeError. Clicking a
+    // crop op repeatedly must apply cleanly and keep the cropper active.
+    const cropper = page.getByTestId('uc-editor-image-cropper');
+    await expect.element(cropper).toBeVisible();
+    await expect.poll(() => cropper.element().className).toMatch(/uc-active_from_/);
+
+    const cropButtons = page.getByTestId('uc-editor-crop-button-control');
+    await userEvent.click(cropButtons.nth(0));
+    await userEvent.click(cropButtons.nth(0));
+
+    await expect.poll(() => cropper.element().className).toMatch(/uc-active_from_/);
+  });
+
   it("should apply 'brightness' operation", async () => {
     const tuningTab = page.getByRole('tab', { name: /tuning/i });
     await userEvent.click(tuningTab);

--- a/tests/cloud-image-editor.e2e.test.tsx
+++ b/tests/cloud-image-editor.e2e.test.tsx
@@ -92,23 +92,39 @@ describe('Cloud Image Editor', () => {
     await expect.element(freeform).toBeVisible();
   });
 
-  it('applies a crop operation through state (rotate/flip) without recursion', async () => {
+  it('applies a crop operation through state (rotate) without recursion', async () => {
     // Regression guard (editor-isolation Task 5): crop ops are modelled through
     // `*editorTransformations` — `EditorCropButtonControl` writes it and the
     // cropper reacts + re-commits, instead of the button calling
     // `cropper.setValue` via a `*cropperEl` state ref. The commit re-notifies
     // synchronously, so the cropper's reaction has a re-entrancy guard; without
-    // it a deactivate→commit→notify cycle recursed to a RangeError. Clicking a
-    // crop op repeatedly must apply cleanly and keep the cropper active.
+    // it a deactivate→commit→notify cycle recursed to a RangeError.
     const cropper = page.getByTestId('uc-editor-image-cropper');
     await expect.element(cropper).toBeVisible();
     await expect.poll(() => cropper.element().className).toMatch(/uc-active_from_/);
 
-    const cropButtons = page.getByTestId('uc-editor-crop-button-control');
-    await userEvent.click(cropButtons.nth(0));
-    await userEvent.click(cropButtons.nth(0));
+    // Capture the applied transformations (the toolbar's `done` button emits
+    // `uc-internal:apply` with the current `*editorTransformations`) so we
+    // assert the clicks actually took effect, not just that the cropper stayed
+    // alive. `rotate` is the first crop button (ALL_CROP_OPERATIONS order).
+    let applied: { rotate?: number } | null = null;
+    const onApply = (event: Event) => {
+      applied = (event as CustomEvent<{ rotate?: number }>).detail;
+    };
+    document.addEventListener('uc-internal:apply', onApply);
+    try {
+      const cropButtons = page.getByTestId('uc-editor-crop-button-control');
+      await userEvent.click(cropButtons.nth(0));
+      await userEvent.click(cropButtons.nth(0));
 
-    await expect.poll(() => cropper.element().className).toMatch(/uc-active_from_/);
+      // Cropper survived the repeated state-driven ops (recursion guard).
+      await expect.poll(() => cropper.element().className).toMatch(/uc-active_from_/);
+
+      await userEvent.click(page.getByRole('button', { name: /apply/i }));
+      await expect.poll(() => applied?.rotate).toBe(180);
+    } finally {
+      document.removeEventListener('uc-internal:apply', onApply);
+    }
   });
 
   it("should apply 'brightness' operation", async () => {


### PR DESCRIPTION
## What & why

Increment 2 of the editor↔uploader isolation refactor, **stage 1**: begin retiring the cross-component DOM refs held in `CloudImageEditorController` state (`*cropperEl`/`*faderEl`/`*imgContainerEl`) by modelling the editor viewer **through state** instead of imperative element references (the approach confirmed for this increment).

This PR does the **cropper**; the fader (`*colorPreview` + `*faderEl`) and `*imgContainerEl` follow in subsequent gated stages.

## Changes

- **`EditorImageCropper` self-activates** from `*tabId` + `*originalUrl` + a new root-supplied `imageSize` prop (was: root/toolbar calling `.activate()`/`.deactivate()` through `*cropperEl`). Resets on `*originalUrl` change.
- **Crop ops (rotate/flip/mirror) flow through `*editorTransformations`**: `EditorCropButtonControl` writes the next value; the cropper reacts, applies, and re-commits the consistent crop. No `*cropperEl.getValue/setValue`.
- **Re-entrancy guard** on the cropper's coarse `subscribeEditor` reaction: `StateController.set` notifies synchronously and `deactivate()` commits before flipping `_isActive`, which otherwise recursed to a `RangeError`. The guard swallows the reaction's own commit-notify.
- Root/toolbar stop driving the cropper; the **fader stays imperative** (`*faderEl`) until the next stage. Root passes `.imageSize` to the cropper.
- Retired `*cropperEl` from `CloudImageEditorControllerState`.

## Testing

Full green gate: `tsc` (app+test), `build`, **specs 708/708**, **e2e 384/384** (incl. the editor-in-uploader-plugin path), locales, lint. Added an e2e guard for the state-driven crop op + the recursion regression; existing editor guards (crop activation, preset, brightness, tab switch) stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Crop controls now apply transformations more reliably while preserving the editor’s active state.
  * The cropper automatically activates, resets, and responds to image, tab, and size changes.
  * Switching between editor tabs provides smoother cropper and preview behavior.

* **Bug Fixes**
  * Fixed an issue where repeated rotate or flip actions could cause the cropper to lose its active state.

* **Tests**
  * Added coverage for repeated crop operations and state preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->