### PR TITLE
refactor(editor-isolation): fader self-activates + slider previews through *colorPreview (3/N)

### DIFF
--- a/src/abstract/controllers/CloudImageEditorController.test.ts
+++ b/src/abstract/controllers/CloudImageEditorController.test.ts
@@ -9,7 +9,7 @@ describe('CloudImageEditorController', () => {
     expect(controller.get('*networkProblems')).toBe(false);
     expect(controller.get('*tabId')).toBe(TabId.CROP);
     expect(controller.get('*editorTransformations')).toEqual({});
-    expect(controller.get('*faderEl')).toBeNull();
+    expect(controller.get('*colorPreview')).toBeNull();
     expect(controller.get('*imgContainerEl')).toBeNull();
     expect(controller.state).toBe(controller.getState());
   });

--- a/src/abstract/controllers/CloudImageEditorController.ts
+++ b/src/abstract/controllers/CloudImageEditorController.ts
@@ -1,5 +1,4 @@
-import type { EditorImageFader } from '../../blocks/CloudImageEditor/src/EditorImageFader';
-import { TabId, type TabIdValue } from '../../blocks/CloudImageEditor/src/toolbar-constants';
+import { type ColorPreview, TabId, type TabIdValue } from '../../blocks/CloudImageEditor/src/toolbar-constants';
 import type { CropAspectRatio, LoadingOperations, Transformations } from '../../blocks/CloudImageEditor/src/types';
 import type { ConfigType, SecureDeliveryProxyUrlResolver } from '../../types';
 import { StateController } from './StateController';
@@ -39,12 +38,13 @@ export const DEFAULT_EDITOR_CONFIG: EditorConfig = {
  * which the root now passes to `<uc-editor-toolbar>` as plain Lit props (root →
  * single child, no cross-subtree sharing).
  *
- * `*faderEl`/`*imgContainerEl` are cross-component coordination refs (a smell,
- * flagged for a later refinement) — the controller only stores/returns them, it
- * never touches the DOM. The cropper is no longer held in state: it
- * self-activates from `*tabId`/`*originalUrl` + the root's `imageSize` prop, and
- * crop ops arrive through `*editorTransformations` (the fader follows in a
- * later stage).
+ * `*colorPreview` is the slider's live, uncommitted color/filter adjustment;
+ * the fader reacts to it and renders the preview (see `ColorPreview`).
+ * `*imgContainerEl` is a cross-component coordination ref (a smell, flagged for
+ * a later refinement) — the controller only stores/returns it, never touches
+ * the DOM. The cropper/fader elements are no longer held in state: they
+ * self-activate from `*tabId`/`*originalUrl`/`*colorPreview` + the root's
+ * `imageSize` prop.
  */
 export type CloudImageEditorControllerState = {
   '*originalUrl': string | null;
@@ -53,7 +53,7 @@ export type CloudImageEditorControllerState = {
   '*editorTransformations': Transformations;
   '*currentAspectRatio': CropAspectRatio | null;
   '*tabId': TabIdValue;
-  '*faderEl': EditorImageFader | null;
+  '*colorPreview': ColorPreview;
   '*imgContainerEl': HTMLElement | null;
 };
 
@@ -65,7 +65,7 @@ function createDefaultState(): CloudImageEditorControllerState {
     '*editorTransformations': {},
     '*currentAspectRatio': null,
     '*tabId': TabId.CROP,
-    '*faderEl': null,
+    '*colorPreview': null,
     '*imgContainerEl': null,
   };
 }

--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -255,37 +255,15 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       this._pendingInitUpdate = null;
       this._isInitialized = true;
       // `_isInitialized` renders the init-gated subtree (the cropper + toolbar);
-      // wait for that render to commit, then share the fader/container refs and
-      // activate the fader. The cropper self-activates once it mounts with its
-      // `imageSize` prop set on the crop tab, so it needs no external kick here.
+      // wait for that render to commit, then share the container ref. The
+      // cropper and fader self-activate once they mount with their `imageSize`
+      // prop set for the current tab, so they need no external kick here.
       await this.updateComplete;
       if (!this.isConnected) {
         return;
       }
       this._assignSharedElements();
-      this._activateViewer();
     });
-  }
-
-  /**
-   * (Re)activate the crop or fader viewer for the current tab, using the loaded
-   * image size. No-op until the image size is known. Called after image info
-   * loads (`updateImage`) and again once the init-gated cropper subtree has
-   * rendered (`_scheduleInitialization`).
-   */
-  private _activateViewer(): void {
-    const editorController = this._editorController;
-    if (!this._imageSize) {
-      return;
-    }
-    // The cropper self-activates from `*tabId`/`*originalUrl` + its `imageSize`
-    // prop (see EditorImageCropper); only the fader is activated here now.
-    if (editorController.get('*tabId') !== TabId.CROP) {
-      const originalUrl = editorController.get('*originalUrl');
-      if (originalUrl) {
-        editorController.get('*faderEl')?.activate({ url: originalUrl });
-      }
-    }
   }
 
   private get _effectiveCtxName(): string | undefined {
@@ -519,12 +497,8 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
   }
 
   private _assignSharedElements(): void {
-    const faderEl = this._faderRef.value;
-    if (faderEl) {
-      this._editorController.set('*faderEl', faderEl);
-    }
-
-    // The cropper is no longer shared through the controller — it self-activates.
+    // The cropper and fader self-activate from state; only the image container
+    // ref is still shared (used by the toolbar's preload — retired next stage).
     const imgContainerEl = this._imgContainerRef.value;
     if (imgContainerEl) {
       this._editorController.set('*imgContainerEl', imgContainerEl);
@@ -679,7 +653,7 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
                   ${ref(this._cropperRef)}
                 ></uc-editor-image-cropper>`,
             )}
-            <uc-editor-image-fader ${ref(this._faderRef)}></uc-editor-image-fader>
+            <uc-editor-image-fader .imageSize=${this._imageSize} ${ref(this._faderRef)}></uc-editor-image-fader>
           </div>
           <div class="uc-info_pan">${message}</div>
         </div>
@@ -850,17 +824,12 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       throw new Error('No UUID nor CDN URL provided');
     }
 
-    // Clear the size until the new image's info loads below. The cropper takes
-    // `imageSize` as a prop and self-activates only once it's set, so this keeps
-    // it from reactivating with the *previous* image's dimensions (a null→value
-    // transition also re-triggers activation even when the new size matches).
+    // Clear the size until the new image's info loads below. The cropper and
+    // fader take `imageSize` as a prop and self-activate only once it's set, so
+    // this keeps them from reactivating with the *previous* image's dimensions
+    // (a null→value transition also re-triggers activation even when the new
+    // size matches). Both also self-reset on the `*originalUrl` change above.
     this._imageSize = null;
-
-    // The cropper resets itself when `*originalUrl` changes (see
-    // EditorImageCropper); only the fader is reset here.
-    if (editorController.get('*tabId') !== TabId.CROP) {
-      editorController.get('*faderEl')?.deactivate();
-    }
 
     try {
       const originalUrlValue = editorController.get('*originalUrl') as string;
@@ -873,8 +842,6 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
 
       const { width, height } = json;
       this._imageSize = { width, height };
-
-      this._activateViewer();
     } catch (err) {
       if (err) {
         editorController.telemetry.sendEventError(err, 'cloud editor image. Failed to load image info');

--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -824,6 +824,12 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
       throw new Error('No UUID nor CDN URL provided');
     }
 
+    // Drop any in-progress live slider preview so it isn't reapplied to the new
+    // image (the fader keys its preview off `*colorPreview`).
+    if (editorController.get('*colorPreview')) {
+      editorController.set('*colorPreview', null);
+    }
+
     // Clear the size until the new image's info loads below. The cropper and
     // fader take `imageSize` as a prop and self-activate only once it's set, so
     // this keeps them from reactivating with the *previous* image's dimensions

--- a/src/blocks/CloudImageEditor/src/EditorImageFader.ts
+++ b/src/blocks/CloudImageEditor/src/EditorImageFader.ts
@@ -1,5 +1,6 @@
-import type { TemplateResult } from 'lit';
+import type { PropertyValues, TemplateResult } from 'lit';
 import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import type { CloudImageEditorController } from '../../../abstract/controllers/CloudImageEditorController';
 import { debounce } from '../../../utils/debounce.js';
@@ -7,8 +8,8 @@ import { batchPreloadImages } from '../../../utils/preloadImage.js';
 import { EditorBlock } from './editor-context';
 import { classNames } from './lib/classNames.js';
 import { linspace } from './lib/linspace.js';
-import { COLOR_OPERATIONS_CONFIG } from './toolbar-constants.js';
-import type { Transformations } from './types';
+import { COLOR_OPERATIONS_CONFIG, type ColorPreview, TabId, type TabIdValue } from './toolbar-constants.js';
+import type { ImageSize, Transformations } from './types';
 import { viewerImageSrc } from './util.js';
 
 type OperationKey = keyof typeof COLOR_OPERATIONS_CONFIG;
@@ -103,6 +104,27 @@ export class EditorImageFader extends EditorBlock {
   private readonly _previewHostRef = createRef<HTMLDivElement>();
   private readonly _layersHostRef = createRef<HTMLDivElement>();
 
+  /**
+   * Loaded image size, passed from the root as a plain Lit prop (DOM-derived,
+   * not controller state) — the fader shows only once it and `*originalUrl` are
+   * ready on a non-crop tab (see `_syncFromState`). Root clears it to null on a
+   * new image, which reliably re-triggers the reaction.
+   */
+  @property({ attribute: false })
+  public imageSize: ImageSize | null = null;
+
+  // Last-seen controller values, to detect real per-key changes in the coarse
+  // `subscribeEditor` reaction (it fires on ANY state change).
+  private _lastTabId?: TabIdValue;
+  private _lastOriginalUrl: string | null = null;
+  private _lastColorPreview: ColorPreview = null;
+  private _lastTransformations?: Transformations;
+  private _shown = false;
+  // Guards the reaction against re-entering itself: the fader's own methods
+  // write state (`*loadingOperations`, `*networkProblems`) and `set` notifies
+  // synchronously (same lesson as EditorImageCropper).
+  private _reacting = false;
+
   public constructor() {
     super();
 
@@ -168,6 +190,111 @@ export class EditorImageFader extends EditorBlock {
         { once: true },
       );
     }, 600);
+
+    // Controller-dependent setup (mirrors EditorImageCropper): the fader now
+    // drives itself from state instead of the toolbar/root/slider calling its
+    // methods. It reacts to `*tabId`/`*originalUrl`/`*editorTransformations`/
+    // `*colorPreview` (+ the `imageSize` prop) and calls its own unchanged
+    // activate/set/deactivate/setTransformations.
+    this.onEditorAttach(() => {
+      const controller = this.editorController;
+      this._lastTabId = controller.get('*tabId');
+      this._lastOriginalUrl = controller.get('*originalUrl');
+      this._lastColorPreview = controller.get('*colorPreview');
+      this.subscribeEditor(() => this._syncFromState());
+    });
+  }
+
+  protected override updated(changedProperties: PropertyValues<this>): void {
+    super.updated(changedProperties);
+    // `imageSize` is a prop, not controller state, so `subscribeEditor` won't
+    // fire for it — re-evaluate visibility when the root updates it.
+    if (changedProperties.has('imageSize')) {
+      this._syncFromState();
+    }
+  }
+
+  /**
+   * Reconcile the fader with controller state — the reactive replacement for
+   * the old imperative calls from the toolbar (`_applyTabState`,
+   * `*editorTransformations`, `*originalUrl`), the root (`_activateViewer`),
+   * and the slider (`set`/`activate`/`deactivate`).
+   */
+  private _syncFromState(): void {
+    if (this._reacting) {
+      return;
+    }
+    this._reacting = true;
+    try {
+      const controller = this.editorControllerOrNull;
+      if (!controller) {
+        return;
+      }
+      const tabId = controller.get('*tabId');
+      const originalUrl = controller.get('*originalUrl');
+      const colorPreview = controller.get('*colorPreview');
+      const transformations = controller.get('*editorTransformations');
+      const shouldShow = tabId !== TabId.CROP && !!originalUrl && !!this.imageSize;
+
+      // New image: hide + drop the stale preview so it re-shows cleanly below.
+      if (originalUrl !== this._lastOriginalUrl) {
+        this._lastOriginalUrl = originalUrl;
+        this._lastColorPreview = null;
+        if (this._shown) {
+          this.deactivate();
+          this._shown = false;
+        }
+      }
+      this._lastTabId = tabId;
+
+      if (shouldShow && !this._shown) {
+        // Enter viewer mode: seed `_transformations` so `activate` (original)
+        // renders the committed result, matching the old tab-switch behaviour.
+        this._shown = true;
+        this._lastTransformations = transformations;
+        this._transformations = transformations;
+        void this.activate({ url: originalUrl as string, fromViewer: false });
+      } else if (!shouldShow && this._shown) {
+        this._shown = false;
+        this.deactivate();
+      }
+
+      if (!this._shown) {
+        return;
+      }
+
+      // Committed transformations → refresh the viewer image (old toolbar sub).
+      if (transformations !== this._lastTransformations) {
+        this._lastTransformations = transformations;
+        void this.setTransformations(transformations);
+      }
+
+      // Live slider preview: op/filter change → rebuild keypoints (`activate`);
+      // same op, new value → `set`; cleared → back to the committed viewer.
+      if (colorPreview !== this._lastColorPreview) {
+        const previous = this._lastColorPreview;
+        this._lastColorPreview = colorPreview;
+        if (colorPreview) {
+          const opChanged =
+            !previous || previous.operation !== colorPreview.operation || previous.filter !== colorPreview.filter;
+          if (opChanged) {
+            void this.activate({
+              url: originalUrl as string,
+              operation: colorPreview.operation,
+              value: colorPreview.value,
+              filter: colorPreview.filter,
+              fromViewer: false,
+            });
+          } else if (typeof colorPreview.value === 'number') {
+            this.set(colorPreview.value);
+          }
+        } else if (previous) {
+          this.deactivate({ hide: false });
+        }
+      }
+    } finally {
+      this._reacting = false;
+    }
   }
 
   private _handleImageLoading(controller: CloudImageEditorController, src: string): () => void {

--- a/src/blocks/CloudImageEditor/src/EditorImageFader.ts
+++ b/src/blocks/CloudImageEditor/src/EditorImageFader.ts
@@ -8,7 +8,7 @@ import { batchPreloadImages } from '../../../utils/preloadImage.js';
 import { EditorBlock } from './editor-context';
 import { classNames } from './lib/classNames.js';
 import { linspace } from './lib/linspace.js';
-import { COLOR_OPERATIONS_CONFIG, type ColorPreview, TabId, type TabIdValue } from './toolbar-constants.js';
+import { COLOR_OPERATIONS_CONFIG, type ColorPreview, TabId } from './toolbar-constants.js';
 import type { ImageSize, Transformations } from './types';
 import { viewerImageSrc } from './util.js';
 
@@ -115,7 +115,6 @@ export class EditorImageFader extends EditorBlock {
 
   // Last-seen controller values, to detect real per-key changes in the coarse
   // `subscribeEditor` reaction (it fires on ANY state change).
-  private _lastTabId?: TabIdValue;
   private _lastOriginalUrl: string | null = null;
   private _lastColorPreview: ColorPreview = null;
   private _lastTransformations?: Transformations;
@@ -198,7 +197,6 @@ export class EditorImageFader extends EditorBlock {
     // activate/set/deactivate/setTransformations.
     this.onEditorAttach(() => {
       const controller = this.editorController;
-      this._lastTabId = controller.get('*tabId');
       this._lastOriginalUrl = controller.get('*originalUrl');
       this._lastColorPreview = controller.get('*colorPreview');
       this.subscribeEditor(() => this._syncFromState());
@@ -236,7 +234,11 @@ export class EditorImageFader extends EditorBlock {
       const transformations = controller.get('*editorTransformations');
       const shouldShow = tabId !== TabId.CROP && !!originalUrl && !!this.imageSize;
 
-      // New image: hide + drop the stale preview so it re-shows cleanly below.
+      // New image: hide and stay hidden until the root supplies the new image's
+      // `imageSize` prop (reactivation then happens via `updated`). Returning
+      // here avoids re-activating with the previous image's still-stale
+      // `imageSize` (root clears it to null asynchronously) or reapplying its
+      // live preview — the root also clears `*colorPreview` on image change.
       if (originalUrl !== this._lastOriginalUrl) {
         this._lastOriginalUrl = originalUrl;
         this._lastColorPreview = null;
@@ -244,8 +246,8 @@ export class EditorImageFader extends EditorBlock {
           this.deactivate();
           this._shown = false;
         }
+        return;
       }
-      this._lastTabId = tabId;
 
       if (shouldShow && !this._shown) {
         // Enter viewer mode: seed `_transformations` so `activate` (original)

--- a/src/blocks/CloudImageEditor/src/EditorSlider.ts
+++ b/src/blocks/CloudImageEditor/src/EditorSlider.ts
@@ -41,10 +41,19 @@ export class EditorSlider extends EditorBlock {
     zero: 0,
   };
 
+  /** The live, uncommitted preview intent for the fader (see `*colorPreview`). `null` clears it. */
+  private _publishPreview(value: number | undefined): void {
+    this.editorController.set('*colorPreview', {
+      operation: this.state.operation,
+      value: this.state.filter === FAKE_ORIGINAL_FILTER ? undefined : value,
+      filter: this.state.filter === FAKE_ORIGINAL_FILTER ? undefined : this.state.filter,
+    });
+  }
+
   private _handleInput = (e: CustomEvent<{ value: number }>): void => {
     const { value } = e.detail;
-    const fader = this.editorController.get('*faderEl');
-    fader?.set(value);
+    // Was `fader.set(value)`; the fader reacts to `*colorPreview` now.
+    this._publishPreview(value);
     this.state = { ...this.state, value };
   };
 
@@ -53,17 +62,9 @@ export class EditorSlider extends EditorBlock {
 
     this._initializeValues();
 
-    const fader = this.editorController.get('*faderEl');
-    const originalUrl = this.state.originalUrl || this.editorController.get('*originalUrl') || undefined;
-    if (fader && originalUrl) {
-      fader.activate({
-        url: originalUrl,
-        operation: this.state.operation,
-        value: this.state.filter === FAKE_ORIGINAL_FILTER ? undefined : this.state.value,
-        filter: this.state.filter === FAKE_ORIGINAL_FILTER ? undefined : this.state.filter,
-        fromViewer: false,
-      });
-    }
+    // Was `fader.activate({...})`; publish the preview and let the fader react
+    // (an operation/filter change rebuilds its keypoints — see EditorImageFader).
+    this._publishPreview(this.state.value);
   }
 
   private _initializeValues(): void {
@@ -106,11 +107,14 @@ export class EditorSlider extends EditorBlock {
     }
 
     this.editorController.set('*editorTransformations', transformations);
+    // Committed — clear the live preview so the fader shows the committed result.
+    this.editorController.set('*colorPreview', null);
   }
 
   public cancel(): void {
-    const fader = this.editorController.get('*faderEl');
-    fader?.deactivate({ hide: false });
+    // Was `fader.deactivate({ hide: false })`; clearing the preview returns the
+    // fader to the committed viewer (see EditorImageFader).
+    this.editorController.set('*colorPreview', null);
   }
 
   public constructor() {

--- a/src/blocks/CloudImageEditor/src/EditorToolbar.ts
+++ b/src/blocks/CloudImageEditor/src/EditorToolbar.ts
@@ -221,20 +221,14 @@ export class EditorToolbar extends EditorBlock {
     }
   }
 
-  private _activateTab(
-    id: TabIdValue,
-    { fromViewer = false, force = false }: { fromViewer?: boolean; force?: boolean } = {},
-  ): void {
+  private _activateTab(id: TabIdValue, { force = false }: { force?: boolean } = {}): void {
     if (this.editorController.get('*tabId') !== id) {
       this.editorController.set('*tabId', id);
     }
-    this._applyTabState(id, { fromViewer, force });
+    this._applyTabState(id, { force });
   }
 
-  private _applyTabState(
-    id: TabIdValue,
-    { fromViewer, force = false }: { fromViewer: boolean; force?: boolean },
-  ): void {
+  private _applyTabState(id: TabIdValue, { force = false }: { force?: boolean } = {}): void {
     if (!force && this.activeTab === id) {
       this._syncTabIndicator();
       return;
@@ -242,20 +236,10 @@ export class EditorToolbar extends EditorBlock {
 
     this.activeTab = id;
 
-    // The cropper self-activates/deactivates from `*tabId`/`*originalUrl` + its
-    // `imageSize` prop (see `EditorImageCropper._syncActivation`); the toolbar
-    // no longer drives it. The fader is still driven imperatively here.
-    const faderEl = this.editorController.get('*faderEl');
-
-    if (id === TabId.CROP) {
-      faderEl?.deactivate();
-    } else {
-      faderEl?.activate({
-        url: this.editorController.get('*originalUrl') as string,
-        fromViewer,
-      });
-    }
-
+    // The cropper and fader both self-activate/deactivate from controller state
+    // (`*tabId`/`*originalUrl`/`*colorPreview`) + their `imageSize` prop — see
+    // `EditorImageCropper` / `EditorImageFader`. The toolbar only owns the tab
+    // UI now.
     for (const tabId of ALL_TABS) {
       const isCurrentTab = tabId === id;
       const toggleRef = this.tabToggleRefs[tabId];
@@ -404,17 +388,15 @@ export class EditorToolbar extends EditorBlock {
       }
       this._updateInfoTooltip();
       this._preloadEditedImage();
-      this.editorController.get('*faderEl')?.setTransformations(editorTransformations);
+      // The fader reacts to `*editorTransformations` itself now.
     });
 
     this.subEditorKey('*tabId', (tabId) => {
-      this._applyTabState(tabId, { fromViewer: false, force: true });
+      this._applyTabState(tabId, { force: true });
       this._updateInfoTooltip();
     });
 
-    this.subEditorKey('*originalUrl', () => {
-      this.editorController.get('*faderEl')?.deactivate();
-    });
+    // The fader self-deactivates on `*originalUrl` change (see EditorImageFader).
 
     this.subEditorKey('*loadingOperations', (loadingOperations) => {
       let anyLoading = false;
@@ -471,7 +453,7 @@ export class EditorToolbar extends EditorBlock {
       if (ctrl && this.tabList.length > 0 && !this.tabList.includes(ctrl.get('*tabId'))) {
         const [firstTab] = this.tabList;
         if (firstTab) {
-          this._activateTab(firstTab, { fromViewer: false });
+          this._activateTab(firstTab);
         }
       }
     }
@@ -482,7 +464,7 @@ export class EditorToolbar extends EditorBlock {
         // macrotask (apply/cancel, router nav), nulling the adopted controller.
         const ctrl = this.editorControllerOrNull;
         if (ctrl) {
-          this._activateTab(ctrl.get('*tabId'), { fromViewer: true });
+          this._activateTab(ctrl.get('*tabId'));
         }
       }, 0);
     }
@@ -547,7 +529,7 @@ export class EditorToolbar extends EditorBlock {
       return;
     }
     this.editorController.telemetry.sendEventCloudImageEditor(e, id);
-    this._activateTab(id, { fromViewer: false });
+    this._activateTab(id);
   };
 
   /** `EditorFilterControl`'s reported selection — replaces the old cross-writes to `*sliderEl`/`*showSlider`/`*currentFilter`/`*tabId`-scoped telemetry. */

--- a/src/blocks/CloudImageEditor/src/toolbar-constants.ts
+++ b/src/blocks/CloudImageEditor/src/toolbar-constants.ts
@@ -78,7 +78,18 @@ type ColorOperationConfig = {
   keypointsNumber: number;
 };
 
-type ColorOperationConfigKey = ColorOperation | 'filter';
+export type ColorOperationConfigKey = ColorOperation | 'filter';
+
+/**
+ * The slider's live, uncommitted color/filter adjustment, published to the
+ * controller (`*colorPreview`) so the fader reacts and renders the preview.
+ * `null` = no live preview (render the committed `*editorTransformations`).
+ */
+export type ColorPreview = {
+  operation: ColorOperationConfigKey;
+  value?: number;
+  filter?: string;
+} | null;
 
 const NUMERIC_OPERATION_DEFAULTS = OPERATIONS_DEFAULTS as Record<ColorOperationConfigKey, number>;
 

--- a/tests/cloud-image-editor.e2e.test.tsx
+++ b/tests/cloud-image-editor.e2e.test.tsx
@@ -145,6 +145,33 @@ describe('Cloud Image Editor', () => {
     await expect.element(tuningTab).toBeVisible();
   });
 
+  it('fader self-activates on a color tab and previews via *colorPreview (no *faderEl)', async () => {
+    // Regression guard (editor-isolation Task 6): the fader self-activates from
+    // `*tabId`/`*originalUrl` + its `imageSize` prop, and the slider drives its
+    // live preview through `*colorPreview` — no `*faderEl` ref. Its reaction has
+    // the same re-entrancy guard as the cropper (deactivate commits + notifies
+    // synchronously), so entering the tab + previewing must not crash/recurse.
+    await userEvent.click(page.getByRole('tab', { name: /tuning/i }));
+
+    // Self-activation: entering a non-crop tab activates the fader (its layers
+    // are absolutely positioned, so assert the active class like the cropper
+    // test does, not `toBeVisible`). The fader has no `data-testid` (it renders
+    // before `testMode` config propagates), so locate it by tag. Activation
+    // resolves a proxied CDN URL then loads the image → allow a generous window.
+    const faderClass = () => document.querySelector('uc-editor-image-fader')?.className ?? '';
+    await expect.poll(faderClass, { timeout: 5000 }).toMatch(/uc-active_from_/);
+
+    // Slider preview flows through `*colorPreview` → the fader reacts.
+    await userEvent.click(page.getByRole('option', { name: /Brightness/i }));
+    const slider = page.getByTestId('uc-editor-slider');
+    await expect.element(slider).toBeVisible();
+    await userEvent.click(slider);
+    await userEvent.keyboard('[ArrowRight]');
+
+    // Preview stayed live (no recursion/teardown).
+    await expect.poll(faderClass, { timeout: 5000 }).toMatch(/uc-active_from_/);
+  });
+
   it('should log timeout without unhandled rejection when container size stays zero', async () => {
     cleanup();
 


### PR DESCRIPTION
## What & why

Stage 2 of modelling the editor viewer **through state** instead of imperative element refs (follows #1033, which did the cropper). Retires the fader DOM ref (`*faderEl`) from `CloudImageEditorController` state; only `*imgContainerEl` remains (next stage).

## Changes

- **`*colorPreview`** added to controller state — the slider's live, uncommitted color/filter adjustment. `null` = render the committed `*editorTransformations`.
- **`EditorImageFader` self-drives from state.** Its `activate`/`set`/`deactivate`/`setTransformations` **bodies are unchanged** — only *who calls them* moves into a `_syncFromState` reaction on `*tabId`/`*originalUrl`/`*colorPreview`/`*editorTransformations` + the root-supplied `imageSize` prop. Same `_reacting` re-entrancy guard as the cropper.
- **`EditorSlider`** writes `*colorPreview` (drag/pick), `*editorTransformations` + `null` (apply), `null` (cancel) — no `*faderEl`.
- **`EditorToolbar`** `_applyTabState` reduces to tab UI (both viewers self-activate); dropped the fader `setTransformations`/`deactivate` subscriptions and the now-dead `fromViewer` threading.
- **Root** deletes `_activateViewer`, drops the fader from `_assignSharedElements`/`updateImage`, and passes `.imageSize` to the fader.
- Retired `*faderEl` from `CloudImageEditorControllerState`.

## Testing

Full green gate: `tsc` (app+test), `build`, **specs 708/708**, **editor e2e 10/10** (new "fader self-activates … via `*colorPreview`" guard), **plugin e2e 8/8** (editor-in-uploader modal + crop-modifier + Apply flow), **full e2e 385/385**, locales, lint.

> Note: an initial full-suite run showed transient flake in the plugin upload tests (real network uploads with 10s `waitFor`s under full parallel load); a clean re-run and the file in isolation both pass. CI's `retry: 1` covers this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added live color adjustment previews while using editor sliders.
  - Improved automatic activation and deactivation of image adjustments when switching tabs or loading images.
  - Preserved active previews through editor update cycles.

- **Bug Fixes**
  - Switching images now clears unfinished color previews to prevent stale adjustments.

- **Tests**
  - Added end-to-end coverage for fader activation and brightness preview behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->