### PR TITLE
refactor(editor): drop vestigial uc-icon export from the editor solution bundle

### DIFF
--- a/specs/npm/__snapshots__/npm.test.ts.snap
+++ b/specs/npm/__snapshots__/npm.test.ts.snap
@@ -142,7 +142,6 @@ exports[`NPM package > exports \`web\` should match snapshot > web/uc-cloud-imag
   "EditorScroller": [Function],
   "EditorSlider": [Function],
   "EditorToolbar": [Function],
-  "Icon": [Function],
   "LineLoaderUi": [Function],
   "PresenceToggle": [Function],
   "SliderUi": [Function],

--- a/src/solutions/cloud-image-editor/index.ts
+++ b/src/solutions/cloud-image-editor/index.ts
@@ -9,5 +9,8 @@ Then we can check whether the dependent tag is registered in the CustomElementRe
 If not, register it from default ones or just log the warning */
 
 export { defineComponents } from '../../abstract/defineComponents';
+// `Config` (uc-config) stays for backward compatibility — the standalone editor
+// composition still relies on a sibling `<uc-config>`. `Icon` (uc-icon) is NOT
+// exported: the editor renders `uc-editor-icon`, so shipping the ChildBlock-based
+// `uc-icon` from this bundle was vestigial.
 export { Config } from '../../blocks/Config/Config';
-export { Icon } from '../../blocks/Icon/Icon';


### PR DESCRIPTION
## What & why

The editor renders `uc-editor-icon` (a ctx-free `UcIconBase` element), so exporting the `ChildBlock`-based `Icon` (`uc-icon`) from `src/solutions/cloud-image-editor/index.ts` was vestigial — it only added that block's code to the editor bundle without being used.

`Config` (`uc-config`) is kept deliberately: the standalone editor composition still relies on a sibling `<uc-config>`, so removing it would break backward compatibility.

## Changes

- Remove `export { Icon }` from the editor solution index (keep `Config`).
- Refresh the npm-surface snapshot: `Icon` is removed from `web/uc-cloud-image-editor.min.js`'s exports only (one line).

## Result

- Editor bundle: 176797 → 175846 bytes (drops the `uc-icon` block).
- `uc-icon` is still exported from the full package index (`src/index.ts`) for uploader usage — unchanged.

## Context

Follow-up to the editor↔uploader isolation effort (stages 1–3 merged: #1033/#1034/#1035). The broader bundle-level isolation ("B" — tree-shaking `UploaderController` out of the editor bundle) was investigated and **dropped as infeasible**: the editor bundle must keep exporting `Config`, which (as a `ChildBlock`) inherently needs the uploader controller. This PR is the one clean, compatible slice of that finding.

## Testing

`tsc`, **specs 708/708** (incl. npm snapshot), lint, editor + standalone + plugin e2e 18/18. CI runs the full e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification around configuration compatibility.
  * Documented that the icon export is not included in this bundle.

* **Breaking Changes**
  * Removed the icon export from the Cloud Image Editor bundle.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->