### PR TITLE
refactor(v2): blocks → @inject + signals (god-object decomposition, PR 2/4, step 6)

### DIFF
--- a/src/abstract/UploaderRegistry.ts
+++ b/src/abstract/UploaderRegistry.ts
@@ -87,10 +87,13 @@ class UploaderRegistryImpl {
   }
 
   /**
-   * Whether any `whenAvailable` consumer is currently watching `ctxName` — the
-   * consumer-refcount teardown predicate (`isCtxUnreferenced`): a ctx stays
-   * alive while a `ChildBlock` is still watching it here. (The v1
-   * `*blocksRegistry` half was removed with the v1 element layer in M11.)
+   * Whether any `whenAvailable` consumer is currently watching `ctxName`.
+   *
+   * Was the consumer-refcount teardown predicate until M-god step 6a, which
+   * moved that role onto the per-ctx `ControllerContainer`
+   * (`container.isUnreferenced()`, see `ctx-lifecycle.isCtxUnreferenced`). Kept
+   * as a standalone registry query. (The v1 `*blocksRegistry` half was removed
+   * with the v1 element layer in M11.)
    */
   public hasConsumers(ctxName: string): boolean {
     return (this._consumers.get(ctxName)?.size ?? 0) > 0;

--- a/src/abstract/controllers/CollectionStateController.ts
+++ b/src/abstract/controllers/CollectionStateController.ts
@@ -56,6 +56,23 @@ export class CollectionStateController {
     return this.#state.get(key) as CollectionState[K];
   }
 
+  /**
+   * Reactive, auto-tracking read of a collection-state key — the `SignalWatcher`
+   * counterpart to `get()`. Reading it inside a migrated `ChildBlock`'s update
+   * cycle (e.g. `ProgressBarCommon`/`DynamicBtn` reading `commonProgress` in
+   * `render()`) subscribes that render to THIS key, so a later `set()`
+   * re-renders the block with no `ctx.sub('*commonProgress', …)` subscription.
+   *
+   * Mirrors `ConfigController.getTracked`: `get()` stays the fast, non-tracking
+   * bag read (kept for the still-imperative `PubSubCompat` compat path, whose
+   * per-read signal overhead on this hot path measurably destabilizes the
+   * parallel e2e suite — see `SignalMap`/`CollectionState` docs); both coexist
+   * only during the strangler migration.
+   */
+  public getTracked<K extends keyof CollectionState>(key: K): CollectionState[K] {
+    return this.#state.signal(key).get() as CollectionState[K];
+  }
+
   /** `Object.is` dedup — replacing the `uploadTrigger` `Set` fires; mutating it in place does not (v1 parity). */
   public set<K extends keyof CollectionState>(key: K, value: CollectionState[K]): void {
     this.#state.set(key, value);

--- a/src/abstract/controllers/ConfigController.test.ts
+++ b/src/abstract/controllers/ConfigController.test.ts
@@ -1,3 +1,4 @@
+import { Signal } from '@lit-labs/signals';
 import { describe, expect, it, vi } from 'vitest';
 import { initialConfig } from '../../blocks/Config/initialConfig';
 import { ConfigController } from './ConfigController';
@@ -128,6 +129,35 @@ describe('ConfigController', () => {
 
     config.notify();
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('getTracked returns the current value, matching get() (M-god step 6a)', () => {
+    const config = new ConfigController();
+    expect(config.getTracked('removeCopyright')).toBe(config.get('removeCopyright'));
+
+    config.set('removeCopyright', true);
+    expect(config.getTracked('removeCopyright')).toBe(true);
+    expect(config.getTracked('removeCopyright')).toBe(config.get('removeCopyright'));
+  });
+
+  it('getTracked auto-tracks the key under a Signal watcher; set() notifies it', () => {
+    const config = new ConfigController();
+    let notified = 0;
+    const watcher = new Signal.subtle.Watcher(() => {
+      notified++;
+    });
+    // A computed that reads via getTracked establishes the dependency on the
+    // 'removeCopyright' key's signal — the exact path SignalWatcher uses in a
+    // migrated render().
+    const c = new Signal.Computed(() => config.getTracked('removeCopyright'));
+    watcher.watch(c);
+    expect(c.get()).toBe(false);
+
+    config.set('removeCopyright', true); // tracked write → watcher notified
+    expect(notified).toBe(1);
+    expect(c.get()).toBe(true);
+
+    watcher.unwatch(c);
   });
 
   it('setCustom does not notify when the value is unchanged', () => {

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -43,6 +43,23 @@ export class ConfigController {
     return this.#state.get(key) as ConfigType[K];
   }
 
+  /**
+   * Reactive, auto-tracking read of a config key. Reading it inside a
+   * `SignalWatcher` update (a migrated `ChildBlock.render()`) subscribes that
+   * render to THIS key, so a later `set()` re-renders the block with no manual
+   * `subConfigValue` subscription.
+   *
+   * Distinct from `get()`, which reads the fast bag and is NOT tracked — kept
+   * for the still-imperative readers (every `api.cfg` lookup, v1
+   * `subConfigValue`, non-migrated blocks) whose hot-path per-read signal
+   * overhead measurably destabilized the parallel e2e suite (see `SignalMap`).
+   * Both coexist only during the strangler migration: once every reader is a
+   * tracked reader, `get()` can route through the signal and this splits away.
+   */
+  public getTracked<K extends keyof ConfigType>(key: K): ConfigType[K] {
+    return this.#state.signal(key).get() as ConfigType[K];
+  }
+
   /** Notifies only when the value actually changes (`Object.is` dedup). */
   public set<K extends keyof ConfigType>(key: K, value: ConfigType[K]): void {
     this.#state.set(key, value);

--- a/src/abstract/controllers/RouterController.ts
+++ b/src/abstract/controllers/RouterController.ts
@@ -57,7 +57,14 @@ export class RouterController {
   private _listeners = new Listeners();
   private _table: RouteTable = {};
   private _activity: ActivityId | null = null;
-  private _modal: ActivityId | null = null;
+  // Backed by `@signalState` so a `SignalWatcher` consumer can track the
+  // foreground modal slot directly (M-god step 6b-3: `<uc-modal>` reads
+  // `router.modal` in `willUpdate` to drive its `<dialog>` open/close). This is
+  // distinct from `_currentActivity` (`_modal ?? _activity`): a modal opening on
+  // the id that's already the background activity leaves the effective activity
+  // unchanged, so only the modal-slot signal captures that transition. The
+  // coarse `_listeners.notify()` every existing reader relies on is unchanged.
+  @signalState() private _modal: ActivityId | null = null;
   // The single "effective" activity as a signal-backed field (M-god step 3c) —
   // kept in lockstep with the two slots by `_transition` (its sole writer, via
   // the two slots' sole writer). Backed by `@signalState` so a future
@@ -97,6 +104,11 @@ export class RouterController {
   public get activity(): ActivityId | null {
     return this._activity;
   }
+  /**
+   * The foreground modal slot, or `null` when no modal is open. Backed by a
+   * signal, so reading it inside a `SignalWatcher` update auto-tracks and a
+   * later open/close re-runs that consumer (see `_modal`).
+   */
   public get modal(): ActivityId | null {
     return this._modal;
   }

--- a/src/blocks/CameraSource/CameraSource.test.ts
+++ b/src/blocks/CameraSource/CameraSource.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { CameraSource } from './CameraSource';
+
+// Idempotent (same path as defineComponents(UC)).
+CameraSource.reg('uc-camera-source');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `camera-source-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: CameraSource; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-camera-source') as CameraSource;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const videoEl = (el: CameraSource): HTMLVideoElement | null => el.querySelector('video');
+
+describe('CameraSource (M-god step 6b-3 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(CameraSource.uses).toEqual([ConfigController, RouterController, TelemetryManager]);
+  });
+
+  it('re-renders the video transform reactively when cameraMirror changes (getTracked, no subConfigValue)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    // Default cameraMirror is false -> no mirror transform. (happy-dom serializes
+    // an omitted styleMap value inconsistently, so assert on the mirror token.)
+    expect(videoEl(el)?.style.transform).not.toContain('scaleX(-1)');
+
+    // External config change; the tracked `cameraMirror` read in the
+    // `_videoTransformCss` getter re-renders the video transform.
+    config.set('cameraMirror', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(videoEl(el)?.style.transform).toContain('scaleX(-1)');
+
+    config.set('cameraMirror', false);
+    await el.updateComplete;
+    await delay(0);
+    expect(videoEl(el)?.style.transform).not.toContain('scaleX(-1)');
+  });
+});

--- a/src/blocks/CameraSource/CameraSource.ts
+++ b/src/blocks/CameraSource/CameraSource.ts
@@ -1,6 +1,9 @@
 import { html, type PropertyValues } from 'lit';
 import { state } from 'lit/decorators.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { canUsePermissionsApi } from '../../utils/abilities';
 import { deserializeCsv } from '../../utils/comma-separated';
@@ -52,6 +55,8 @@ export type CameraMode = 'photo' | 'video';
 export type CameraStatus = 'shot' | 'retake' | 'accept' | 'play' | 'stop' | 'pause' | 'resume';
 
 export class CameraSource extends ChildBlock {
+  public static override readonly uses = [ConfigController, RouterController, TelemetryManager] as const;
+
   private _unsubPermissions: (() => void) | null = null;
 
   private _capturing = false;
@@ -92,8 +97,12 @@ export class CameraSource extends ChildBlock {
   private _startTime = 0;
   private _elapsedTime = 0;
 
-  @state()
-  private _videoTransformCss: string | null = null;
+  // Tracked read: `cameraMirror` auto-tracks under `SignalWatcher`, so a config
+  // change re-renders the video transform — replacing the v1
+  // `subConfigValue('cameraMirror')` mirror into a `_videoTransformCss` @state.
+  private get _videoTransformCss(): string | null {
+    return this.use(ConfigController).getTracked('cameraMirror') ? 'scaleX(-1)' : null;
+  }
 
   @state()
   private _videoHidden = true;
@@ -157,7 +166,7 @@ export class CameraSource extends ChildBlock {
   }
 
   private _chooseActionWithCamera = () => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -205,7 +214,7 @@ export class CameraSource extends ChildBlock {
   };
 
   private _handleStartCamera = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -227,7 +236,7 @@ export class CameraSource extends ChildBlock {
   };
 
   private _handleRetake = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -241,7 +250,7 @@ export class CameraSource extends ChildBlock {
   };
 
   private _handleAccept = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -264,7 +273,7 @@ export class CameraSource extends ChildBlock {
 
   private _updateTimer = (): void => {
     const currentTime = Math.floor((performance.now() - this._startTime + this._elapsedTime) / 1000);
-    const maxVideoRecordingDuration = this.uploader.config.get('maxVideoRecordingDuration');
+    const maxVideoRecordingDuration = this.use(ConfigController).get('maxVideoRecordingDuration');
 
     if (typeof maxVideoRecordingDuration === 'number' && maxVideoRecordingDuration > 0) {
       const remainingTime = maxVideoRecordingDuration - currentTime;
@@ -331,7 +340,7 @@ export class CameraSource extends ChildBlock {
   private _startRecording = (): void => {
     try {
       this._chunks = [];
-      const mediaRecorderOptions = this.uploader.config.get('mediaRecorderOptions');
+      const mediaRecorderOptions = this.use(ConfigController).get('mediaRecorderOptions');
       this._options = {
         ...mediaRecorderOptions,
       };
@@ -361,7 +370,7 @@ export class CameraSource extends ChildBlock {
       }
     } catch (error) {
       console.error('Failed to start recording', error);
-      this.bag.telemetryManager.sendEventError(error, 'camera recording. Failed to start recording');
+      this.use(TelemetryManager).sendEventError(error, 'camera recording. Failed to start recording');
     }
   };
 
@@ -377,7 +386,7 @@ export class CameraSource extends ChildBlock {
     this._mediaRecorder?.stop();
     this.classList.remove('uc-recording');
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -435,7 +444,7 @@ export class CameraSource extends ChildBlock {
       this._attachPreviewListeners(videoElement);
     } catch (error) {
       console.error('Failed to preview video', error);
-      this.bag.telemetryManager.sendEventError(error, 'camera previewing. Failed to preview video');
+      this.use(TelemetryManager).sendEventError(error, 'camera previewing. Failed to preview video');
     }
   };
 
@@ -532,7 +541,7 @@ export class CameraSource extends ChildBlock {
   };
 
   private _handleVideo = (status: CameraStatus): void => {
-    const enableAudioRecording = this.uploader.config.get('enableAudioRecording');
+    const enableAudioRecording = this.use(ConfigController).get('enableAudioRecording');
     if (status === CameraSourceEvents.PLAY) {
       this._timerHidden = false;
       this._tabCameraHidden = true;
@@ -601,7 +610,7 @@ export class CameraSource extends ChildBlock {
     this._canvas.height = videoEl.videoHeight;
     this._canvas.width = videoEl.videoWidth;
 
-    if (this.uploader.config.get('cameraMirror')) {
+    if (this.use(ConfigController).get('cameraMirror')) {
       this._ctx.translate(this._canvas.width, 0);
       this._ctx.scale(-1, 1);
     }
@@ -619,14 +628,14 @@ export class CameraSource extends ChildBlock {
     }
 
     if (tabId === CameraSourceTypes.VIDEO) {
-      const enableAudioRecording = this.uploader.config.get('enableAudioRecording');
+      const enableAudioRecording = this.use(ConfigController).get('enableAudioRecording');
       this._currentTimelineIcon = 'play';
       this._currentIcon = 'video-camera-full';
       this._audioSelectHidden = !enableAudioRecording || this._audioDevices.length <= 1;
       this._audioToggleMicrophoneHidden = !enableAudioRecording;
     }
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -689,13 +698,15 @@ export class CameraSource extends ChildBlock {
    * The send file to the server
    */
   private _toSend = (file: File): void => {
+    // `api` (UploaderPublicApi) has no DI token (set via UploaderController.setApi),
+    // so it stays on the v1 `bag` (step 8).
     this.bag.api.addFileFromObject(file, { source: UploadSource.CAMERA });
 
-    this.bag.router.traverse('onFileAdd');
+    this.use(RouterController).traverse('onFileAdd');
   };
 
   private get _cameraModes(): CameraMode[] {
-    return stringToArray(this.uploader.config.get('cameraModes')).filter(
+    return stringToArray(this.use(ConfigController).get('cameraModes')).filter(
       (mode): mode is CameraMode => mode === CameraSourceTypes.PHOTO || mode === CameraSourceTypes.VIDEO,
     );
   }
@@ -708,7 +719,7 @@ export class CameraSource extends ChildBlock {
     this.classList.toggle('uc-initialized', state === 'granted');
 
     const visibleAudio =
-      this._activeTab === CameraSourceTypes.VIDEO && this.uploader.config.get('enableAudioRecording');
+      this._activeTab === CameraSourceTypes.VIDEO && this.use(ConfigController).get('enableAudioRecording');
     const currentIcon = this._activeTab === CameraSourceTypes.PHOTO ? 'camera-full' : 'video-camera-full';
 
     if (state === 'granted') {
@@ -776,7 +787,7 @@ export class CameraSource extends ChildBlock {
   };
 
   private _capture = async (): Promise<void> => {
-    const enableAudioRecording = this.uploader.config.get('enableAudioRecording');
+    const enableAudioRecording = this.use(ConfigController).get('enableAudioRecording');
     const constraints: MediaStreamConstraints = {
       video: { ...DEFAULT_VIDEO_CONFIG },
       audio: enableAudioRecording ? ({} as MediaTrackConstraints) : false,
@@ -817,7 +828,7 @@ export class CameraSource extends ChildBlock {
     } catch (error) {
       this._setPermissionsState('denied');
       console.log('Failed to capture camera', error);
-      this.bag.telemetryManager.sendEventError(error, 'camera capturing. Failed to capture camera');
+      this.use(TelemetryManager).sendEventError(error, 'camera capturing. Failed to capture camera');
     }
   };
 
@@ -845,7 +856,7 @@ export class CameraSource extends ChildBlock {
     } catch (error) {
       this._teardownPermissionListeners();
       console.log('Failed to use permissions API. Fallback to manual request mode.', error);
-      this.bag.telemetryManager.sendEventError(error, 'camera permissions. Failed to use permissions API');
+      this.use(TelemetryManager).sendEventError(error, 'camera permissions. Failed to use permissions API');
       this._capture();
     }
   };
@@ -865,13 +876,13 @@ export class CameraSource extends ChildBlock {
     try {
       await navigator.mediaDevices.getUserMedia({
         video: true,
-        audio: this.uploader.config.get('enableAudioRecording'),
+        audio: this.use(ConfigController).get('enableAudioRecording'),
       });
       await this._getDevices();
 
       navigator.mediaDevices.addEventListener('devicechange', this._getDevices);
     } catch (error) {
-      this.bag.telemetryManager.sendEventError(error, 'camera devices. Failed to get user media');
+      this.use(TelemetryManager).sendEventError(error, 'camera devices. Failed to get user media');
       console.log('Failed to get user media', error);
     }
   };
@@ -879,7 +890,7 @@ export class CameraSource extends ChildBlock {
   private _getDevices = async (): Promise<void> => {
     try {
       const devices = await navigator.mediaDevices.enumerateDevices();
-      const enableAudioRecording = this.uploader.config.get('enableAudioRecording');
+      const enableAudioRecording = this.use(ConfigController).get('enableAudioRecording');
 
       this._cameraDevices = devices
         .filter((device) => device.kind === 'videoinput')
@@ -905,7 +916,7 @@ export class CameraSource extends ChildBlock {
       this._audioSelectHidden = !enableAudioRecording || this._audioDevices.length <= 1;
       this._selectedAudioId = this._audioDevices[0]?.value ?? null;
     } catch (error) {
-      this.bag.telemetryManager.sendEventError(error, 'camera devices. Failed to get devices');
+      this.use(TelemetryManager).sendEventError(error, 'camera devices. Failed to get devices');
       console.log('Failed to get devices', error);
     }
   };
@@ -943,10 +954,11 @@ export class CameraSource extends ChildBlock {
   };
 
   protected override controllerReady(): void {
-    this.subConfigValue('cameraMirror', (val) => {
-      this._videoTransformCss = val ? 'scaleX(-1)' : null;
-    });
-
+    // `cameraMirror` is now a tracked render read (see `_videoTransformCss`).
+    // These two stay `subConfigValue` (side-effecting, not pure render reads):
+    // `enableAudioRecording` and `cameraModes` mutate several imperative @state
+    // fields also written by the camera-stream handlers, so they can't collapse
+    // into a derived render getter.
     this.subConfigValue('enableAudioRecording', (val) => {
       this._audioToggleMicrophoneHidden = !val;
       this._audioSelectDisabled = !val;
@@ -995,7 +1007,7 @@ export class CameraSource extends ChildBlock {
         <button
           type="button"
           class="uc-mini-btn"
-          @click=${() => this.bag.router.traverse('onBack')}
+          @click=${() => this.use(RouterController).traverse('onBack')}
           title=${this.l10n('back')}
         >
           <uc-icon name="back"></uc-icon>
@@ -1014,7 +1026,7 @@ export class CameraSource extends ChildBlock {
         <button
           type="button"
           class="uc-mini-btn uc-close-btn"
-          @click=${() => this.bag.router.traverse('onClose')}
+          @click=${() => this.use(RouterController).traverse('onClose')}
           title=${this.l10n('a11y-activity-header-button-close')}
           aria-label=${this.l10n('a11y-activity-header-button-close')}
         >

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
@@ -1,0 +1,229 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import type { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
+import type { TypedData } from '../../abstract/TypedData';
+import type { UploadEntryData } from '../../abstract/uploadEntrySchema';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import type { Uid } from '../../lit/Uid';
+import { delay } from '../../utils/delay';
+import { CloudImageEditorActivity } from './CloudImageEditorActivity';
+
+// Idempotent (same path as defineComponents(UC)).
+CloudImageEditorActivity.reg('uc-cloud-image-editor-activity');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `cloud-image-editor-activity-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+type FakeEntry = {
+  setMultipleValues: ReturnType<typeof vi.fn>;
+};
+
+// Minimal `*uploadCollection` fake: `read(uid)` returns an entry whose
+// `getValue('cdnUrl')` resolves so `_mountEditor` sets `_cdnUrl`. Absent a
+// `cdnUrl` (or absent the whole collection) the block's `bag.when` observer
+// leaves `_cdnUrl` null and nothing renders — matching the v1 mount gate.
+const makeFakeCollection = (entriesById: Record<string, { cdnUrl?: string } & FakeEntry>): UploadCollectionController =>
+  ({
+    read: (uid: Uid) => {
+      const entry = entriesById[uid as string];
+      if (!entry) return undefined;
+      return {
+        getValue: (key: string) => (key === 'cdnUrl' ? entry.cdnUrl : undefined),
+        setMultipleValues: entry.setMultipleValues,
+      } as unknown as TypedData<UploadEntryData>;
+    },
+  }) as unknown as UploadCollectionController;
+
+const mount = async (
+  ctxName: string,
+  opts: {
+    internalId?: string;
+    entries?: Record<string, { cdnUrl?: string } & FakeEntry>;
+  } = {},
+): Promise<{ el: CloudImageEditorActivity; config: ConfigController; router: RouterController }> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const ctx = PubSub.getCtx(ctxName);
+  const config = container?.get(ConfigController);
+  const router = container?.get(RouterController);
+  if (!container || !ctx || !config || !router) throw new Error('controllers not resolved');
+
+  // Router params carry the `internalId` `_mountEditor` reads on adoption, so set
+  // them before the element adopts.
+  if (opts.internalId) {
+    router.setActivity('cloud-image-edit', { internalId: opts.internalId });
+  }
+  if (opts.entries) {
+    ctx.add('*uploadCollection', makeFakeCollection(opts.entries), true);
+  }
+
+  const el = document.createElement('uc-cloud-image-editor-activity') as CloudImageEditorActivity;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config, router };
+};
+
+const editorEl = (el: CloudImageEditorActivity): HTMLElement | null => el.querySelector('uc-cloud-image-editor');
+
+describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
+  it('declares its dependencies via static uses (incl. the base RouterController)', () => {
+    expect(CloudImageEditorActivity.uses).toEqual([RouterController, ConfigController]);
+  });
+
+  it('pre-warms its declared dependencies into the container on adoption', async () => {
+    const ctxName = freshCtxName();
+    await mount(ctxName);
+    const container = PubSub.getContainer(ctxName);
+    expect(container?.get(RouterController)).toBeInstanceOf(RouterController);
+    expect(container?.get(ConfigController)).toBeInstanceOf(ConfigController);
+  });
+
+  it('renders nothing until the uploadCollection entry (with a cdnUrl) resolves', async () => {
+    const ctxName = freshCtxName();
+    // Router params present, but no uploadCollection registered -> `bag.when`
+    // never fires, `_cdnUrl` stays null, nothing renders.
+    const { el } = await mount(ctxName, { internalId: 'file-1' });
+    expect(editorEl(el)).toBeNull();
+  });
+
+  it('mounts the <uc-cloud-image-editor> with the entry cdn-url once the collection resolves', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+    });
+    const editor = editorEl(el);
+    expect(editor).not.toBeNull();
+    expect(editor?.getAttribute('cdn-url')).toBe('https://cdn.test/file-1/');
+  });
+
+  it('feeds cropPreset / cloudImageEditorTabs to the editor and re-renders reactively (getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+    });
+    config.set('cropPreset', '1:1');
+    config.set('cloudImageEditorTabs', 'crop,tuning');
+    await el.updateComplete;
+    await delay(0);
+    expect(editorEl(el)?.getAttribute('crop-preset')).toBe('1:1');
+    expect(editorEl(el)?.getAttribute('tabs')).toBe('crop,tuning');
+
+    // A later config change re-renders the mounted editor with new attributes —
+    // the tracked read replaces the v1 `subConfigValue` subscriptions.
+    config.set('cropPreset', '16:9');
+    await el.updateComplete;
+    await delay(0);
+    expect(editorEl(el)?.getAttribute('crop-preset')).toBe('16:9');
+  });
+
+  it('applies the editor result to the entry and traverses onBack on the "apply" event', async () => {
+    const ctxName = freshCtxName();
+    const setMultipleValues = vi.fn();
+    const { el, router } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues } },
+    });
+    const traverse = vi.spyOn(router, 'traverse');
+    const editor = editorEl(el);
+    expect(editor).not.toBeNull();
+
+    editor?.dispatchEvent(
+      new CustomEvent('apply', {
+        detail: { cdnUrl: 'https://cdn.test/file-1/-/edited/', cdnUrlModifiers: '-/edited/' },
+      }),
+    );
+
+    expect(setMultipleValues).toHaveBeenCalledWith({
+      cdnUrl: 'https://cdn.test/file-1/-/edited/',
+      cdnUrlModifiers: '-/edited/',
+    });
+    expect(traverse).toHaveBeenCalledWith('onBack');
+  });
+
+  it('traverses onBack on the "cancel" event (via the RouterController)', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+    });
+    const traverse = vi.spyOn(router, 'traverse');
+    editorEl(el)?.dispatchEvent(new CustomEvent('cancel', { detail: {} }));
+    expect(traverse).toHaveBeenCalledWith('onBack');
+
+    // A non-CustomEvent (`detail` undefined branch) still navigates back.
+    traverse.mockClear();
+    editorEl(el)?.dispatchEvent(new Event('cancel'));
+    expect(traverse).toHaveBeenCalledWith('onBack');
+  });
+
+  it('debug-prints the "change" event without side-effects (editor stays mounted)', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+    });
+    const traverse = vi.spyOn(router, 'traverse');
+    editorEl(el)?.dispatchEvent(new CustomEvent('change', { detail: { cdnUrlModifiers: '-/x/' } }));
+    // `handleChange` only debug-prints — no navigation, editor untouched.
+    expect(traverse).not.toHaveBeenCalled();
+    expect(editorEl(el)).not.toBeNull();
+  });
+
+  it('ignores the "apply" event when there is no resolved entry', async () => {
+    const ctxName = freshCtxName();
+    const setMultipleValues = vi.fn();
+    const { el, router } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues } },
+    });
+    const editor = editorEl(el);
+    const traverse = vi.spyOn(router, 'traverse');
+    // Simulate the (post-teardown) race where the entry is gone but a queued
+    // editor event still lands: `_handleApply` must early-return.
+    (el as unknown as { _entry: undefined })._entry = undefined;
+    editor?.dispatchEvent(
+      new CustomEvent('apply', { detail: { cdnUrl: 'https://cdn.test/x/', cdnUrlModifiers: '-/x/' } }),
+    );
+    expect(setMultipleValues).not.toHaveBeenCalled();
+    expect(traverse).not.toHaveBeenCalled();
+  });
+
+  it('does not mount the editor when the entry is missing from the collection', async () => {
+    const ctxName = freshCtxName();
+    // Collection registered but `read('file-1')` returns undefined -> the mount
+    // observer throws (isolated by `controllerReady`), leaving nothing rendered.
+    const { el } = await mount(ctxName, { internalId: 'file-1', entries: {} });
+    expect(editorEl(el)).toBeNull();
+  });
+
+  it('does not mount the editor when the entry has not uploaded yet (no cdnUrl)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName, {
+      internalId: 'file-1',
+      entries: { 'file-1': { setMultipleValues: vi.fn() } },
+    });
+    expect(editorEl(el)).toBeNull();
+  });
+});

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
@@ -1,6 +1,8 @@
 import { html, nothing } from 'lit';
 import { state } from 'lit/decorators.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { TypedData } from '../../abstract/TypedData';
 import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
@@ -14,50 +16,29 @@ import '../../solutions/cloud-image-editor/CloudImageEditor';
 
 export type ActivityParams = { internalId: string };
 
-type EditorTemplateConfig = {
-  cdnUrl: string;
-  cropPreset: string;
-  tabs: string;
-};
-
 export class CloudImageEditorActivity extends ActivityChildBlock {
+  // `RouterController` is what the base `ActivityChildBlock` already declares (its
+  // `[active]` toggle reads it, and this block traverses on apply/cancel);
+  // `ConfigController` is added for the tracked `cropPreset` /
+  // `cloudImageEditorTabs` render reads that feed the editor's attributes.
+  // `uploadCollection` (the entry source) has no DI token yet (registration
+  // race), so it stays on the v1 `bag` (step 8).
+  public static override readonly uses = [RouterController, ConfigController] as const;
+
   private _entry?: TypedData<UploadEntryData>;
 
+  // Mount marker: the resolved cdn url of the entry being edited, set once the
+  // uploadCollection entry is available and cleared on unmount. Its presence
+  // gates whether the `<uc-cloud-image-editor>` renders; `cropPreset` / `tabs`
+  // are read reactively at render time (see `render`), not stored here.
   @state()
-  private _editorConfig: EditorTemplateConfig | null = null;
+  private _cdnUrl: string | null = null;
 
   /** Same contract as v1 `LitBlock.debugPrint` (`createDebugPrinter`), scoped to this ctx. */
   private _debugPrint = createDebugPrinter(() => this.bag.ctx, this.constructor.name);
 
   protected override controllerReady(ctrl: UploaderController): void {
     super.controllerReady(ctrl);
-
-    this.subConfigValue('cropPreset', (cropPreset) => {
-      if (!this._editorConfig) {
-        return;
-      }
-      if (this._editorConfig.cropPreset === cropPreset) {
-        return;
-      }
-      this._editorConfig = {
-        ...this._editorConfig,
-        cropPreset,
-      };
-    });
-
-    this.subConfigValue('cloudImageEditorTabs', (tabs) => {
-      if (!this._editorConfig) {
-        return;
-      }
-      if (this._editorConfig.tabs === tabs) {
-        return;
-      }
-      this._editorConfig = {
-        ...this._editorConfig,
-        tabs,
-      };
-    });
-
     this._mountEditor();
   }
 
@@ -78,13 +59,13 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
     });
     // The back intent closes the cloud-editor activity and returns to the
     // previous one.
-    this.bag.router.traverse('onBack');
+    this.use(RouterController).traverse('onBack');
   }
 
   private _handleCancel(event?: Event): void {
     const detail = event instanceof CustomEvent ? event.detail : undefined;
     this._debugPrint(`editor event "cancel"`, detail);
-    this.bag.router.traverse('onBack');
+    this.use(RouterController).traverse('onBack');
   }
 
   public handleChange(event: CustomEvent<ChangeResult>): void {
@@ -95,11 +76,13 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
     // `internalId` comes from the router-params object, whose shape is a
     // per-activity contract (ExternalSource precedent) rather than a runtime
     // guard the router already enforces.
-    const { internalId } = this.bag.router.params as ActivityParams;
+    const { internalId } = this.use(RouterController).params as ActivityParams;
     // The uploader-scope `*uploadCollection` instance may not have registered
     // yet when this block's controller adopts (controllerReady is an
     // adoption path) — go through `bag.when` rather than the throwing
     // `bag.uploadCollection` getter (FileItem/UploadList precedent).
+    // `uploadCollection` has no DI token yet (registration race), so this
+    // observer stays on the v1 `bag` (step 8).
     this.trackSub(
       this.bag.when('uploadCollection', (collection) => {
         const entry = collection.read(internalId as Uid);
@@ -111,26 +94,35 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
         if (!cdnUrl) {
           throw new Error(`Entry with internalId "${internalId}" hasn't uploaded yet`);
         }
-        this._editorConfig = this._createEditorConfig(cdnUrl);
+        this._cdnUrl = cdnUrl;
       }),
     );
   }
 
   private _unmountEditor(): void {
     this._entry = undefined;
-    this._editorConfig = null;
+    this._cdnUrl = null;
   }
 
   public override render() {
-    if (!this._editorConfig) {
+    if (this._cdnUrl === null) {
       return nothing;
     }
 
-    const { cdnUrl, cropPreset, tabs } = this._editorConfig;
+    // Render-feeding config reads through the TRACKED accessor: `SignalWatcher`
+    // (on the `ChildBlock` base) auto-tracks these, so a `cropPreset` /
+    // `cloudImageEditorTabs` config change while the editor is mounted re-renders
+    // it with the new attributes — matching the v1
+    // `subConfigValue('cropPreset' | 'cloudImageEditorTabs')` subscriptions this
+    // replaces. While unmounted (`_cdnUrl === null`) nothing renders and nothing
+    // tracks, mirroring the v1 `if (!this._editorConfig) return` guard.
+    const config = this.use(ConfigController);
+    const cropPreset = config.getTracked('cropPreset');
+    const tabs = config.getTracked('cloudImageEditorTabs');
 
     return html`
       <uc-cloud-image-editor
-        cdn-url=${cdnUrl}
+        cdn-url=${this._cdnUrl}
         crop-preset=${ifDefined(cropPreset)}
         tabs=${ifDefined(tabs)}
         @apply=${this._handleApply}
@@ -138,15 +130,6 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
         @change=${this.handleChange}
       ></uc-cloud-image-editor>
     `;
-  }
-
-  private _createEditorConfig(cdnUrl: string): EditorTemplateConfig {
-    const config: EditorTemplateConfig = {
-      cdnUrl,
-      cropPreset: this.uploader.config.get('cropPreset'),
-      tabs: this.uploader.config.get('cloudImageEditorTabs'),
-    };
-    return config;
   }
 }
 

--- a/src/blocks/Config/Config.test.ts
+++ b/src/blocks/Config/Config.test.ts
@@ -1,0 +1,110 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { Config } from './Config';
+
+// Idempotent (same path as defineComponents(UC)).
+Config.reg('uc-config');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `config-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const track = (el: HTMLElement): void => {
+  mounted.push(el);
+};
+
+/** The SAME ConfigController the rest of the app reads (v1 `this.uploader.config`). */
+const controllerFor = (ctxName: string): ConfigController => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  if (!container) throw new Error('no container');
+  return container.get(ConfigController);
+};
+
+const mount = async (ctxName: string, attrs: Record<string, string> = {}): Promise<Config> => {
+  const el = document.createElement('uc-config') as Config;
+  for (const [name, value] of Object.entries(attrs)) el.setAttribute(name, value);
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  track(el);
+  await el.updateComplete;
+  await delay(0);
+  return el;
+};
+
+describe('Config (<uc-config>) — M-god step 6b-5 use(ConfigController)', () => {
+  it('declares its dependency via static uses', () => {
+    expect(Config.uses).toEqual([ConfigController]);
+  });
+
+  it('writes a DOM-property value into the SAME ConfigController the app reads', async () => {
+    const ctxName = freshCtxName();
+    // Force ctx/container/controller into existence up front so we compare
+    // against the exact instance the block resolves via use().
+    const config = controllerFor(ctxName);
+
+    const el = await mount(ctxName);
+    el.pubkey = 'demopublickey';
+
+    expect(config.get('pubkey')).toBe('demopublickey');
+    // Round-trips back through the element getter (which reads the same controller).
+    expect(el.pubkey).toBe('demopublickey');
+  });
+
+  it('writes an attribute change (attributeChangedCallback) into that controller', async () => {
+    const ctxName = freshCtxName();
+    const config = controllerFor(ctxName);
+
+    const el = await mount(ctxName);
+    el.setAttribute('multiple', 'false');
+    await delay(0);
+
+    expect(config.get('multiple')).toBe(false);
+  });
+
+  it('flushes an initial pre-mount attribute value into the controller', async () => {
+    const ctxName = freshCtxName();
+    const config = controllerFor(ctxName);
+
+    await mount(ctxName, { pubkey: 'seededkey' });
+
+    expect(config.get('pubkey')).toBe('seededkey');
+  });
+
+  it('reflects an external controller change back onto the element (subscribe path)', async () => {
+    const ctxName = freshCtxName();
+    const config = controllerFor(ctxName);
+
+    const el = await mount(ctxName);
+    // External write on the SAME controller — the block's config subscription
+    // must pull it back onto the local property (and DOM attribute).
+    config.set('pubkey', 'externallyset');
+    await el.updateComplete;
+    await delay(0);
+
+    expect(el.pubkey).toBe('externallyset');
+    expect(el.getAttribute('pubkey')).toBe('externallyset');
+  });
+
+  // The custom-config attribute bridge (MutationObserver + attributeChangedCallback
+  // custom path) routes through the PLUGIN MANAGER's `configRegistry` (the v1 `bag`
+  // path, no DI token) rather than `ConfigController.register`, so exercising it
+  // needs the full plugin-manager machinery. It is covered end-to-end by
+  // `tests/plugins/custom-config.e2e.test.tsx`.
+});

--- a/src/blocks/Config/Config.ts
+++ b/src/blocks/Config/Config.ts
@@ -1,4 +1,5 @@
 // @ts-check
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { CustomConfig } from '../../abstract/customConfigOptions';
 import type { PluginController } from '../../abstract/managers/plugin';
@@ -52,6 +53,16 @@ const getLocalPropName = (key: string) => `__${key}`;
 
 // biome-ignore lint/suspicious/noUnsafeDeclarationMerging: This is intentional interface merging, used to add configuration setters/getters
 export class Config extends ChildBlock {
+  // `<uc-config>` is the config WRITER: it resolves the ctx's `ConfigController`
+  // via `this.use(ConfigController)` and writes attribute/property values into it
+  // (`set`/`setCustom`/`register`). This is the SAME instance the rest of the app
+  // reads (v1's `this.uploader.config` resolved to `container.get(ConfigController)` too),
+  // so writes land where every reader looks. The plugin manager (custom-config
+  // registry) has no DI token, so it stays on the v1 `bag.when('pluginManager')`/
+  // `bag.pluginManagerOrNull` path (see `_getCustomConfigDefinition` /
+  // `_setupCustomConfigs`), migrated once it grows a container-owned controller.
+  public static override readonly uses = [ConfigController] as const;
+
   public declare attributesMeta: Partial<ConfigPlainType> & {
     'ctx-name': string;
   };
@@ -137,7 +148,9 @@ export class Config extends ChildBlock {
   private _flushValueToState(key: string, value: unknown) {
     const isCustom = this._isCustomConfig(key);
     const configKey = key as keyof ConfigType;
-    const currentValue = isCustom ? this.uploader.config.getCustom(key) : this.uploader.config.get(configKey);
+    const currentValue = isCustom
+      ? this.use(ConfigController).getCustom(key)
+      : this.use(ConfigController).get(configKey);
 
     if (currentValue !== value) {
       if (typeof value === 'undefined' || value === null) {
@@ -145,15 +158,15 @@ export class Config extends ChildBlock {
         const defaultValue = initialConfig[configKey];
         const nextValue = defaultValue !== undefined ? defaultValue : value;
         if (isCustom) {
-          this.uploader.config.setCustom(key, nextValue);
+          this.use(ConfigController).setCustom(key, nextValue);
         } else {
-          this.uploader.config.set(configKey, nextValue as ConfigType[typeof configKey]);
+          this.use(ConfigController).set(configKey, nextValue as ConfigType[typeof configKey]);
         }
       } else {
         if (isCustom) {
-          this.uploader.config.setCustom(key, value);
+          this.use(ConfigController).setCustom(key, value);
         } else {
-          this.uploader.config.set(configKey, value as ConfigType[typeof configKey]);
+          this.use(ConfigController).set(configKey, value as ConfigType[typeof configKey]);
         }
       }
     }
@@ -195,7 +208,7 @@ export class Config extends ChildBlock {
 
     // Only run assertions for built-in configs
     if (!this._isCustomConfig(key)) {
-      runAssertions(this.uploader.config.values);
+      runAssertions(this.use(ConfigController).values);
     }
   }
 
@@ -205,13 +218,13 @@ export class Config extends ChildBlock {
     return (
       anyThis[localPropName] ??
       (this._isCustomConfig(key)
-        ? this.uploader.config.getCustom(key)
-        : this.uploader.config.get(key as keyof ConfigType))
+        ? this.use(ConfigController).getCustom(key)
+        : this.use(ConfigController).get(key as keyof ConfigType))
     );
   }
 
   private _assertSameValueDifferentReference(key: string, previousValue: unknown, nextValue: unknown) {
-    if (this.uploader.config.values.debug) {
+    if (this.use(ConfigController).values.debug) {
       if (
         nextValue !== previousValue &&
         typeof nextValue === 'object' &&
@@ -313,9 +326,9 @@ export class Config extends ChildBlock {
         // Manual per-key dedup over the coarse `ConfigController.subscribe`
         // notification — same contract as v1's `this.sub(stateKey, cb, false)`
         // (init=false: no immediate call, only on subsequent changes).
-        let lastValue = this.uploader.config.getCustom(name);
-        const unsub = this.uploader.config.subscribe(() => {
-          const nextValue = this.uploader.config.getCustom(name);
+        let lastValue = this.use(ConfigController).getCustom(name);
+        const unsub = this.use(ConfigController).subscribe(() => {
+          const nextValue = this.use(ConfigController).getCustom(name);
           if (!Object.is(nextValue, lastValue)) {
             lastValue = nextValue;
             // Use _setValue for consistent handling (matches built-in config pattern)
@@ -437,10 +450,10 @@ export class Config extends ChildBlock {
     // manual per-key dedup over the coarse `ConfigController.subscribe`
     // notification, and ties teardown to controller release/re-adoption.
     for (const key of plainConfigKeys) {
-      let lastValue = this.uploader.config.get(key);
+      let lastValue = this.use(ConfigController).get(key);
       this.trackSub(
-        this.uploader.config.subscribe(() => {
-          const nextValue = this.uploader.config.get(key);
+        this.use(ConfigController).subscribe(() => {
+          const nextValue = this.use(ConfigController).get(key);
           if (!Object.is(nextValue, lastValue)) {
             lastValue = nextValue;
             this._setValue(key, nextValue);
@@ -453,7 +466,7 @@ export class Config extends ChildBlock {
       // Flush the initial value to the state.
       // Initial value is taken from the DOM property if it was set before the element was initialized.
       // If no DOM property was set, the initial value is taken from the initialConfig.
-      const initialValue = anyThis[key] ?? this.uploader.config.get(key);
+      const initialValue = anyThis[key] ?? this.use(ConfigController).get(key);
       if (initialValue !== initialConfig[key]) {
         this._setValue(key, initialValue);
         // `_setValue`'s no-op guard (skip when the local property cache

--- a/src/blocks/Copyright/Copyright.test.ts
+++ b/src/blocks/Copyright/Copyright.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { Copyright } from './Copyright';
+
+// Idempotent (same path as defineComponents(UC)).
+Copyright.reg('uc-copyright');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `copyright-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<Copyright> => {
+  const el = document.createElement('uc-copyright') as Copyright;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+const link = (el: HTMLElement): HTMLAnchorElement | null => el.querySelector<HTMLAnchorElement>('.uc-credits');
+
+describe('Copyright (M-god step 6a probe)', () => {
+  it('renders the credits link into its own light DOM (no shadow root)', async () => {
+    const ctxName = freshCtxName();
+    const el = await mount(ctxName);
+
+    // LightDomMixin renders into the host itself, not a shadow root.
+    expect(el.shadowRoot).toBeNull();
+    const a = link(el);
+    expect(a).not.toBeNull();
+    expect(a?.textContent?.trim()).toBe('Powered by Uploadcare');
+    expect(a?.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('re-renders the overridden render() into light DOM when the external config signal changes', async () => {
+    const ctxName = freshCtxName();
+    // Force the ctx/container/controller into existence so we can drive config
+    // through the SAME ConfigController instance the block resolves via use().
+    ensureUploaderCtx(ctxName);
+    const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+    expect(config).toBeDefined();
+
+    const el = await mount(ctxName);
+    expect(link(el)?.hasAttribute('hidden')).toBe(false);
+
+    // External config change — no imperative wiring on the block. SignalWatcher
+    // tracked the `removeCopyright` read during render(), so this re-renders.
+    config?.set('removeCopyright', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(link(el)?.hasAttribute('hidden')).toBe(true);
+
+    config?.set('removeCopyright', false);
+    await el.updateComplete;
+    await delay(0);
+    expect(link(el)?.hasAttribute('hidden')).toBe(false);
+  });
+
+  it('declares its dependency via static uses', () => {
+    expect(Copyright.uses).toEqual([ConfigController]);
+  });
+});

--- a/src/blocks/Copyright/Copyright.test.ts
+++ b/src/blocks/Copyright/Copyright.test.ts
@@ -46,10 +46,14 @@ describe('Copyright (M-god step 6a probe)', () => {
     const a = link(el);
     expect(a).not.toBeNull();
     expect(a?.textContent?.trim()).toBe('Powered by Uploadcare');
+    // The inner <a> never carries `hidden` — visibility is driven from the host
+    // (see below), which the inline solution's `:has(uc-copyright[hidden])` CSS
+    // keys off.
     expect(a?.hasAttribute('hidden')).toBe(false);
+    expect(el.hasAttribute('hidden')).toBe(false);
   });
 
-  it('re-renders the overridden render() into light DOM when the external config signal changes', async () => {
+  it('toggles [hidden] on the HOST (not the inner <a>) when the external config signal changes', async () => {
     const ctxName = freshCtxName();
     // Force the ctx/container/controller into existence so we can drive config
     // through the SAME ConfigController instance the block resolves via use().
@@ -58,18 +62,24 @@ describe('Copyright (M-god step 6a probe)', () => {
     expect(config).toBeDefined();
 
     const el = await mount(ctxName);
+    expect(el.hasAttribute('hidden')).toBe(false);
+    // The <a> must never receive `hidden` — the host owns that state so the
+    // inline `:has(uc-copyright[hidden])` selector matches.
     expect(link(el)?.hasAttribute('hidden')).toBe(false);
 
     // External config change — no imperative wiring on the block. SignalWatcher
-    // tracked the `removeCopyright` read during render(), so this re-renders.
+    // tracked the `removeCopyright` read during willUpdate(), so this re-runs the
+    // update and re-toggles the host attribute.
     config?.set('removeCopyright', true);
     await el.updateComplete;
     await delay(0);
-    expect(link(el)?.hasAttribute('hidden')).toBe(true);
+    expect(el.hasAttribute('hidden')).toBe(true);
+    expect(link(el)?.hasAttribute('hidden')).toBe(false);
 
     config?.set('removeCopyright', false);
     await el.updateComplete;
     await delay(0);
+    expect(el.hasAttribute('hidden')).toBe(false);
     expect(link(el)?.hasAttribute('hidden')).toBe(false);
   });
 

--- a/src/blocks/Copyright/Copyright.ts
+++ b/src/blocks/Copyright/Copyright.ts
@@ -1,4 +1,4 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './copyright.css';
@@ -6,22 +6,34 @@ import './copyright.css';
 /**
  * Probe block for the M-god step-6a reactive path: it declares its dependency
  * with `static uses`, resolves it with `this.use()`, and reads `removeCopyright`
- * through the TRACKED signal accessor inside `render()`. `SignalWatcher` (on the
- * `ChildBlock` base) auto-tracks that read, so a later `removeCopyright` config
- * change re-renders this element with no `controllerReady`/`subConfigValue`/
- * imperative `toggleAttribute` — the whole v1 subscription dance is gone.
+ * through the TRACKED signal accessor. `SignalWatcher` (on the `ChildBlock`
+ * base) wraps `performUpdate`, so a `getTracked` read anywhere in the update
+ * cycle (here `willUpdate`) is auto-tracked and a later `removeCopyright` config
+ * change re-runs the update with no `subConfigValue`/manual subscription.
+ *
+ * The `hidden` attribute lives on the HOST `<uc-copyright>`, not the inner
+ * `<a>`: the inline solution's layout CSS keys off it via
+ * `:has(uc-copyright[hidden])` (see `solutions/file-uploader/inline/index.css`),
+ * which only matches when the host carries the attribute. We toggle it in
+ * `willUpdate` (mirroring pre-6a's `toggleAttribute` on the host) driven by the
+ * tracked signal. `hidden` is not a declared reactive property, so toggling it
+ * here does not schedule a further update.
  */
 export class Copyright extends ChildBlock {
   public static override readonly uses = [ConfigController] as const;
 
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+    const removeCopyright = this.use(ConfigController).getTracked('removeCopyright');
+    this.toggleAttribute('hidden', !!removeCopyright);
+  }
+
   public override render() {
-    const hidden = this.use(ConfigController).getTracked('removeCopyright');
     return html`
       <a
         href="https://uploadcare.com/?utm_source=copyright&amp;utm_medium=referral&amp;utm_campaign=v4"
         target="_blank noopener"
         class="uc-credits"
-        ?hidden=${hidden}
         >Powered by Uploadcare</a
       >
     `;

--- a/src/blocks/Copyright/Copyright.ts
+++ b/src/blocks/Copyright/Copyright.ts
@@ -1,20 +1,27 @@
 import { html } from 'lit';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './copyright.css';
 
+/**
+ * Probe block for the M-god step-6a reactive path: it declares its dependency
+ * with `static uses`, resolves it with `this.use()`, and reads `removeCopyright`
+ * through the TRACKED signal accessor inside `render()`. `SignalWatcher` (on the
+ * `ChildBlock` base) auto-tracks that read, so a later `removeCopyright` config
+ * change re-renders this element with no `controllerReady`/`subConfigValue`/
+ * imperative `toggleAttribute` — the whole v1 subscription dance is gone.
+ */
 export class Copyright extends ChildBlock {
-  protected override controllerReady(): void {
-    this.subConfigValue('removeCopyright', (value) => {
-      this.toggleAttribute('hidden', !!value);
-    });
-  }
+  public static override readonly uses = [ConfigController] as const;
 
   public override render() {
+    const hidden = this.use(ConfigController).getTracked('removeCopyright');
     return html`
       <a
         href="https://uploadcare.com/?utm_source=copyright&amp;utm_medium=referral&amp;utm_campaign=v4"
         target="_blank noopener"
         class="uc-credits"
+        ?hidden=${hidden}
         >Powered by Uploadcare</a
       >
     `;

--- a/src/blocks/DropArea/DropArea.test.ts
+++ b/src/blocks/DropArea/DropArea.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { DropArea } from './DropArea';
+
+// Idempotent (same path as defineComponents(UC)).
+DropArea.reg('uc-drop-area');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `drop-area-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: DropArea; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-drop-area') as DropArea;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+describe('DropArea (M-god step 6b-3 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(DropArea.uses).toEqual([ConfigController, RouterController]);
+  });
+
+  it('attaches the uploader scope and renders into its own light DOM', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    expect(el.shadowRoot).toBeNull();
+    // The scope-attach role is preserved: adopting a controller bootstraps the
+    // ctx and the block renders its content wrapper.
+    expect(el.querySelector('.uc-content-wrapper')).not.toBeNull();
+  });
+
+  it('hides the drop area when the sourceList config drops local (config read via the same ConfigController)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    // Default sourceList allows local uploads -> visible.
+    expect(el.hidden).toBe(false);
+
+    config.set('sourceList', 'url');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.hidden).toBe(true);
+
+    config.set('sourceList', 'local, url');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.hidden).toBe(false);
+  });
+});

--- a/src/blocks/DropArea/DropArea.ts
+++ b/src/blocks/DropArea/DropArea.ts
@@ -1,6 +1,8 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { createRef, type Ref, ref } from 'lit/directives/ref.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { createDebugPrinter } from '../../lit/createDebugPrinter';
@@ -17,6 +19,8 @@ const dropAreaRegistry = new Set<DropArea>();
 
 export class DropArea extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-drop-area'];
+
+  public static override readonly uses = [ConfigController, RouterController] as const;
 
   public declare attributesMeta: {
     single?: boolean;
@@ -93,6 +97,8 @@ export class DropArea extends ChildBlock {
       return;
     }
 
+    // `api` (UploaderPublicApi) has no DI token (set via UploaderController.setApi),
+    // so it stays on the v1 `bag` (step 8) — same for the `onItems` add-file calls.
     if (this.initflow) {
       this.bag.api.initFlow();
       return;
@@ -176,13 +182,19 @@ export class DropArea extends ChildBlock {
           }
         });
         if (this.bag.uploadCollection.size > prevSize) {
-          this.bag.router.traverse('onFileAdd');
+          this.use(RouterController).traverse('onFileAdd');
         }
       },
     });
 
     this.updateComplete.then(() => this._setupContentWrapperDropzone());
 
+    // Kept as `subConfigValue` (side-effecting, not pure render reads): both
+    // drive imperative host/DOM state read outside `render()` — `sourceList`
+    // recomputes `_isEnabled` (consulted by the drop-handler `_shouldIgnore`/
+    // `isActive`) and toggles `this.hidden` on the host; `multiple` seeds
+    // `_dropTextKey`. `subConfigValue` reads the same `ConfigController`, so
+    // this is behavior-identical to a tracked read while staying imperative.
     this.subConfigValue('sourceList', (value: string) => {
       const list = stringToArray(value);
       this._sourceListAllowsLocal = list.includes(UploadSource.LOCAL);
@@ -249,8 +261,11 @@ export class DropArea extends ChildBlock {
   }
 
   private _couldHandleFiles(): boolean {
-    const isMultiple = this.uploader.config.get('multiple');
-    const multipleMax = this.uploader.config.get('multipleMax');
+    // Imperative reads (drop-handler path, not render) — `get()`, not the tracked
+    // `getTracked()`. `uploadCollection` has no DI token (registration race),
+    // so it stays on the v1 `bag` (step 8).
+    const isMultiple = this.use(ConfigController).get('multiple');
+    const multipleMax = this.use(ConfigController).get('multipleMax');
     const currentFilesCount = this.bag.uploadCollection.size;
 
     if (isMultiple && multipleMax && currentFilesCount >= multipleMax) {

--- a/src/blocks/DynamicBtn/DynamicBtn.test.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { DynamicBtn } from './DynamicBtn';
+
+// Idempotent (same path as defineComponents(UC)).
+DynamicBtn.reg('uc-dynamic-btn');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `dynamic-btn-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mountWithConfig = async (ctxName: string): Promise<{ el: DynamicBtn; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-dynamic-btn') as DynamicBtn;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const hasPrimaryAction = (el: DynamicBtn): boolean => el.querySelector('uc-primary-action') !== null;
+
+describe('DynamicBtn (M-god step 6b-2 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(DynamicBtn.uses).toEqual([ConfigController, RouterController, CollectionStateController]);
+  });
+
+  it('re-renders reactively when config.dynamicButtonViewMode changes (getTracked, no subConfigValue)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mountWithConfig(ctxName);
+
+    // Idle, no entries: `auto` mode always shows the primary action; `compact`
+    // mode never does. Switching the config re-renders through the tracked
+    // `_mode` read with no imperative `subConfigValue` subscription.
+    config.set('dynamicButtonViewMode', 'auto');
+    await el.updateComplete;
+    await delay(0);
+    expect(hasPrimaryAction(el)).toBe(true);
+
+    config.set('dynamicButtonViewMode', 'compact');
+    await el.updateComplete;
+    await delay(0);
+    expect(hasPrimaryAction(el)).toBe(false);
+
+    // Bidirectional.
+    config.set('dynamicButtonViewMode', 'auto');
+    await el.updateComplete;
+    await delay(0);
+    expect(hasPrimaryAction(el)).toBe(true);
+  });
+});

--- a/src/blocks/DynamicBtn/DynamicBtn.test.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.test.ts
@@ -4,8 +4,20 @@ import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { RouterController } from '../../abstract/controllers/RouterController';
 import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
 import { PubSub } from '../../lit/PubSubCompat';
+import type { OutputCollectionState, OutputCollectionStatus } from '../../types';
 import { delay } from '../../utils/delay';
+import type { FileActionButton } from '../FileItem/FileActionButton';
 import { DynamicBtn } from './DynamicBtn';
+
+type Entries = OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
+
+// Same narrow-cast fixture recipe as PrimaryAction.test.ts / tests/blocks/primary-action.e2e.test.tsx:
+// only `status`/`allEntries` are read on the paths these tests exercise.
+const makeEntries = (
+  partial: Partial<Pick<Entries, 'status' | 'totalCount'>> & {
+    allEntries?: Array<Partial<Entries['allEntries'][number]>>;
+  },
+): Entries => partial as Entries;
 
 // Idempotent (same path as defineComponents(UC)).
 DynamicBtn.reg('uc-dynamic-btn');
@@ -68,5 +80,48 @@ describe('DynamicBtn (M-god step 6b-2 migration)', () => {
     await el.updateComplete;
     await delay(0);
     expect(hasPrimaryAction(el)).toBe(true);
+  });
+
+  it('reactively updates the abort action progress via CollectionStateController.getTracked (no ctx.sub mirror)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mountWithConfig(ctxName);
+    const collectionState = PubSub.getContainer(ctxName)?.get(CollectionStateController);
+    if (!collectionState) throw new Error('collection-state controller not resolved');
+
+    // `_status`/`_collection` are normally populated from
+    // `bag.apiOrNull.getOutputCollectionState()` via the real
+    // `observeProperties`/`observeCollection` wiring in `controllerReady` — set
+    // directly here (same private-field-poke recipe as
+    // UploadController.test.ts / ValidationController.test.ts) to reach the
+    // `shouldShowAbortAction || hasCollectionEntries` render branch
+    // (`_renderAbortAction`) without standing up a full upload-collection
+    // instance. `_status`/`_collection` are Lit `@state` fields, so assigning
+    // them schedules a render exactly as the real observer callback would.
+    const target = el as unknown as {
+      _status: 'idle' | 'success' | 'uploading' | 'failed';
+      _collection: Entries;
+    };
+    target._status = 'uploading';
+    target._collection = makeEntries({ status: 'uploading', totalCount: 1, allEntries: [{}] });
+    await el.updateComplete;
+    await delay(0);
+
+    const abortAction = el.querySelector('uc-file-action-button') as FileActionButton | null;
+    expect(abortAction).not.toBeNull();
+    expect(abortAction?.progress).toBe(0);
+
+    // `_progress` (read inside `_renderAbortAction`) is a tracked
+    // `CollectionStateController.getTracked('commonProgress')` read — no
+    // imperative `ctx.sub('*commonProgress')` mirror — so an external
+    // `set()` re-renders it reactively.
+    collectionState.set('commonProgress', 42);
+    await el.updateComplete;
+    await delay(0);
+    expect(abortAction?.progress).toBe(42);
+
+    collectionState.set('commonProgress', 100);
+    await el.updateComplete;
+    await delay(0);
+    expect(abortAction?.progress).toBe(100);
   });
 });

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -2,6 +2,9 @@ import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { cache } from 'lit/directives/cache.js';
 import { SourceListController } from '../../abstract/controllers';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import type { Uid } from '../../lit/Uid';
 import type { SourceButtonConfig } from '../SourceBtn/SourceBtn';
@@ -54,11 +57,17 @@ const AUTO_MODE_INLINE_THRESHOLD = 3;
 export class DynamicBtn extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-dynamic-btn'];
 
+  public static override readonly uses = [ConfigController, RouterController, CollectionStateController] as const;
+
   @property({ attribute: 'dropzone', type: Boolean })
   public dropzone = true;
 
-  @state()
-  private _mode: DynamicButtonMode = 'auto';
+  // Tracked read: `dynamicButtonViewMode` auto-tracks under `SignalWatcher`, so a
+  // config change re-renders — replacing the v1 `subConfigValue` mirror that fed
+  // a `_mode` @state and imperatively recomputed `_mainAndRemainSources`.
+  private get _mode(): DynamicButtonMode {
+    return this.use(ConfigController).getTracked('dynamicButtonViewMode');
+  }
 
   private _sourceListController: SourceListController | null = null;
 
@@ -68,14 +77,21 @@ export class DynamicBtn extends ChildBlock {
   @state()
   private _status: 'idle' | 'success' | 'uploading' | 'failed' = 'idle';
 
-  @state()
-  private _mainAndRemainSources!: SourceSplit;
+  // Derived from `_sources` + the tracked `_mode` (both re-render triggers), so a
+  // change in either re-splits with no imperative `_updateSourceSplit`.
+  private get _mainAndRemainSources(): SourceSplit {
+    return adjustSourceBasedOnMode(this._sources, this._mode);
+  }
 
   @state()
   private _collection!: OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
 
-  @state()
-  private _progress = 0;
+  // Tracked read: `commonProgress` (owned by `CollectionStateController`) auto-
+  // tracks under `SignalWatcher` — replacing the v1 `ctx.sub('*commonProgress')`
+  // subscription that mirrored it into `_progress` @state.
+  private get _progress(): number {
+    return this.use(CollectionStateController).getTracked('commonProgress');
+  }
 
   private get isIdle() {
     return this._status === 'idle';
@@ -140,6 +156,8 @@ export class DynamicBtn extends ChildBlock {
   }, 300);
 
   private _updateButtonBasedOnCollectionState() {
+    // `api` (UploaderPublicApi) is not container-resolved (set via
+    // UploaderController.setApi, no DI token), so it stays on the v1 `bag` (step 8).
     const collectionState = this.bag.apiOrNull?.getOutputCollectionState();
 
     if (!collectionState) {
@@ -151,24 +169,7 @@ export class DynamicBtn extends ChildBlock {
     this._status = collectionState.status;
   }
 
-  private _updateSourceSplit(): void {
-    this._mainAndRemainSources = adjustSourceBasedOnMode(this._sources, this._mode);
-  }
-
   protected override controllerReady(): void {
-    this.subConfigValue('dynamicButtonViewMode', (value) => {
-      if (this._mode === value) return;
-
-      this._mode = value;
-      this._updateSourceSplit();
-    });
-
-    this.trackSub(
-      this.bag.ctx.sub('*commonProgress', (progress: number) => {
-        this._progress = progress;
-      }),
-    );
-
     // Re-adoption would otherwise stack a new SourceListController per
     // adoption without removing the previous one (same shape as SourceList).
     this._teardownSourceListController();
@@ -177,7 +178,6 @@ export class DynamicBtn extends ChildBlock {
       sharedInstancesBag: this.bag,
       onSourcesChange: (sources) => {
         this._sources = sources;
-        this._updateSourceSplit();
       },
     });
 
@@ -186,6 +186,8 @@ export class DynamicBtn extends ChildBlock {
     // uploader/solution block finishes its own init, which can race this
     // block's adoption) — go through `bag.when` rather than the throwing
     // `bag.uploadCollection` getter (FileItem precedent for `pluginManager`).
+    // Kept on the v1 `bag` path: the registration race makes an eager
+    // `use(UploadCollectionController)` unsafe here (step 8).
     this.trackSub(
       this.bag.when('uploadCollection', (collection) => {
         // Deliberate post-parity improvement (v1 never unobserved these):
@@ -196,16 +198,17 @@ export class DynamicBtn extends ChildBlock {
       }),
     );
 
+    const router = this.use(RouterController);
     this.trackSub(
-      this.bag.router.hooks.onFileAdd(() => {
+      router.hooks.onFileAdd(() => {
         // With confirmUpload, always land on the upload list.
-        if (this.uploader.config.get('confirmUpload')) {
+        if (this.use(ConfigController).get('confirmUpload')) {
           return ACTIVITY_TYPES.UPLOAD_LIST;
         }
         // If the user navigated somewhere to add the file, fall through to the
         // default (upload list); otherwise close everything so the dynamic button
         // just shows inline status.
-        if (this.bag.router.canGoBack) {
+        if (router.canGoBack) {
           return undefined;
         }
         return null;

--- a/src/blocks/DynamicBtn/PrimaryAction.test.ts
+++ b/src/blocks/DynamicBtn/PrimaryAction.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import type { OutputCollectionState, OutputCollectionStatus } from '../../types';
+import { delay } from '../../utils/delay';
+import { PrimaryAction } from './PrimaryAction';
+
+// Idempotent (same path as defineComponents(UC)).
+PrimaryAction.reg('uc-primary-action');
+
+type Entries = OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
+
+// Same narrow-cast fixture recipe as tests/blocks/primary-action.e2e.test.tsx:
+// PrimaryAction only reads a subset of the collection-state fields.
+const makeEntries = (
+  partial: Partial<Pick<Entries, 'status' | 'totalCount' | 'isSuccess'>> & {
+    allEntries?: Array<Partial<Entries['allEntries'][number]>>;
+  },
+): Entries => partial as Entries;
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `primary-action-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mountWithConfig = async (ctxName: string): Promise<{ el: PrimaryAction; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-primary-action') as PrimaryAction;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const iconEl = (el: PrimaryAction): Element | null => el.querySelector('uc-icon');
+
+describe('PrimaryAction (M-god step 6b-1 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(PrimaryAction.uses).toEqual([ConfigController, RouterController]);
+  });
+
+  it('renders/hides the source icon reactively when dynamicButtonShowFirstIcon toggles (getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mountWithConfig(ctxName);
+    config.set('dynamicButtonShowFirstIcon', false);
+    el.source = { id: 'local', label: 'src-type-local', icon: 'my-icon', onClick: () => {} };
+    el.entries = makeEntries({ totalCount: 0, allEntries: [] });
+    await el.updateComplete;
+    await delay(0);
+    expect(iconEl(el)).toBeNull();
+
+    // External config change re-renders with no subConfigValue subscription.
+    config.set('dynamicButtonShowFirstIcon', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(iconEl(el)).not.toBeNull();
+
+    config.set('dynamicButtonShowFirstIcon', false);
+    await el.updateComplete;
+    await delay(0);
+    expect(iconEl(el)).toBeNull();
+  });
+
+  it('navigates via the container-resolved RouterController (use()) when entries are present', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const router = PubSub.getContainer(ctxName)!.get(RouterController);
+    const spy = vi.spyOn(router, 'navigate').mockImplementation(() => {});
+
+    const { el } = await mountWithConfig(ctxName);
+    el.source = { id: 'local', label: 'src-type-local', onClick: () => {} };
+    el.entries = makeEntries({ status: 'success', isSuccess: true, totalCount: 1, allEntries: [{}] });
+    await el.updateComplete;
+
+    (el.querySelector('button') as HTMLButtonElement).click();
+
+    expect(spy).toHaveBeenCalledWith('upload-list');
+  });
+});

--- a/src/blocks/DynamicBtn/PrimaryAction.ts
+++ b/src/blocks/DynamicBtn/PrimaryAction.ts
@@ -1,5 +1,7 @@
 import { html } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import type { Uid } from '../../lit/Uid';
@@ -13,6 +15,8 @@ import '../Thumb/Thumb';
 
 export class PrimaryAction extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-primary-action'];
+
+  public static override readonly uses = [ConfigController, RouterController] as const;
 
   private static readonly SOURCE_TEXT_CONFIG: Record<string, { action: string }> = {
     [UploadSource.LOCAL]: { action: 'upload-from' },
@@ -28,24 +32,20 @@ export class PrimaryAction extends ChildBlock {
   @property({ type: Object })
   public entries!: OutputCollectionState<OutputCollectionStatus, 'maybe-has-group'>;
 
-  @state()
-  private showIcon = false;
+  // Config-derived render inputs read through the tracked signal path: reading
+  // them in `render()`/`_renderThumbnail()` auto-tracks the key under
+  // `SignalWatcher`, so a later `set()` re-renders — replacing the v1
+  // `subConfigValue` subscriptions that mirrored these into `@state`.
+  private get showIcon(): boolean {
+    return this.use(ConfigController).getTracked('dynamicButtonShowFirstIcon');
+  }
 
-  @state()
-  private _isMultiple = false;
+  private get _isMultiple(): boolean {
+    return this.use(ConfigController).getTracked('multiple');
+  }
 
   protected override subscriptionsFor(ctrl: UploaderController) {
     return [(listener: () => void) => ctrl.locale.subscribe(listener)];
-  }
-
-  protected override controllerReady(): void {
-    this.subConfigValue('dynamicButtonShowFirstIcon', (value) => {
-      this.showIcon = value;
-    });
-
-    this.subConfigValue('multiple', (value) => {
-      this._isMultiple = value;
-    });
   }
 
   private get hasEntries(): boolean {
@@ -125,7 +125,7 @@ export class PrimaryAction extends ChildBlock {
 
   private _handleClick() {
     if (this.hasEntries) {
-      this.bag.router.navigate('upload-list');
+      this.use(RouterController).navigate('upload-list');
       return;
     }
 

--- a/src/blocks/ExternalSource/ExternalSource.test.ts
+++ b/src/blocks/ExternalSource/ExternalSource.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { ExternalSource } from './ExternalSource';
+
+// Idempotent (same path as defineComponents(UC)).
+ExternalSource.reg('uc-external-source');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `external-source-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: ExternalSource; router: RouterController }> => {
+  ensureUploaderCtx(ctxName);
+  const router = PubSub.getContainer(ctxName)?.get(RouterController);
+  if (!router) throw new Error('router controller not resolved');
+  const el = document.createElement('uc-external-source') as ExternalSource;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, router };
+};
+
+describe('ExternalSource (M-god step 6b-2 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(ExternalSource.uses).toEqual([ConfigController, RouterController]);
+  });
+
+  it('routes the close button through the container-resolved RouterController (use())', async () => {
+    // The deferred mount in controllerReady reads router params for the (absent)
+    // externalSourceType and console.errors then bails — silence it here so the
+    // test asserts only the close-button routing.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName);
+    const spy = vi.spyOn(router, 'traverse').mockImplementation(() => {});
+
+    (el.querySelector('.uc-close-btn') as HTMLButtonElement).click();
+
+    expect(spy).toHaveBeenCalledWith('onClose');
+  });
+});

--- a/src/blocks/ExternalSource/ExternalSource.ts
+++ b/src/blocks/ExternalSource/ExternalSource.ts
@@ -7,6 +7,8 @@ import './external-source.css';
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { MessageBridge } from './MessageBridge';
@@ -24,6 +26,8 @@ const SOCIAL_SOURCE_MAPPING: Record<string, string> = {
 export type ActivityParams = { externalSourceType: string };
 
 export class ExternalSource extends ChildBlock {
+  public static override readonly uses = [ConfigController, RouterController] as const;
+
   private _messageBridge?: MessageBridge;
 
   private _iframeRef = createRef<HTMLIFrameElement>();
@@ -82,12 +86,12 @@ export class ExternalSource extends ChildBlock {
     // initial mount is deferred a tick (v1 relied on its immediate-fire
     // params subscription for exactly this — its pre-render direct
     // `_mountIframe()` call was a no-op against an empty ref).
-    this._lastActivityParams = this.bag.router.params;
+    this._lastActivityParams = this.use(RouterController).params;
     setTimeout(() => {
       if (!this.isConnected) {
         return;
       }
-      const { externalSourceType } = this.bag.router.params as ActivityParams;
+      const { externalSourceType } = this.use(RouterController).params as ActivityParams;
       if (!externalSourceType) {
         console.error(`Param "externalSourceType" is required for external source activity`);
         return;
@@ -96,8 +100,8 @@ export class ExternalSource extends ChildBlock {
       this._mountIframe();
     });
     this.trackSub(
-      this.bag.router.subscribe(() => {
-        const params = this.bag.router.params;
+      this.use(RouterController).subscribe(() => {
+        const params = this.use(RouterController).params;
         if (params === this._lastActivityParams) {
           return;
         }
@@ -116,6 +120,12 @@ export class ExternalSource extends ChildBlock {
         });
       }),
     );
+    // These stay on `subConfigValue` (which reads the same ConfigController):
+    // they are side-effecting subscriptions, not pure render reads — `multiple`
+    // seeds a `_showSelectionStatus` that the iframe's selection messages then
+    // overwrite, and `localeName`/`externalSourcesEmbedCss` `postMessage` into
+    // the iframe. A tracked `render()` read cannot express either, so they are
+    // not convertible to `getTracked` here (step 8).
     this.subConfigValue('multiple', (multiple) => {
       this._showSelectionStatus = multiple;
     });
@@ -133,7 +143,7 @@ export class ExternalSource extends ChildBlock {
     selectedFile: NonNullable<InputMessageMap['selected-files-change']['selectedFiles']>[number],
   ): string {
     if (selectedFile.alternatives) {
-      const preferredTypes = stringToArray(this.uploader.config.get('externalSourcesPreferredTypes'));
+      const preferredTypes = stringToArray(this.use(ConfigController).get('externalSourcesPreferredTypes'));
       for (const preferredType of preferredTypes) {
         const regexp = wildcardRegexp(preferredType);
         for (const [type, typeUrl] of Object.entries(selectedFile.alternatives)) {
@@ -152,7 +162,7 @@ export class ExternalSource extends ChildBlock {
   }
 
   private async _handleSelectedFilesChange(message: InputMessageMap['selected-files-change']) {
-    if (this.uploader.config.get('multiple') !== message.isMultipleMode) {
+    if (this.use(ConfigController).get('multiple') !== message.isMultipleMode) {
       console.error('Multiple mode mismatch');
       return;
     }
@@ -170,7 +180,7 @@ export class ExternalSource extends ChildBlock {
   }
 
   private _handleIframeLoad(): void {
-    this._applyEmbedCss(this.uploader.config.get('externalSourcesEmbedCss'));
+    this._applyEmbedCss(this.use(ConfigController).get('externalSourcesEmbedCss'));
     this._applyTheme();
     this._setupL10n();
   }
@@ -192,16 +202,16 @@ export class ExternalSource extends ChildBlock {
   private _setupL10n(): void {
     this._messageBridge?.send({
       type: 'set-locale-definition',
-      localeDefinition: this.uploader.config.get('localeName'),
+      localeDefinition: this.use(ConfigController).get('localeName'),
     });
   }
 
   private _remoteUrl(): string {
-    const pubkey = this.uploader.config.get('pubkey');
-    const remoteTabSessionKey = this.uploader.config.get('remoteTabSessionKey');
-    const socialBaseUrl = this.uploader.config.get('socialBaseUrl');
-    const multiple = this.uploader.config.get('multiple');
-    const { externalSourceType } = this.bag.router.params as ActivityParams;
+    const pubkey = this.use(ConfigController).get('pubkey');
+    const remoteTabSessionKey = this.use(ConfigController).get('remoteTabSessionKey');
+    const socialBaseUrl = this.use(ConfigController).get('socialBaseUrl');
+    const multiple = this.use(ConfigController).get('multiple');
+    const { externalSourceType } = this.use(RouterController).params as ActivityParams;
     if (!externalSourceType) {
       throw new Error(`Param "externalSourceType" is required for external source activity`);
     }
@@ -214,8 +224,8 @@ export class ExternalSource extends ChildBlock {
       session_key: remoteTabSessionKey,
       wait_for_theme: true,
       multiple: multiple.toString(),
-      origin: this.uploader.config.get('topLevelOrigin') || getTopLevelOrigin(),
-      debug: this.uploader.config.get('debug'),
+      origin: this.use(ConfigController).get('topLevelOrigin') || getTopLevelOrigin(),
+      debug: this.use(ConfigController).get('debug'),
     };
     const url = new URL(`/window4/${sourceName}`, socialBaseUrl);
     url.search = queryString(params);
@@ -226,21 +236,23 @@ export class ExternalSource extends ChildBlock {
     for (const message of this._selectedList) {
       const url = this._extractUrlFromSelectedFile(message);
       const { filename } = message;
-      const { externalSourceType } = this.bag.router.params as ActivityParams;
+      const { externalSourceType } = this.use(RouterController).params as ActivityParams;
       if (!externalSourceType) {
         throw new Error(`Param "externalSourceType" is required for external source activity`);
       }
+      // `api` (UploaderPublicApi) is not container-resolved (set via
+      // UploaderController.setApi, no DI token), so it stays on the v1 `bag` (step 8).
       this.bag.api.addFileFromUrl(url, {
         fileName: filename,
         source: externalSourceType,
       });
     }
 
-    this.bag.router.traverse('onFileAdd');
+    this.use(RouterController).traverse('onFileAdd');
   };
 
   private _handleCancel = (): void => {
-    this.bag.router.traverse('onCancel');
+    this.use(RouterController).traverse('onCancel');
   };
 
   private _handleSelectAll = (): void => {
@@ -278,7 +290,9 @@ export class ExternalSource extends ChildBlock {
 
     this._messageBridge?.destroy();
 
-    this._messageBridge = new MessageBridge(iframe.contentWindow, () => this.uploader.config.get('socialBaseUrl'));
+    this._messageBridge = new MessageBridge(iframe.contentWindow, () =>
+      this.use(ConfigController).get('socialBaseUrl'),
+    );
     this._messageBridge.on('selected-files-change', this._handleSelectedFilesChange.bind(this));
     this._messageBridge.on('toolbar-state-change', this._handleToolbarStateChange.bind(this));
 
@@ -318,7 +332,7 @@ export class ExternalSource extends ChildBlock {
         <button
           type="button"
           class="uc-mini-btn uc-close-btn"
-          @click=${() => this.bag.router.traverse('onClose')}
+          @click=${() => this.use(RouterController).traverse('onClose')}
           title=${this.l10n('a11y-activity-header-button-close')}
           aria-label=${this.l10n('a11y-activity-header-button-close')}
         >

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -1,0 +1,115 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { FileItem } from './FileItem';
+
+// Idempotent (same path as defineComponents(UC)).
+FileItem.reg('uc-file-item');
+
+// Narrow test-only accessor for the private IntersectionObserver render gate:
+// happy-dom never fires `isIntersecting`, so `_pauseRender` stays true and the
+// element never renders. Flipping it directly (it is a `@state`, so the write
+// triggers an update) opens the gate the same way an on-screen file item would.
+type RenderGate = { _pauseRender: boolean };
+const openRenderGate = async (el: FileItem): Promise<void> => {
+  (el as unknown as RenderGate)._pauseRender = false;
+  await el.updateComplete;
+  await delay(0);
+};
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `file-item-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: FileItem; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-file-item') as FileItem;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const fileNameHidden = (el: FileItem): boolean =>
+  (el.querySelector('.uc-file-name') as HTMLElement | null)?.hasAttribute('hidden') ?? true;
+
+describe('FileItem (M-god step 6b-6 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(FileItem.uses).toEqual([ConfigController, TelemetryManager]);
+  });
+
+  it('pre-warms its declared dependencies into the container on adoption', async () => {
+    const ctxName = freshCtxName();
+    await mount(ctxName);
+    const container = PubSub.getContainer(ctxName);
+    // `static uses` pre-warm resolves both deps eagerly on adoption, so they
+    // exist (as the container's own singletons) before first render.
+    expect(container?.get(ConfigController)).toBeInstanceOf(ConfigController);
+    expect(container?.get(TelemetryManager)).toBeInstanceOf(TelemetryManager);
+  });
+
+  it('reflects the config filesViewMode onto the host [mode] attribute and reacts to changes', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    // Default config is list mode — the imperative subConfigValue side-effect sets
+    // the host attribute eagerly on adoption (independent of the render gate).
+    expect(el.getAttribute('mode')).toBe('list');
+
+    config.set('filesViewMode', 'grid');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.getAttribute('mode')).toBe('grid');
+
+    config.set('filesViewMode', 'list');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.getAttribute('mode')).toBe('list');
+  });
+
+  it('shows file names reactively via the tracked _showFileNames getter (no @state / subConfigValue mirror)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    await openRenderGate(el);
+
+    // List mode always shows names.
+    expect(fileNameHidden(el)).toBe(false);
+
+    // Grid mode without gridShowFileNames hides them — a tracked config read in
+    // render() re-renders the item with no imperative subscription.
+    config.set('filesViewMode', 'grid');
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameHidden(el)).toBe(true);
+
+    // Toggling gridShowFileNames in grid mode re-renders too (the getter reads
+    // that key via getTracked, so it is auto-tracked).
+    config.set('gridShowFileNames', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameHidden(el)).toBe(false);
+
+    config.set('gridShowFileNames', false);
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameHidden(el)).toBe(true);
+  });
+});

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -1,8 +1,10 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import type { PluginController, PluginFileActionRegistration } from '../../abstract/managers/plugin';
 import type { Owned } from '../../abstract/managers/plugin/PluginTypes';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import type { UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
 import { debounce } from '../../utils/debounce';
 import { throttle } from '../../utils/throttle';
@@ -29,6 +31,8 @@ const FileItemState = Object.freeze({
 type FileItemStateValue = (typeof FileItemState)[keyof typeof FileItemState];
 
 export class FileItem extends FileItemConfig {
+  public static override readonly uses = [ConfigController, TelemetryManager] as const;
+
   @state()
   private _pauseRender = true;
 
@@ -71,9 +75,6 @@ export class FileItem extends FileItemConfig {
   private _isFocused = false;
 
   @state()
-  private _showFileNames = false;
-
-  @state()
   private _ariaLabelStatusFile = '';
 
   @state()
@@ -84,7 +85,7 @@ export class FileItem extends FileItemConfig {
   private _pluginManager: PluginController | null = null;
 
   private _handleRemove = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       payload: {
         metadata: {
           event: 'remove-file',
@@ -93,6 +94,9 @@ export class FileItem extends FileItemConfig {
       },
     });
 
+    // `uploadCollection` is registered by the upload stack, not eagerly in the
+    // container — no clean DI token to `use()`, so this stays on the null-safe
+    // v1 `bag` path (step 8).
     const collection = this.bag.uploadCollectionOrNull;
     if (this.uid && collection?.hasItem(this.uid)) {
       this.entry?.getValue('abortController')?.abort();
@@ -256,14 +260,17 @@ export class FileItem extends FileItemConfig {
     this._updatePluginFileActions();
   }
 
-  private _updateShowFileNames(value: boolean): void {
-    const isListMode = this.uploader.config.get('filesViewMode') === 'list';
-    if (isListMode) {
-      this._showFileNames = true;
-      return;
-    }
-
-    this._showFileNames = value;
+  /**
+   * Whether file names are shown: always in list mode, otherwise driven by
+   * `gridShowFileNames`. Tracked getter (drops the v1 `@state _showFileNames`,
+   * `_updateShowFileNames`, and the `subConfigValue('gridShowFileNames')` mirror):
+   * reading both keys via `getTracked` in `render()` auto-tracks them under
+   * `SignalWatcher`, so a config change re-renders — same reactivity as the v1
+   * subscription.
+   */
+  private get _showFileNames(): boolean {
+    const config = this.use(ConfigController);
+    return config.getTracked('filesViewMode') === 'list' ? true : config.getTracked('gridShowFileNames');
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {
@@ -321,7 +328,7 @@ export class FileItem extends FileItemConfig {
       return;
     }
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       payload: {
         metadata: {
           event: action.id,
@@ -341,14 +348,17 @@ export class FileItem extends FileItemConfig {
   protected override controllerReady(): void {
     this._handleEntryId(this.uid);
 
+    // Host `[mode]` attribute: the `uc-file-item[mode="grid"]` CSS selectors key
+    // off the host attr, driving the grid/list box sizing. Kept as an imperative
+    // `subConfigValue` side-effect (repointed to a `filesViewMode`-only read)
+    // rather than the 6b-3 `willUpdate`+`getTracked` host-attr recipe: this block
+    // gates rendering behind `_pauseRender` (an IntersectionObserver lazy-render
+    // gate), so a `willUpdate` host-attr write would not run until the item
+    // scrolls into view — whereas v1 sets `mode` eagerly on adoption so the box
+    // sizing is correct before first paint. `_showFileNames` (a pure render read)
+    // moved to a tracked getter; only this host side-effect remains here.
     this.subConfigValue('filesViewMode', (mode) => {
-      this._updateShowFileNames(this.uploader.config.get('gridShowFileNames'));
-
       this.setAttribute('mode', mode);
-    });
-
-    this.subConfigValue('gridShowFileNames', (value) => {
-      this._updateShowFileNames(value);
     });
 
     this.onclick = () => {
@@ -361,6 +371,10 @@ export class FileItem extends FileItemConfig {
       });
     };
 
+    // Side-effecting subscription (fires `_upload`, not a render read): stays on
+    // the v1 `bag.ctx.sub` path even though `CollectionStateController` owns
+    // `*uploadTrigger` — that token is adopted only for pure render reads (see
+    // ProgressBarCommon/DynamicBtn), not for imperative triggers.
     this.trackSub(
       this.bag.ctx.sub('*uploadTrigger', (itemsToUpload) => {
         if (this.entry && !itemsToUpload.has(this.entry.uid)) {
@@ -370,6 +384,8 @@ export class FileItem extends FileItemConfig {
       }),
     );
 
+    // The plugin manager has no DI token — it stays on the v1 `bag.when` path
+    // (step 8); a plugin change re-derives file actions imperatively.
     this.trackSub(
       this.bag.when('pluginManager', (pm) => {
         this._pluginManager = pm;

--- a/src/blocks/FormInput/FormInput.test.ts
+++ b/src/blocks/FormInput/FormInput.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import type { OutputCollectionState } from '../../types/index';
+import { delay } from '../../utils/delay';
+import { FormInput } from './FormInput';
+
+// Idempotent (same path as defineComponents(UC)).
+FormInput.reg('uc-form-input');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `form-input-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+  attrs: Record<string, string> = {},
+): Promise<{ el: FormInput; config: ConfigController; collection: CollectionStateController }> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const config = container?.get(ConfigController);
+  const collection = container?.get(CollectionStateController);
+  if (!config || !collection) throw new Error('controllers not resolved');
+  const el = document.createElement('uc-form-input') as FormInput;
+  el.setAttribute('ctx-name', ctxName);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config, collection };
+};
+
+// Minimal mock of the large `OutputCollectionState` discriminated union — only
+// the fields FormInput reads (`status`/`errors`/`group`/`allEntries`) matter.
+type TestState = {
+  status: OutputCollectionState['status'];
+  errors: { message?: string }[];
+  group: { cdnUrl?: string } | null;
+  allEntries: { cdnUrl?: string }[];
+};
+
+const setState = async (el: FormInput, collection: CollectionStateController, state: TestState): Promise<void> => {
+  collection.set('collectionState', state as unknown as OutputCollectionState);
+  await el.updateComplete;
+  await delay(0);
+};
+
+const validationInput = (el: FormInput): HTMLInputElement | null => el.querySelector('input[type="text"]');
+const hiddenInputs = (el: FormInput): HTMLInputElement[] =>
+  Array.from(el.querySelectorAll<HTMLInputElement>('input[type="hidden"]'));
+
+describe('FormInput (M-god step 6b-4 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(FormInput.uses).toEqual([ConfigController, CollectionStateController]);
+  });
+
+  it('creates the validation input on ready, reflecting multipleMin via ConfigController', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    PubSub.getContainer(ctxName)!.get(ConfigController).set('multipleMin', 2);
+    const { el } = await mount(ctxName);
+    const input = validationInput(el);
+    expect(input).not.toBeNull();
+    expect(input?.required).toBe(true);
+    expect(input?.name).toBe(ctxName);
+  });
+
+  it('leaves the validation input optional when multipleMin is 0', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    expect(validationInput(el)?.required).toBe(false);
+  });
+
+  it('clears the value while uploading (reactive collectionState read, no ctx.sub)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collection } = await mount(ctxName);
+    await setState(el, collection, { status: 'uploading', errors: [], group: null, allEntries: [] });
+    const input = validationInput(el);
+    expect(input?.value).toBe('');
+    expect(hiddenInputs(el)).toHaveLength(0);
+  });
+
+  it('sets the validation message on a failed collection', async () => {
+    const ctxName = freshCtxName();
+    const { el, collection } = await mount(ctxName);
+    await setState(el, collection, {
+      status: 'failed',
+      errors: [{ message: 'boom' }],
+      group: null,
+      allEntries: [],
+    });
+    expect(validationInput(el)?.validationMessage).toBe('boom');
+  });
+
+  it('writes the single cdnUrl into the validation input when not multiple', async () => {
+    const ctxName = freshCtxName();
+    const { el, config, collection } = await mount(ctxName);
+    config.set('multiple', false);
+    await setState(el, collection, {
+      status: 'success',
+      errors: [],
+      group: null,
+      allEntries: [{ cdnUrl: 'https://cdn/one' }],
+    });
+    expect(validationInput(el)?.value).toBe('https://cdn/one');
+    expect(hiddenInputs(el)).toHaveLength(0);
+  });
+
+  it('regenerates hidden inputs[] when multiple and re-renders on a later collectionState change', async () => {
+    const ctxName = freshCtxName();
+    const { el, config, collection } = await mount(ctxName);
+    config.set('multiple', true);
+    await setState(el, collection, {
+      status: 'success',
+      errors: [],
+      group: null,
+      allEntries: [{ cdnUrl: 'https://cdn/a' }, { cdnUrl: 'https://cdn/b' }],
+    });
+    let hidden = hiddenInputs(el);
+    expect(hidden.map((i) => i.value)).toEqual(['https://cdn/a', 'https://cdn/b']);
+    expect(hidden.every((i) => i.name === `${ctxName}[]`)).toBe(true);
+    // The validation input is removed on the multi path so it isn't submitted.
+    expect(validationInput(el)).toBeNull();
+
+    // A new collection state re-runs the reactive rebuild.
+    await setState(el, collection, {
+      status: 'success',
+      errors: [],
+      group: null,
+      allEntries: [{ cdnUrl: 'https://cdn/c' }],
+    });
+    hidden = hiddenInputs(el);
+    expect(hidden.map((i) => i.value)).toEqual(['https://cdn/c']);
+  });
+
+  it('uses the group cdnUrl when the collection has a group', async () => {
+    const ctxName = freshCtxName();
+    const { el, collection } = await mount(ctxName);
+    await setState(el, collection, {
+      status: 'success',
+      errors: [],
+      group: { cdnUrl: 'https://cdn/group' },
+      allEntries: [{ cdnUrl: 'https://cdn/a' }],
+    });
+    expect(validationInput(el)?.value).toBe('https://cdn/group');
+  });
+});

--- a/src/blocks/FormInput/FormInput.ts
+++ b/src/blocks/FormInput/FormInput.ts
@@ -1,15 +1,25 @@
+import type { PropertyValues } from 'lit';
 import { property } from 'lit/decorators.js';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import type { OutputCollectionState } from '../../types/index';
 import { applyStyles } from '../../utils/applyStyles';
 
 export class FormInput extends ChildBlock {
+  public static override readonly uses = [ConfigController, CollectionStateController] as const;
+
   public declare attributesMeta: {
     'ctx-name': string;
     name?: string;
   };
   private _validationInputElement: HTMLInputElement | null = null;
   private _dynamicInputsContainer: HTMLDivElement | null = null;
+  // Dedup guard: the collection state is republished as a fresh object per change
+  // (`Object.is` differs), so this reproduces the v1 `bag.ctx.sub('*collectionState')`
+  // "rebuild only on an actual change" semantics now that the rebuild is driven by
+  // a re-render (which `willUpdate` also runs for unrelated updates, e.g. `ctx-name`).
+  private _lastSyncedState: OutputCollectionState | null = null;
 
   @property({ type: String, noAccessor: true, attribute: 'name' })
   public nameAttrValue?: string;
@@ -22,7 +32,7 @@ export class FormInput extends ChildBlock {
     const validationInput = document.createElement('input');
     validationInput.type = 'text';
     validationInput.name = this._inputName;
-    validationInput.required = this.uploader.config.get('multipleMin') > 0;
+    validationInput.required = this.use(ConfigController).get('multipleMin') > 0;
     validationInput.tabIndex = -1;
     applyStyles(validationInput, {
       opacity: 0,
@@ -34,82 +44,91 @@ export class FormInput extends ChildBlock {
 
   protected override controllerReady(): void {
     // `controllerReady` re-runs on controller re-adoption — guard the append
-    // so duplicate hidden inputs can't stack (same guard as the subscription
-    // callback below).
+    // so duplicate hidden inputs can't stack (same guard as `_syncFormInputs`).
     if (!this._validationInputElement) {
       this._validationInputElement = this._createValidationInput();
       this.appendChild(this._validationInputElement);
     }
+  }
 
-    this.trackSub(
-      this.bag.ctx.sub(
-        '*collectionState',
-        (collectionState: OutputCollectionState | null) => {
-          if (!collectionState) {
-            return;
-          }
-          if (!this._dynamicInputsContainer) {
-            const dynamicInputsContainer = document.createElement('div');
-            this.appendChild(dynamicInputsContainer);
-            this._dynamicInputsContainer = dynamicInputsContainer;
-          }
-          if (!this._validationInputElement) {
-            const input = this._createValidationInput();
-            this.appendChild(input);
-            this._validationInputElement = input;
-          }
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+    // Reactive collection-state read (replaces the v1
+    // `bag.ctx.sub('*collectionState', …, false)` subscription): `getTracked`
+    // auto-tracks under `SignalWatcher`, so a new collection state re-runs this
+    // update and rebuilds the hidden `<input>`(s). The `false` (no immediate
+    // fire) of the v1 sub is preserved by the initial `null` state falling
+    // through the early-return in `_syncFormInputs`.
+    this._syncFormInputs(this.use(CollectionStateController).getTracked('collectionState'));
+  }
 
-          this._dynamicInputsContainer.innerHTML = '';
+  private _syncFormInputs(collectionState: OutputCollectionState | null): void {
+    if (!collectionState) {
+      return;
+    }
+    if (Object.is(collectionState, this._lastSyncedState)) {
+      return;
+    }
+    this._lastSyncedState = collectionState;
 
-          if (collectionState.status === 'uploading' || collectionState.status === 'idle') {
-            this._validationInputElement.value = '';
-            this._validationInputElement.setCustomValidity('');
-            return;
-          }
+    if (!this._dynamicInputsContainer) {
+      const dynamicInputsContainer = document.createElement('div');
+      this.appendChild(dynamicInputsContainer);
+      this._dynamicInputsContainer = dynamicInputsContainer;
+    }
+    if (!this._validationInputElement) {
+      const input = this._createValidationInput();
+      this.appendChild(input);
+      this._validationInputElement = input;
+    }
 
-          if (collectionState.status === 'failed') {
-            const errorMsg = collectionState.errors[0]?.message;
-            this._validationInputElement.value = '';
-            this._validationInputElement.setCustomValidity(errorMsg ?? '');
-            return;
-          }
+    this._dynamicInputsContainer.innerHTML = '';
 
-          const group = collectionState.group ? collectionState.group : null;
-          if (group) {
-            this._validationInputElement.value = group.cdnUrl ?? '';
-            this._validationInputElement.setCustomValidity('');
-            return;
-          }
+    if (collectionState.status === 'uploading' || collectionState.status === 'idle') {
+      this._validationInputElement.value = '';
+      this._validationInputElement.setCustomValidity('');
+      return;
+    }
 
-          const cdnUrls = collectionState.allEntries
-            .map((entry) => entry.cdnUrl)
-            .filter((url): url is string => typeof url === 'string');
+    if (collectionState.status === 'failed') {
+      const errorMsg = collectionState.errors[0]?.message;
+      this._validationInputElement.value = '';
+      this._validationInputElement.setCustomValidity(errorMsg ?? '');
+      return;
+    }
 
-          if (!this.uploader.config.get('multiple') && cdnUrls.length === 1 && cdnUrls[0]) {
-            this._validationInputElement.value = cdnUrls[0];
-            this._validationInputElement.setCustomValidity('');
-            return;
-          }
+    const group = collectionState.group ? collectionState.group : null;
+    if (group) {
+      this._validationInputElement.value = group.cdnUrl ?? '';
+      this._validationInputElement.setCustomValidity('');
+      return;
+    }
 
-          // Remove validation input to prevent it from being submitted
-          this._validationInputElement.remove();
-          this._validationInputElement = null;
+    const cdnUrls = collectionState.allEntries
+      .map((entry) => entry.cdnUrl)
+      .filter((url): url is string => typeof url === 'string');
 
-          const fr = new DocumentFragment();
+    if (!this.use(ConfigController).get('multiple') && cdnUrls.length === 1 && cdnUrls[0]) {
+      this._validationInputElement.value = cdnUrls[0];
+      this._validationInputElement.setCustomValidity('');
+      return;
+    }
 
-          for (const value of cdnUrls) {
-            const input = document.createElement('input');
-            input.type = 'hidden';
-            input.name = `${this._inputName}[]`;
-            input.value = value;
-            fr.appendChild(input);
-          }
+    // Remove validation input to prevent it from being submitted
+    this._validationInputElement.remove();
+    this._validationInputElement = null;
 
-          this._dynamicInputsContainer.replaceChildren(fr);
-        },
-        false,
-      ),
-    );
+    const fr = new DocumentFragment();
+
+    for (const value of cdnUrls) {
+      const input = document.createElement('input');
+      input.type = 'hidden';
+      input.name = `${this._inputName}[]`;
+      input.value = value;
+      fr.appendChild(input);
+    }
+
+    this._dynamicInputsContainer.replaceChildren(fr);
   }
 }
 

--- a/src/blocks/Icon/Icon.test.ts
+++ b/src/blocks/Icon/Icon.test.ts
@@ -1,7 +1,10 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
+import type { PluginController } from '../../abstract/managers/plugin';
+import { PluginRegistry } from '../../abstract/managers/plugin/PluginRegistry';
 import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
 import { PubSub } from '../../lit/PubSubCompat';
+import type { SharedState } from '../../lit/SharedState';
 import type { IconHrefResolver } from '../../types/index';
 import { delay } from '../../utils/delay';
 import { Icon } from './Icon';
@@ -70,5 +73,47 @@ describe('Icon (M-god step 6b-2 migration)', () => {
     await el.updateComplete;
     await delay(0);
     expect(useHref(el)).toBe('#uc-icon-upload');
+  });
+
+  it('renders the empty-name early return (no sprite href) when name is unset', async () => {
+    const { el } = await mountWithConfig(freshCtxName(), '');
+    // The early-return branch (`!this.name`) still calls `renderIconSvg('')` —
+    // an empty href, not the `#uc-icon-<name>` sprite reference — and never
+    // touches `_pluginManager` at all.
+    expect(useHref(el)).toBe('');
+  });
+
+  it('renders a plugin-registered icon when the plugin manager snapshot has one for this name', async () => {
+    const ctxName = freshCtxName();
+    const ctx = ensureUploaderCtx(ctxName);
+
+    // A real `PluginRegistry` (rather than hand-typing `PluginRegistrySnapshot`)
+    // so the snapshot shape stays correct by construction; only `snapshot`/
+    // `onPluginsChange` are read by `Icon`, matching how `_pluginManager` is
+    // obtained via `bag.when('pluginManager', …)` — pre-registering the shared
+    // instance before mount makes `when` resolve it synchronously.
+    const registry = new PluginRegistry(() => {});
+    registry.addIcon('test-plugin', {
+      name: 'custom-icon',
+      svg: '<svg data-plugin-icon="true"><circle r="1"></circle></svg>',
+    });
+    const fakePluginManager: Pick<PluginController, 'snapshot' | 'onPluginsChange'> = {
+      snapshot: () => registry.snapshot(),
+      onPluginsChange: () => () => {},
+    };
+    ctx.add('*pluginManager', fakePluginManager as unknown as SharedState['*pluginManager'], true);
+
+    const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+    if (!config) throw new Error('config controller not resolved');
+    const el = document.createElement('uc-icon') as Icon;
+    el.setAttribute('ctx-name', ctxName);
+    el.name = 'custom-icon';
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    // Plugin icon takes precedence over the sprite href — no `<use>` element.
+    expect(el.querySelector('svg use')).toBeNull();
+    expect(el.querySelector('svg[data-plugin-icon]')).not.toBeNull();
   });
 });

--- a/src/blocks/Icon/Icon.test.ts
+++ b/src/blocks/Icon/Icon.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import type { IconHrefResolver } from '../../types/index';
+import { delay } from '../../utils/delay';
+import { Icon } from './Icon';
+
+// Idempotent (same path as defineComponents(UC)).
+Icon.reg('uc-icon');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `icon-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mountWithConfig = async (ctxName: string, name: string): Promise<{ el: Icon; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-icon') as Icon;
+  el.setAttribute('ctx-name', ctxName);
+  el.name = name;
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const useHref = (el: Icon): string | null | undefined => el.querySelector('svg use')?.getAttribute('href');
+
+describe('Icon (M-god step 6b-2 migration)', () => {
+  it('declares its dependency via static uses', () => {
+    expect(Icon.uses).toEqual([ConfigController]);
+  });
+
+  it('renders the default sprite href for a name with no custom resolver', async () => {
+    const { el } = await mountWithConfig(freshCtxName(), 'upload');
+    expect(useHref(el)).toBe('#uc-icon-upload');
+  });
+
+  it('re-renders the resolved href reactively when config.iconHrefResolver changes (getTracked, no subConfigValue)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mountWithConfig(ctxName, 'upload');
+    expect(useHref(el)).toBe('#uc-icon-upload');
+
+    // External config change — no imperative subscription on the block. The
+    // `iconHrefResolver` read in render() was tracked by SignalWatcher, so this
+    // re-renders with the resolver's href.
+    const resolver: IconHrefResolver = (name) => `https://cdn.example/${name}.svg`;
+    config.set('iconHrefResolver', resolver);
+    await el.updateComplete;
+    await delay(0);
+    expect(useHref(el)).toBe('https://cdn.example/upload.svg');
+
+    // And back to the default when the resolver is cleared — bidirectional.
+    config.set('iconHrefResolver', null);
+    await el.updateComplete;
+    await delay(0);
+    expect(useHref(el)).toBe('#uc-icon-upload');
+  });
+});

--- a/src/blocks/Icon/Icon.ts
+++ b/src/blocks/Icon/Icon.ts
@@ -1,25 +1,23 @@
-import { html, type PropertyValues } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { html } from 'lit';
+import { property } from 'lit/decorators.js';
 import { unsafeSVG } from 'lit/directives/unsafe-svg.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import type { PluginController } from '../../abstract/managers/plugin';
 import { ChildBlock } from '../../lit/ChildBlock';
-import type { IconHrefResolver } from '../../types/index';
 import { renderIconSvg } from './renderIconSvg';
 import './icon.css';
 
 export class Icon extends ChildBlock {
+  public static override readonly uses = [ConfigController] as const;
+
   @property({ type: String })
   public name = '';
 
-  @state()
-  private _resolvedHref = '';
-
-  @state()
-  private _pluginSvg: string | null = null;
-
-  private _iconHrefResolver: IconHrefResolver | null = null;
   // Transiently null until the shared PluginController registers (bag.when) —
-  // render falls back to the sprite href meanwhile.
+  // render falls back to the sprite href meanwhile. The plugin manager is NOT
+  // container-resolved (no DI token), so it stays on the v1 `bag` path (step 8);
+  // a plugin change re-renders via `requestUpdate` since its snapshot is not a
+  // signal.
   private _pluginManager: PluginController | null = null;
 
   public override connectedCallback(): void {
@@ -28,16 +26,11 @@ export class Icon extends ChildBlock {
   }
 
   protected override controllerReady(): void {
-    this.subConfigValue('iconHrefResolver', (resolver: IconHrefResolver | null) => {
-      this._iconHrefResolver = resolver;
-      this._updateResolvedHref();
-    });
-
     this.trackSub(
       this.bag.when('pluginManager', (pluginManager) => {
         this._pluginManager = pluginManager;
-        this.trackSub(pluginManager.onPluginsChange(() => this._updateResolvedHref()));
-        this._updateResolvedHref();
+        this.trackSub(pluginManager.onPluginsChange(() => this.requestUpdate()));
+        this.requestUpdate();
       }),
     );
   }
@@ -46,46 +39,22 @@ export class Icon extends ChildBlock {
     this._pluginManager = null;
   }
 
-  // Pre-adoption safety: unlike `willUpdate`-gated derivations, a `name` set
-  // before adoption is not lost here — `controllerReady`'s `subConfigValue`/
-  // `bag.when` subscriptions above both call `_updateResolvedHref()` when
-  // they first fire on adoption. If this restructures, keep one of those
-  // subscriptions calling it (or add an explicit re-derive here) so a
-  // pre-adoption `name` write still resolves.
-  protected override willUpdate(changedProperties: PropertyValues<this>): void {
-    super.willUpdate(changedProperties);
-    if (changedProperties.has('name')) {
-      this._updateResolvedHref();
-    }
-  }
-
-  private _updateResolvedHref(): void {
+  public override render() {
     if (!this.name) {
-      this._resolvedHref = '';
-      this._pluginSvg = null;
-      return;
+      return html` ${this.yield('', renderIconSvg(''))} `;
     }
 
     const pluginIcon = this._pluginManager?.snapshot().icons.find((icon) => icon.name === this.name);
-
     if (pluginIcon) {
-      this._pluginSvg = pluginIcon.svg;
-      this._resolvedHref = '';
-      return;
+      return html`${this.yield('', html`${unsafeSVG(pluginIcon.svg)}`)}`;
     }
 
-    this._pluginSvg = null;
-    const defaultHref = `#uc-icon-${this.name}`;
-    const customHref = this._iconHrefResolver?.(this.name);
-    this._resolvedHref = customHref ?? defaultHref;
-  }
-
-  public override render() {
-    if (this._pluginSvg) {
-      return html`${this.yield('', html`${unsafeSVG(this._pluginSvg)}`)}`;
-    }
-
-    return html` ${this.yield('', renderIconSvg(this._resolvedHref))} `;
+    // Tracked read: reading `iconHrefResolver` here auto-tracks it under
+    // `SignalWatcher`, so a later config `set()` re-renders — replacing the v1
+    // `subConfigValue('iconHrefResolver', …)` mirror that fed `_resolvedHref`.
+    const iconHrefResolver = this.use(ConfigController).getTracked('iconHrefResolver');
+    const href = iconHrefResolver?.(this.name) ?? `#uc-icon-${this.name}`;
+    return html` ${this.yield('', renderIconSvg(href))} `;
   }
 }
 

--- a/src/blocks/Modal/Modal.test.ts
+++ b/src/blocks/Modal/Modal.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { Modal } from './Modal';
+
+// Idempotent (same path as defineComponents(UC)).
+Modal.reg('uc-modal');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `modal-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+  id: string,
+): Promise<{ el: Modal; router: RouterController; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const router = container?.get(RouterController);
+  const config = container?.get(ConfigController);
+  if (!router || !config) throw new Error('controllers not resolved');
+  const el = document.createElement('uc-modal') as Modal;
+  el.id = id;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, router, config };
+};
+
+const dialogOf = (el: Modal): HTMLDialogElement | null => el.querySelector('dialog');
+
+describe('Modal (M-god step 6b-3 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(Modal.uses).toEqual([ConfigController, RouterController]);
+  });
+
+  it('opens/closes the <dialog> reactively when the router modal slot changes (no subRouter)', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName, 'camera');
+    const dialog = dialogOf(el);
+    expect(dialog).not.toBeNull();
+    // Nothing open yet: the router modal slot is null.
+    expect(dialog?.open).toBe(false);
+
+    // Router modal slot -> this modal's id. `router.modal` is a tracked signal,
+    // so willUpdate re-runs and show() opens the dialog. No imperative wiring.
+    router.openModal('camera');
+    await el.updateComplete;
+    await delay(0);
+    expect(dialog?.open).toBe(true);
+    expect(el.getAttribute('aria-modal')).toBe('true');
+
+    router.closeModal();
+    await el.updateComplete;
+    await delay(0);
+    expect(dialog?.open).toBe(false);
+    expect(el.getAttribute('aria-modal')).toBe('false');
+  });
+
+  it('does not open for a modal slot that is not this modal id', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName, 'camera');
+
+    router.openModal('upload-list');
+    await el.updateComplete;
+    await delay(0);
+    expect(dialogOf(el)?.open).toBe(false);
+  });
+
+  it('toggles the host [strokes] attribute reactively from the modalBackdropStrokes config (getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName, 'camera');
+    // Default modalBackdropStrokes is false -> host must not carry [strokes].
+    expect(el.hasAttribute('strokes')).toBe(false);
+
+    config.set('modalBackdropStrokes', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.hasAttribute('strokes')).toBe(true);
+
+    config.set('modalBackdropStrokes', false);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.hasAttribute('strokes')).toBe(false);
+  });
+});

--- a/src/blocks/Modal/Modal.ts
+++ b/src/blocks/Modal/Modal.ts
@@ -1,4 +1,6 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './modal.css';
 import { property } from 'lit/decorators.js';
@@ -8,6 +10,8 @@ import { getScrollLock } from '../../utils/scroll-lock';
 
 export class Modal extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-modal'];
+
+  public static override readonly uses = [ConfigController, RouterController] as const;
 
   private _mouseDownTarget: EventTarget | null | undefined;
 
@@ -34,7 +38,9 @@ export class Modal extends ChildBlock {
     // The native <dialog> "close" event is dispatched from a queued task and
     // can land after this block's ctx was torn down (deferred destroyCtx once
     // the last block disconnects) — there is no router to notify then, and
-    // nothing left to close.
+    // nothing left to close. Deliberately kept on the null-safe `bag.routerOrNull`
+    // rather than `use(RouterController)`: the latter throws once the container
+    // is released, exactly the post-teardown race this guard exists to absorb.
     const router = this.bag.routerOrNull;
     if (!router) {
       return;
@@ -96,39 +102,45 @@ export class Modal extends ChildBlock {
     }
   }
 
-  protected override controllerReady(): void {
-    this.subConfigValue('modalBackdropStrokes', (val: boolean) => {
-      if (val) {
-        this.setAttribute('strokes', '');
-      } else {
-        this.removeAttribute('strokes');
-      }
-    });
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+
+    // Host CSS attribute: `:where([uc-modal])[strokes] > dialog::backdrop` keys
+    // off `strokes` ON THE HOST, so drive it there from the tracked config
+    // signal (the Copyright `willUpdate` + `getTracked` recipe). Reading
+    // `modalBackdropStrokes` via `getTracked` auto-tracks under `SignalWatcher`,
+    // so a config change re-runs this update and re-toggles the attribute —
+    // matching the reactivity of the v1 `subConfigValue('modalBackdropStrokes')`
+    // it replaces. `strokes` is not a signal, so toggling it schedules no
+    // further update.
+    this.toggleAttribute('strokes', !!this.use(ConfigController).getTracked('modalBackdropStrokes'));
 
     // Show when the router's foreground modal slot is this modal's id; hide
-    // otherwise. The router emits `modal-open`/`modal-close` centrally. Uses
-    // `subRouter` (no effective-activity dedup) so a modal opening on the id
-    // that's already the background activity still shows.
+    // otherwise. `router.modal` is a tracked signal (M-god step 6b-3), so a
+    // modal-open/close transition re-runs this update and drives the imperative
+    // `<dialog>` side-effects below — replacing the v1 `subRouter` subscription
+    // with no effective-activity dedup (a modal opening on the id that's already
+    // the background activity still transitions the modal slot, so it still shows).
     //
     // The scroll lock follows *router* state, not dialog state — a native
     // Esc-close reaches here with the <dialog> already closed (so `hide()`
     // early-returns), and the lock must release regardless. The shared
     // refcount keeps the body locked across modal-to-modal swaps and across
-    // other uploader instances on the same page.
-    this.subRouter(() => {
-      const isForeground = this.bag.router.modal === (this.id as RegisteredActivityType);
-      if (isForeground && this.uploader.config.get('modalScrollLock')) {
-        this._releaseScrollLock ??= getScrollLock(document).acquire();
-      } else {
-        this._releaseScrollLock?.();
-        this._releaseScrollLock = null;
-      }
-      if (isForeground) {
-        this.show();
-      } else {
-        this.hide();
-      }
-    });
+    // other uploader instances on the same page. `modalScrollLock` is read
+    // untracked (v1 read it fresh inside the router callback, not as its own
+    // reactive trigger) — the router-slot signal is what re-runs this.
+    const isForeground = this.use(RouterController).modal === (this.id as RegisteredActivityType);
+    if (isForeground && this.use(ConfigController).get('modalScrollLock')) {
+      this._releaseScrollLock ??= getScrollLock(document).acquire();
+    } else {
+      this._releaseScrollLock?.();
+      this._releaseScrollLock = null;
+    }
+    if (isForeground) {
+      this.show();
+    } else {
+      this.hide();
+    }
   }
 
   public override disconnectedCallback(): void {

--- a/src/blocks/PluginActivityRenderer/PluginActivityRenderer.test.ts
+++ b/src/blocks/PluginActivityRenderer/PluginActivityRenderer.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { PluginActivityRenderer } from './PluginActivityRenderer';
+
+// Idempotent (same path as defineComponents(UC)).
+PluginActivityRenderer.reg('uc-plugin-activity-renderer');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `plugin-activity-renderer-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<PluginActivityRenderer> => {
+  ensureUploaderCtx(ctxName);
+  const el = document.createElement('uc-plugin-activity-renderer') as PluginActivityRenderer;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+describe('PluginActivityRenderer (M-god step 6b-2 migration)', () => {
+  it('declares no container dependencies — its only read (the plugin manager) has no DI token', () => {
+    // Documents the migration outcome: there is no config/activity/collection
+    // read to move onto use(); the plugin manager stays on the v1 `bag` path.
+    expect(PluginActivityRenderer.uses).toEqual([]);
+  });
+
+  it('renders an empty activity list when no plugin manager has registered', async () => {
+    const el = await mount(freshCtxName());
+    await delay(0);
+    expect(el.querySelector('uc-plugin-activity-host')).toBeNull();
+    expect(el.querySelector('uc-modal')).toBeNull();
+  });
+});

--- a/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
+++ b/src/blocks/PluginActivityRenderer/PluginActivityRenderer.ts
@@ -103,6 +103,9 @@ export class PluginActivityRenderer extends ChildBlock {
 
   // Transiently null until the shared PluginController registers (bag.when) —
   // render falls back to an empty activity list meanwhile (Icon/FileItem precedent).
+  // This is the block's ONLY external read: the plugin manager is NOT
+  // container-resolved (no DI token), so it stays on the v1 `bag` path — there is
+  // no config/activity/collection-state read here to move onto `use()` (step 8).
   private _pluginManager: PluginController | null = null;
 
   protected override controllerReady(): void {

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.test.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import type { ProgressBar } from '../ProgressBar/ProgressBar';
+import { ProgressBarCommon } from './ProgressBarCommon';
+
+// Idempotent (same path as defineComponents(UC)).
+ProgressBarCommon.reg('uc-progress-bar-common');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `progress-bar-common-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+): Promise<{ el: ProgressBarCommon; collectionState: CollectionStateController }> => {
+  ensureUploaderCtx(ctxName);
+  const collectionState = PubSub.getContainer(ctxName)?.get(CollectionStateController);
+  if (!collectionState) throw new Error('collection-state controller not resolved');
+  const el = document.createElement('uc-progress-bar-common') as ProgressBarCommon;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, collectionState };
+};
+
+const innerValue = (el: ProgressBarCommon): number | undefined =>
+  (el.querySelector('uc-progress-bar') as ProgressBar | null)?.value;
+
+describe('ProgressBarCommon (M-god step 6b-2 migration)', () => {
+  it('declares its dependency via static uses', () => {
+    expect(ProgressBarCommon.uses).toEqual([CollectionStateController]);
+  });
+
+  it('re-renders the inner progress-bar value reactively when commonProgress changes (getTracked, no ctx.sub)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collectionState } = await mount(ctxName);
+    expect(innerValue(el)).toBe(0);
+
+    // External collection-state change — no imperative `ctx.sub('*commonProgress')`
+    // on the block. The tracked `commonProgress` read in render() re-renders.
+    collectionState.set('commonProgress', 42);
+    await el.updateComplete;
+    await delay(0);
+    expect(innerValue(el)).toBe(42);
+
+    collectionState.set('commonProgress', 100);
+    await el.updateComplete;
+    await delay(0);
+    expect(innerValue(el)).toBe(100);
+  });
+});

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
@@ -1,30 +1,32 @@
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './progress-bar-common.css';
 
 import '../ProgressBar/ProgressBar';
 
 export class ProgressBarCommon extends ChildBlock {
+  public static override readonly uses = [CollectionStateController] as const;
+
   @state()
   private _visible = false;
 
-  @state()
-  private _value = 0;
+  // Tracked read: `commonProgress` (owned by `CollectionStateController`)
+  // auto-tracks under `SignalWatcher`, so a progress change re-renders —
+  // replacing the v1 `ctx.sub('*commonProgress')` subscription that mirrored it
+  // into a `_value` @state. No `init$`: `commonProgress` is seeded by the
+  // controller, not this block.
+  private get _value(): number {
+    return this.use(CollectionStateController).getTracked('commonProgress');
+  }
 
-  // No `init$` here: `*commonProgress` is a ctx-scope key seeded by v1
-  // uploader blocks (`UploaderController`/solution wiring), not by this
-  // block — `ChildBlock` has no `init$` seam to declare it in.
   protected override controllerReady(): void {
-    this.trackSub(
-      this.bag.ctx.sub('*commonProgress', (progress: number) => {
-        this._value = progress;
-      }),
-    );
-
     // The uploader-scope `*uploadCollection` instance may not have registered
     // yet when this block's controller adopts — go through `bag.when` rather
     // than the throwing `bag.uploadCollection` getter (DynamicBtn precedent).
+    // Kept on the v1 `bag` path: the registration race makes an eager
+    // `use(UploadCollectionController)` unsafe here (step 8).
     this.trackSub(
       this.bag.when('uploadCollection', (collection) => {
         this.trackSub(

--- a/src/blocks/SimpleBtn/SimpleBtn.test.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.test.ts
@@ -1,0 +1,73 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { SimpleBtn } from './SimpleBtn';
+
+// Idempotent (same path as defineComponents(UC)).
+SimpleBtn.reg('uc-simple-btn');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `simple-btn-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mountWithConfig = async (ctxName: string): Promise<{ el: SimpleBtn; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-simple-btn') as SimpleBtn;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+const buttonText = (el: SimpleBtn): string | null | undefined => el.querySelector('button span')?.textContent?.trim();
+
+describe('SimpleBtn (M-god step 6b-1 migration)', () => {
+  it('declares its dependency via static uses', () => {
+    expect(SimpleBtn.uses).toEqual([ConfigController]);
+  });
+
+  it('re-renders the button text reactively when config.multiple changes (getTracked, no subConfigValue)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mountWithConfig(ctxName);
+    config.set('multiple', true);
+    await el.updateComplete;
+    await delay(0);
+    const multiText = buttonText(el);
+    expect(multiText).toBeTruthy();
+
+    // External config change — no imperative subscription on the block.
+    // SignalWatcher tracked the `multiple` read during render(), so this
+    // re-renders with the single-file text key.
+    config.set('multiple', false);
+    await el.updateComplete;
+    await delay(0);
+    const singleText = buttonText(el);
+
+    expect(singleText).toBeTruthy();
+    expect(singleText).not.toBe(multiText);
+
+    // And back again — reactivity is bidirectional.
+    config.set('multiple', true);
+    await el.updateComplete;
+    await delay(0);
+    expect(buttonText(el)).toBe(multiText);
+  });
+});

--- a/src/blocks/SimpleBtn/SimpleBtn.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.ts
@@ -1,5 +1,6 @@
 import { html } from 'lit';
-import { property, state } from 'lit/decorators.js';
+import { property } from 'lit/decorators.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './simple-btn.css';
@@ -10,12 +11,13 @@ import '../Icon/Icon';
 export class SimpleBtn extends ChildBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-simple-btn'];
 
+  public static override readonly uses = [ConfigController] as const;
+
   @property({ attribute: 'dropzone', type: Boolean })
   public dropzone = true;
 
-  @state()
-  private _buttonTextKey = 'upload-file';
-
+  // `api` (UploaderPublicApi) is not container-resolved (it's set via
+  // UploaderController.setApi, has no DI token), so it stays on the v1 `bag`.
   private readonly _handleClick = () => {
     this.bag.api.initFlow();
   };
@@ -24,18 +26,13 @@ export class SimpleBtn extends ChildBlock {
     return [(listener: () => void) => ctrl.locale.subscribe(listener)];
   }
 
-  protected override controllerReady(): void {
-    this.subConfigValue('multiple', (val) => {
-      this._buttonTextKey = val ? 'upload-files' : 'upload-file';
-    });
-  }
-
   public override render() {
+    const buttonTextKey = this.use(ConfigController).getTracked('multiple') ? 'upload-files' : 'upload-file';
     return html`
     <uc-drop-area .disabled=${!this.dropzone}>
     <button type="button" @click=${this._handleClick}>
       <uc-icon name="upload"></uc-icon>
-      <span>${this.l10n(this._buttonTextKey)}</span>
+      <span>${this.l10n(buttonTextKey)}</span>
       ${this.yield('')}
       <div class="uc-visual-drop-area">${this.l10n('drop-files-here')}</div>
     </button>

--- a/src/blocks/SourceBtn/SourceBtn.test.ts
+++ b/src/blocks/SourceBtn/SourceBtn.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { SourceBtn } from './SourceBtn';
+
+// Idempotent (same path as defineComponents(UC)).
+SourceBtn.reg('uc-source-btn');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `source-btn-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<SourceBtn> => {
+  const el = document.createElement('uc-source-btn') as SourceBtn;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+describe('SourceBtn (M-god step 6b-1 migration)', () => {
+  it('declares its dependency via static uses (TelemetryManager only — not ConfigController)', () => {
+    expect(SourceBtn.uses).toEqual([TelemetryManager]);
+    // Guard against accidentally over-declaring: SourceBtn reads no config.
+    expect(SourceBtn.uses).not.toContain(ConfigController);
+  });
+
+  it('routes activate() telemetry through the container-resolved TelemetryManager (use())', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const container = PubSub.getContainer(ctxName);
+    expect(container).toBeDefined();
+    const telemetry = container?.get(TelemetryManager);
+    expect(telemetry).toBeDefined();
+    const spy = vi.spyOn(telemetry!, 'sendEvent').mockImplementation(() => {});
+
+    const el = await mount(ctxName);
+    el.source = { id: 'my-src', label: 'my-label-key', onClick: () => {} };
+    await el.updateComplete;
+
+    el.activate();
+
+    // The instance `use(TelemetryManager)` resolves is the same one the ctx's
+    // container owns — proving the bag→use() migration kept a single instance.
+    expect(spy).toHaveBeenCalledOnce();
+    expect(spy.mock.calls[0]?.[0]).toMatchObject({ payload: { sourceId: 'my-src' } });
+  });
+
+  it('activate() with no source set is a no-op (no telemetry, no crash)', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const telemetry = PubSub.getContainer(ctxName)!.get(TelemetryManager);
+    const spy = vi.spyOn(telemetry, 'sendEvent').mockImplementation(() => {});
+
+    const el = await mount(ctxName);
+    el.activate();
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/blocks/SourceBtn/SourceBtn.ts
+++ b/src/blocks/SourceBtn/SourceBtn.ts
@@ -1,6 +1,7 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { ChildBlock } from '../../lit/ChildBlock';
 import './source-btn.css';
 
@@ -15,6 +16,8 @@ export type SourceButtonConfig = {
 };
 
 export class SourceBtn extends ChildBlock {
+  public static override readonly uses = [TelemetryManager] as const;
+
   @property({ attribute: false })
   public source?: SourceButtonConfig;
 
@@ -64,7 +67,7 @@ export class SourceBtn extends ChildBlock {
   public activate(): void {
     if (!this.source) return;
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         sourceId: this.source.id,

--- a/src/blocks/SourceList/SourceList.test.ts
+++ b/src/blocks/SourceList/SourceList.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { SourceList } from './SourceList';
+
+// Idempotent (same path as defineComponents(UC)).
+SourceList.reg('uc-source-list');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `source-list-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: SourceList; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-source-list') as SourceList;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return { el, config };
+};
+
+describe('SourceList (M-god step 6b-3 migration)', () => {
+  it('declares its dependency via static uses', () => {
+    expect(SourceList.uses).toEqual([ConfigController]);
+  });
+
+  it('drives the host display style from the sourceListWrap config resolved via use(ConfigController)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+
+    // Default sourceListWrap is true -> no inline `display: contents`.
+    expect(el.style.display).toBe('');
+
+    config.set('sourceListWrap', false);
+    // `updated()` reads the value on the next render; force one and let it settle.
+    el.requestUpdate();
+    await el.updateComplete;
+    await delay(0);
+    expect(el.style.display).toBe('contents');
+
+    config.set('sourceListWrap', true);
+    el.requestUpdate();
+    await el.updateComplete;
+    await delay(0);
+    expect(el.style.display).toBe('');
+  });
+});

--- a/src/blocks/SourceList/SourceList.ts
+++ b/src/blocks/SourceList/SourceList.ts
@@ -2,12 +2,15 @@ import type { PropertyValues } from 'lit';
 import { html } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { SourceListController } from '../../abstract/controllers';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
 import type { SourceButtonConfig } from '../SourceBtn/SourceBtn';
 
 import '../SourceBtn/SourceBtn';
 import { ChildBlock } from '../../lit/ChildBlock';
 
 export class SourceList extends ChildBlock {
+  public static override readonly uses = [ConfigController] as const;
+
   @state()
   private _sources: SourceButtonConfig[] = [];
 
@@ -50,7 +53,11 @@ export class SourceList extends ChildBlock {
   protected override updated(changedProperties: PropertyValues<this>): void {
     super.updated(changedProperties);
 
-    if (this.uploader.config.get('sourceListWrap')) {
+    // Imperative `updated()` read (host inline-style side-effect) — `get()`, not
+    // the tracked `getTracked()`: v1 re-evaluated this only on re-render (driven
+    // by `_sources`), not as its own reactive trigger, so keep it untracked to
+    // preserve behavior exactly.
+    if (this.use(ConfigController).get('sourceListWrap')) {
       this.style.removeProperty('display');
     } else {
       this.style.display = 'contents';

--- a/src/blocks/Thumb/Thumb.test.ts
+++ b/src/blocks/Thumb/Thumb.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { delay } from '../../utils/delay';
+import { Thumb } from './Thumb';
+
+// Idempotent (same path as defineComponents(UC)).
+Thumb.reg('uc-thumb');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `thumb-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<{ el: Thumb; config: ConfigController }> => {
+  ensureUploaderCtx(ctxName);
+  const config = PubSub.getContainer(ctxName)?.get(ConfigController);
+  if (!config) throw new Error('config controller not resolved');
+  const el = document.createElement('uc-thumb') as Thumb;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config };
+};
+
+const badgeIconName = (el: Thumb): string | null => el.querySelector('.uc-badge uc-icon')?.getAttribute('name') ?? null;
+
+describe('Thumb (M-god step 6b-6 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(Thumb.uses).toEqual([ConfigController, TelemetryManager]);
+  });
+
+  it('pre-warms its declared dependencies into the container on adoption', async () => {
+    const ctxName = freshCtxName();
+    await mount(ctxName);
+    const container = PubSub.getContainer(ctxName);
+    expect(container?.get(ConfigController)).toBeInstanceOf(ConfigController);
+    expect(container?.get(TelemetryManager)).toBeInstanceOf(TelemetryManager);
+  });
+
+  it('adopts the controller (reading filesViewMode via use(ConfigController)) without throwing in grid mode', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    // Seed grid mode before mount so controllerReady's `_firstViewMode` init reads
+    // it through `use(ConfigController).get('filesViewMode')`.
+    PubSub.getContainer(ctxName)?.get(ConfigController).set('filesViewMode', 'grid');
+    const { el } = await mount(ctxName);
+    expect(el.isConnected).toBe(true);
+    expect(el.querySelector('.uc-thumb')).not.toBeNull();
+  });
+
+  it('renders the badge icon from the badgeIcon property', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    el.badgeIcon = 'badge-success';
+    await el.updateComplete;
+    await delay(0);
+    expect(badgeIconName(el)).toBe('badge-success');
+  });
+});

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -1,5 +1,7 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { createCdnUrl, createCdnUrlModifiers, createOriginalUrl } from '../../utils/cdn-utils';
 import { debounce } from '../../utils/debounce';
 import { preloadImage } from '../../utils/preloadImage';
@@ -23,6 +25,13 @@ type PendingThumbUpdate = {
 };
 
 export class Thumb extends FileItemConfig {
+  // All config/telemetry reads here are imperative side-effects of thumbnail
+  // generation (not render reads), so they use the untracked `use(...).get()` /
+  // `use(TelemetryManager)` path. The thumb image itself renders from the
+  // per-entry `thumbUrl` observer, which has no DI token and stays on the v1
+  // `bag`/`subEntry` path (step 8).
+  public static override readonly uses = [ConfigController, TelemetryManager] as const;
+
   @property({ type: String })
   public badgeIcon = '';
 
@@ -54,7 +63,7 @@ export class Thumb extends FileItemConfig {
     let size = Math.max(
       parseInt(String(this?._thumbRect?.height || 0), 10),
       parseInt(String(this?._thumbRect?.width || 0), 10),
-      this.uploader.config.get('thumbSize'),
+      this.use(ConfigController).get('thumbSize'),
     );
 
     if (window.devicePixelRatio > 1) {
@@ -76,7 +85,7 @@ export class Thumb extends FileItemConfig {
     if (fileInfo && isImage && uuid) {
       const thumbUrl = await this.proxyUrl(
         createCdnUrl(
-          createOriginalUrl(this.uploader.config.get('cdnCname'), uuid),
+          createOriginalUrl(this.use(ConfigController).get('cdnCname'), uuid),
           createCdnUrlModifiers(entry.getValue('cdnUrlModifiers'), `stretch/off`, `scale_crop/${size}x${size}/center`),
         ),
       );
@@ -100,7 +109,7 @@ export class Thumb extends FileItemConfig {
             const blobThumbUrl = await generateThumb(file, size);
             entry.setValue('thumbUrl', blobThumbUrl);
           } catch (err) {
-            this.bag.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
+            this.use(TelemetryManager).sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
             const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
             entry.setValue('thumbUrl', fileCssBg(color));
           }
@@ -119,7 +128,7 @@ export class Thumb extends FileItemConfig {
         const thumbUrl = await generateThumb(file, size);
         entry.setValue('thumbUrl', thumbUrl);
       } catch (err) {
-        this.bag.telemetryManager.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
+        this.use(TelemetryManager).sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
         const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
         entry.setValue('thumbUrl', fileCssBg(color));
       }
@@ -344,9 +353,12 @@ export class Thumb extends FileItemConfig {
     this._requestThumbGeneration(true);
   }
 
-  protected override controllerReady(ctrl: UploaderController): void {
-    this._firstViewMode ??= ctrl.config.get('filesViewMode');
+  protected override controllerReady(_ctrl: UploaderController): void {
+    this._firstViewMode ??= this.use(ConfigController).get('filesViewMode');
 
+    // Side-effecting subscription (forces a one-time thumb regeneration on the
+    // first list->grid switch so the higher grid resolution is fetched), not a
+    // render read — stays on the imperative `subConfigValue` path.
     this.subConfigValue('filesViewMode', (viewMode) => {
       if (viewMode === 'grid' && !this._renderedGridOnce) {
         if (this._firstViewMode === 'list') {

--- a/src/blocks/UploadList/UploadList.test.ts
+++ b/src/blocks/UploadList/UploadList.test.ts
@@ -1,0 +1,288 @@
+import type { UploadcareGroup } from '@uploadcare/upload-client';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import type { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import type { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import type { Uid } from '../../lit/Uid';
+import type { ConfigType, OutputCollectionState } from '../../types';
+import { delay } from '../../utils/delay';
+import { UploadList } from './UploadList';
+
+// Idempotent (same path as defineComponents(UC)).
+UploadList.reg('uc-upload-list');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `upload-list-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+// `UploadList.controllerReady` fires `_updateUploadsState` (via the leading-edge
+// throttled collection-update tick that `subConfigValue('multiple')` triggers
+// immediately), which reads `bag.api.getOutputCollectionState()`, and wires
+// `bag.when('uploadCollection')` observers. Both `api` and `uploadCollection`
+// have no DI token and are registered by the upload stack, absent in a bare ctx —
+// so seed minimal fakes so adoption completes and the imperative derived-state
+// path runs. The migrated reactive reads under test (uploadList /
+// collectionErrors / filesViewMode) don't touch these fakes.
+type ApiSpies = {
+  getOutputCollectionState: ReturnType<typeof vi.fn>;
+  uploadAll: ReturnType<typeof vi.fn>;
+  initFlow: ReturnType<typeof vi.fn>;
+  doneFlow: ReturnType<typeof vi.fn>;
+};
+
+const zeroCollectionState = (over: Partial<OutputCollectionState> = {}): OutputCollectionState =>
+  ({
+    totalCount: 0,
+    successCount: 0,
+    failedCount: 0,
+    uploadingCount: 0,
+    idleEntries: [],
+    allEntries: [],
+    errors: [],
+    group: null,
+    ...over,
+  }) as unknown as OutputCollectionState;
+
+const makeFakeApi = (state: OutputCollectionState): { api: UploaderPublicApi; spies: ApiSpies } => {
+  const spies: ApiSpies = {
+    getOutputCollectionState: vi.fn(() => state),
+    // The leading throttled tick auto-uploads when `confirmUpload` is off.
+    uploadAll: vi.fn(),
+    initFlow: vi.fn(),
+    doneFlow: vi.fn(),
+  };
+  return { api: spies as unknown as UploaderPublicApi, spies };
+};
+
+const makeFakeCollection = (): { collection: UploadCollectionController; clearAll: ReturnType<typeof vi.fn> } => {
+  const clearAll = vi.fn();
+  const noop = () => () => {};
+  const collection = {
+    clearAll,
+    size: 0,
+    observeProperties: noop,
+    observeCollection: noop,
+    hasItem: () => false,
+  } as unknown as UploadCollectionController;
+  return { collection, clearAll };
+};
+
+const mount = async (
+  ctxName: string,
+  opts: { state?: Partial<OutputCollectionState>; config?: Partial<ConfigType> } = {},
+): Promise<{
+  el: UploadList;
+  config: ConfigController;
+  collectionState: CollectionStateController;
+  router: RouterController;
+  telemetry: TelemetryManager;
+  spies: ApiSpies;
+  clearAll: ReturnType<typeof vi.fn>;
+}> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const ctx = PubSub.getCtx(ctxName);
+  const config = container?.get(ConfigController);
+  const collectionState = container?.get(CollectionStateController);
+  const router = container?.get(RouterController);
+  const telemetry = container?.get(TelemetryManager);
+  if (!container || !ctx || !config || !collectionState || !router || !telemetry)
+    throw new Error('controllers not resolved');
+  // Config must be applied before the element adopts (the leading throttled tick
+  // in `controllerReady` reads it), so set it up front.
+  for (const [k, v] of Object.entries(opts.config ?? {})) {
+    config.set(k as keyof ConfigType, v as ConfigType[keyof ConfigType]);
+  }
+  const { api, spies } = makeFakeApi(zeroCollectionState(opts.state));
+  const { collection, clearAll } = makeFakeCollection();
+  ctx.add('*publicApi', api, true);
+  ctx.add('*uploadCollection', collection, true);
+  const el = document.createElement('uc-upload-list') as UploadList;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config, collectionState, router, telemetry, spies, clearAll };
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+describe('UploadList (M-god step 6b-8 migration)', () => {
+  it('declares its dependencies via static uses (incl. the base RouterController)', () => {
+    expect(UploadList.uses).toEqual([ConfigController, CollectionStateController, RouterController, TelemetryManager]);
+  });
+
+  it('re-renders the <uc-file-item> list reactively when uploadList changes (getTracked, no ctx.sub)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collectionState } = await mount(ctxName);
+
+    expect(el.querySelectorAll('uc-file-item')).toHaveLength(0);
+
+    collectionState.set('uploadList', [{ uid: 'file-1' as Uid }, { uid: 'file-2' as Uid }]);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.querySelectorAll('uc-file-item')).toHaveLength(2);
+
+    collectionState.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.querySelectorAll('uc-file-item')).toHaveLength(1);
+
+    collectionState.set('uploadList', []);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.querySelectorAll('uc-file-item')).toHaveLength(0);
+  });
+
+  it('shows/hides the common-error row reactively from collectionErrors (tracked getter)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collectionState } = await mount(ctxName);
+    const errorRow = () => el.querySelector<HTMLElement>('.uc-common-error');
+
+    // No errors -> row hidden, no text.
+    expect(errorRow()?.hasAttribute('hidden')).toBe(true);
+    expect(errorRow()?.textContent?.trim()).toBe('');
+
+    collectionState.set('collectionErrors', [{ type: 'TOO_MANY_FILES', message: 'too many files' }]);
+    await el.updateComplete;
+    await delay(0);
+    expect(errorRow()?.hasAttribute('hidden')).toBe(false);
+    expect(errorRow()?.textContent?.trim()).toBe('too many files');
+
+    // Per-file marker errors are ignored — the row stays for real collection errors only.
+    collectionState.set('collectionErrors', [{ type: 'SOME_FILES_HAS_ERRORS', message: 'ignored' }]);
+    await el.updateComplete;
+    await delay(0);
+    expect(errorRow()?.hasAttribute('hidden')).toBe(true);
+    expect(errorRow()?.textContent?.trim()).toBe('');
+  });
+
+  it('drives the host [mode] attribute reactively from the filesViewMode config (willUpdate + getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+
+    // Default filesViewMode is 'list'.
+    expect(el.getAttribute('mode')).toBe('list');
+
+    config.set('filesViewMode', 'grid');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.getAttribute('mode')).toBe('grid');
+
+    config.set('filesViewMode', 'list');
+    await el.updateComplete;
+    await delay(0);
+    expect(el.getAttribute('mode')).toBe('list');
+  });
+
+  it('traverses onClose via the RouterController when the close button is clicked', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName);
+    const traverse = vi.spyOn(router, 'traverse');
+    const closeBtn = el.querySelector<HTMLButtonElement>('button.uc-close-btn');
+    expect(closeBtn).not.toBeNull();
+    closeBtn?.click();
+    expect(traverse).toHaveBeenCalledWith('onClose');
+  });
+
+  it('add-more sends an action telemetry event (use(TelemetryManager)) and calls api.initFlow(true)', async () => {
+    const ctxName = freshCtxName();
+    const { el, telemetry, spies } = await mount(ctxName);
+    const sendEvent = vi.spyOn(telemetry, 'sendEvent');
+    const addBtn = el.querySelector<HTMLButtonElement>('button.uc-add-more-btn');
+    expect(addBtn).not.toBeNull();
+    addBtn?.click();
+    expect(sendEvent).toHaveBeenCalledOnce();
+    expect(spies.initFlow).toHaveBeenCalledWith(true);
+  });
+
+  it('clear-all sends an action telemetry event and clears the upload collection', async () => {
+    const ctxName = freshCtxName();
+    const { el, telemetry, clearAll } = await mount(ctxName);
+    const sendEvent = vi.spyOn(telemetry, 'sendEvent');
+    el.querySelector<HTMLButtonElement>('button.uc-cancel-btn')?.click();
+    expect(sendEvent).toHaveBeenCalledOnce();
+    expect(clearAll).toHaveBeenCalledOnce();
+  });
+
+  it('shows the upload button + hides empty state for a ready-to-upload collection with confirmUpload (derived @state)', async () => {
+    const ctxName = freshCtxName();
+    const { el, spies } = await mount(ctxName, {
+      config: { confirmUpload: true },
+      state: { totalCount: 2 },
+    });
+
+    const uploadBtn = el.querySelector<HTMLButtonElement>('button.uc-upload-btn');
+    const doneBtn = el.querySelector<HTMLButtonElement>('button.uc-done-btn');
+    const emptyState = el.querySelector<HTMLElement>('.uc-no-files');
+    expect(uploadBtn?.hasAttribute('hidden')).toBe(false);
+    expect(doneBtn?.hasAttribute('hidden')).toBe(true);
+    expect(emptyState?.hasAttribute('hidden')).toBe(true);
+    // Header text derives from the summary and is localized (non-empty).
+    expect(el.querySelector('.uc-header-text')?.textContent?.trim()).not.toBe('');
+
+    uploadBtn?.click();
+    expect(spies.uploadAll).toHaveBeenCalled();
+  });
+
+  it('enables the done button for a fully-succeeded collection and calls doneFlow on click', async () => {
+    const ctxName = freshCtxName();
+    const { el, spies } = await mount(ctxName, {
+      state: { totalCount: 1, successCount: 1 },
+    });
+
+    const doneBtn = el.querySelector<HTMLButtonElement>('button.uc-done-btn');
+    expect(doneBtn?.hasAttribute('hidden')).toBe(false);
+    expect(doneBtn?.hasAttribute('disabled')).toBe(false);
+
+    doneBtn?.click();
+    expect(spies.getOutputCollectionState).toHaveBeenCalled();
+    expect(spies.doneFlow).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    ['uploading', { totalCount: 1, uploadingCount: 1 }],
+    ['failed', { totalCount: 1, failedCount: 1 }],
+    ['succeed', { totalCount: 1, successCount: 1 }],
+    ['total', { totalCount: 1 }],
+  ] as const)('derives a non-empty localized header for the %s state', async (_label, state) => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName, { state });
+    expect(el.querySelector('.uc-header-text')?.textContent?.trim()).not.toBe('');
+  });
+
+  it('registers a router guard that blocks entering an empty upload-list and reacts to group info', async () => {
+    const ctxName = freshCtxName();
+    const { el, router, collectionState } = await mount(ctxName);
+
+    // Guard predicate: empty collection (fake size 0) + default showEmptyList=false
+    // -> the router refuses to make upload-list the active activity.
+    router.setActivity('upload-list');
+    expect(router.activity).not.toBe('upload-list');
+
+    // The `*groupInfo` subscription re-runs the derived-state recompute; a
+    // truthy group must not throw.
+    collectionState.set('groupInfo', {} as unknown as UploadcareGroup);
+    await el.updateComplete;
+    await delay(0);
+    expect(el.isConnected).toBe(true);
+  });
+});

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -1,9 +1,12 @@
-import { html } from 'lit';
+import { html, type PropertyValues } from 'lit';
 import { state } from 'lit/decorators.js';
+import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import { ACTIVITY_TYPES } from '../../lit/activity-constants';
-import type { OutputCollectionErrorType, OutputError } from '../../types';
 import { throttle } from '../../utils/throttle';
 import { EventType, InternalEventType } from '../UploadCtxProvider/EventEmitter';
 import './upload-list.css';
@@ -25,6 +28,19 @@ export type Summary = {
 };
 
 export class UploadList extends ActivityChildBlock {
+  // Includes `RouterController` (the base `ActivityChildBlock` declares it for
+  // its `[active]` toggle) alongside the controllers this block reads directly:
+  // `ConfigController` (tracked `filesViewMode` host attr + imperative
+  // derived-state reads), `CollectionStateController` (tracked `uploadList` /
+  // `collectionErrors` render reads), `TelemetryManager` (add-more / clear-all
+  // action events).
+  public static override readonly uses = [
+    ConfigController,
+    CollectionStateController,
+    RouterController,
+    TelemetryManager,
+  ] as const;
+
   public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
 
   @state()
@@ -43,9 +59,6 @@ export class UploadList extends ActivityChildBlock {
   private _addMoreBtnEnabled = false;
 
   @state()
-  private _commonErrorMessage: string | null = null;
-
-  @state()
   private _hasFiles = false;
 
   @state()
@@ -58,8 +71,22 @@ export class UploadList extends ActivityChildBlock {
     return this._getHeaderText(this._latestSummary);
   }
 
+  /**
+   * Tracked getter: the common (collection-level) error message, derived from
+   * `collectionErrors` (owned by `CollectionStateController`). Reading it via
+   * `getTracked` in `render()` auto-tracks under `SignalWatcher`, so a
+   * collection-error change re-renders — replacing the v1
+   * `ctx.sub('*collectionErrors')` subscription that mirrored the first
+   * non-`SOME_FILES_HAS_ERRORS` error into a `_commonErrorMessage` @state.
+   */
+  private get _commonErrorMessage(): string | null {
+    const errors = this.use(CollectionStateController).getTracked('collectionErrors');
+    const firstError = errors.filter((err) => err.type !== 'SOME_FILES_HAS_ERRORS')[0];
+    return firstError?.message ?? null;
+  }
+
   private _handleAdd = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -68,22 +95,26 @@ export class UploadList extends ActivityChildBlock {
         },
       },
     });
+    // `api` (UploaderPublicApi) has no DI token (set via `UploaderController.setApi`),
+    // so it stays on the v1 `bag` path (step 8).
     this.bag.api.initFlow(true);
   };
 
   private _handleUpload = (): void => {
     this.emit(EventType.UPLOAD_CLICK);
+    // `api` has no DI token — stays on the v1 `bag` path (step 8).
     this.bag.api.uploadAll();
     this._throttledHandleCollectionUpdate();
   };
 
   private _handleDone = (): void => {
+    // `api` has no DI token — stays on the v1 `bag` path (step 8).
     this.emit(EventType.DONE_CLICK, this.bag.api.getOutputCollectionState());
     this.bag.api.doneFlow();
   };
 
   private _handleCancel = (): void => {
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -93,6 +124,8 @@ export class UploadList extends ActivityChildBlock {
       },
     });
 
+    // `uploadCollection` has no DI token (registration race) — stays on the v1
+    // `bag` path (step 8).
     this.bag.uploadCollection.clearAll();
   };
 
@@ -116,6 +149,13 @@ export class UploadList extends ActivityChildBlock {
   }, 300);
 
   private _updateUploadsState(): void {
+    // Imperative derived-state recompute (writes the toolbar/button `@state`
+    // below), not a render read — runs only from the throttled tick after its
+    // `!uploader` guard, so the container is adopted and `use()` is safe. Config
+    // reads use the untracked `get()` (a re-render is driven by the throttled
+    // tick's `subConfigValue`/collection observers, not by tracking here);
+    // `api` has no DI token so `getOutputCollectionState` stays on `bag` (step 8).
+    const config = this.use(ConfigController);
     const collectionState = this.bag.api.getOutputCollectionState();
     const summary: Summary = {
       total: collectionState.totalCount,
@@ -128,8 +168,8 @@ export class UploadList extends ActivityChildBlock {
       (err) => err.type === 'TOO_MANY_FILES' || err.type === 'TOO_FEW_FILES',
     );
     const tooMany = collectionState.errors.some((err) => err.type === 'TOO_MANY_FILES');
-    const multiple = this.uploader.config.get('multiple');
-    const exact = collectionState.totalCount === (multiple ? this.uploader.config.get('multipleMax') : 1);
+    const multiple = config.get('multiple');
+    const exact = collectionState.totalCount === (multiple ? config.get('multipleMax') : 1);
     const isValidationPending = collectionState.allEntries.some((entry) => entry.isValidationPending);
     const validationOk = summary.failed === 0 && collectionState.errors.length === 0 && !isValidationPending;
     let uploadBtnVisible = false;
@@ -137,11 +177,11 @@ export class UploadList extends ActivityChildBlock {
     let doneBtnEnabled = false;
 
     const readyToUpload = summary.total - summary.succeed - summary.uploading - summary.failed;
-    if (readyToUpload > 0 && fitCountRestrictions && validationOk && this.uploader.config.get('confirmUpload')) {
+    if (readyToUpload > 0 && fitCountRestrictions && validationOk && config.get('confirmUpload')) {
       uploadBtnVisible = true;
     } else {
       allDone = true;
-      const groupOk = this.uploader.config.get('groupOutput') ? !!collectionState.group : true;
+      const groupOk = config.get('groupOutput') ? !!collectionState.group : true;
       doneBtnEnabled = summary.total === summary.succeed && fitCountRestrictions && validationOk && groupOk;
     }
 
@@ -190,8 +230,13 @@ export class UploadList extends ActivityChildBlock {
     // like the other subscriptions below so teardown is uniform (release-time,
     // not just disconnect) and the predicate itself reads the controller
     // non-throwingly so a teardown-time navigation can't warn spuriously.
+    // The guard registration goes through `use(RouterController)` (container is
+    // adopted by `controllerReady`), but the predicate keeps its null-tolerant
+    // `uploaderOrNull`/`bag.uploadCollectionOrNull` reads — it can fire during a
+    // teardown-time navigation, after the container is released, where `use()`
+    // would throw.
     this.trackSub(
-      this.bag.router.guard(
+      this.use(RouterController).guard(
         this.activityType,
         () =>
           (this.uploaderOrNull?.config.get('showEmptyList') ?? false) ||
@@ -199,6 +244,11 @@ export class UploadList extends ActivityChildBlock {
       ),
     );
 
+    // Imperative derived-state triggers (kept on the v1 `subConfigValue`/`ctx.sub`
+    // path, step 8): these don't feed `render()` directly — they re-run
+    // `_updateUploadsState` (which writes the toolbar/button `@state`) on a config
+    // or group change. A tracked read can't replace them because that recompute
+    // runs outside the `SignalWatcher` update cycle, so it wouldn't auto-track.
     this.subConfigValue('multiple', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMin', this._throttledHandleCollectionUpdate);
     this.subConfigValue('multipleMax', this._throttledHandleCollectionUpdate);
@@ -210,14 +260,6 @@ export class UploadList extends ActivityChildBlock {
       }),
     );
 
-    // Restores v1's next-tick item appearance: re-render as soon as the list
-    // changes instead of waiting for the throttled derived-state tick below.
-    this.trackSub(this.bag.ctx.sub('*uploadList', () => this.requestUpdate()));
-
-    this.subConfigValue('filesViewMode', (mode: FilesViewMode) => {
-      this.setAttribute('mode', mode);
-    });
-
     // TODO: could be performance issue on many files
     // there is no need to update buttons state on every progress tick
     //
@@ -225,24 +267,30 @@ export class UploadList extends ActivityChildBlock {
     // yet when this block's controller adopts — go through `bag.when` rather
     // than the throwing `bag.uploadCollection` getter (FileItem/DynamicBtn
     // precedent), and track the observer unsubscribers so release/re-adoption
-    // can't stack duplicate observers.
+    // can't stack duplicate observers. `uploadCollection` has no DI token
+    // (registration race) so this stays on the v1 `bag` path (step 8).
     this.trackSub(
       this.bag.when('uploadCollection', (collection) => {
         this.trackSub(collection.observeProperties(this._throttledHandleCollectionUpdate));
         this.trackSub(collection.observeCollection(this._throttledHandleCollectionUpdate));
       }),
     );
+  }
 
-    this.trackSub(
-      this.bag.ctx.sub('*collectionErrors', (errors: OutputError<OutputCollectionErrorType>[]) => {
-        const firstError = errors.filter((err) => err.type !== 'SOME_FILES_HAS_ERRORS')[0];
-        if (!firstError) {
-          this._commonErrorMessage = null;
-          return;
-        }
-        this._commonErrorMessage = firstError.message;
-      }),
-    );
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+    // Host CSS attribute: `uc-upload-list[mode="grid"]` keys off `mode` ON THE
+    // HOST (grid/list box sizing), so drive it there from the tracked config
+    // signal (the Modal/Copyright `willUpdate` + `getTracked` host-attr recipe).
+    // Reading `filesViewMode` via `getTracked` auto-tracks under `SignalWatcher`,
+    // so a config change re-runs this update and re-sets the attribute — matching
+    // the reactivity of the v1 `subConfigValue('filesViewMode')` it replaces.
+    // This block has no lazy-render gate (unlike FileItem's `_pauseRender`, which
+    // is why FileItem keeps its `mode` host attr imperative), so `willUpdate`
+    // runs on the first post-adoption render — before first paint, matching v1's
+    // eager `subConfigValue` fire. `mode` is not a reactive property, so setting
+    // it schedules no further update.
+    this.setAttribute('mode', this.use(ConfigController).getTracked('filesViewMode'));
   }
 
   protected override subscriptionsFor(ctrl: UploaderController) {
@@ -250,13 +298,19 @@ export class UploadList extends ActivityChildBlock {
   }
 
   public override render() {
+    // Tracked render reads: `uploadList` drives the `<uc-file-item>` list and
+    // `collectionErrors` (via `_commonErrorMessage`) drives the common-error row —
+    // both `getTracked` off `CollectionStateController`, auto-tracked under
+    // `SignalWatcher`, so a collection change re-renders with no `ctx.sub`.
+    const uploadList = this.use(CollectionStateController).getTracked('uploadList');
+    const commonErrorMessage = this._commonErrorMessage;
     return html`
   <uc-activity-header>
     <span aria-live="polite" class="uc-header-text">${this._headerText}</span>
     <button
       type="button"
       class="uc-mini-btn uc-close-btn"
-      @click=${() => this.bag.router.traverse('onClose')}
+      @click=${() => this.use(RouterController).traverse('onClose')}
       title=${this.l10n('a11y-activity-header-button-close')}
       aria-label=${this.l10n('a11y-activity-header-button-close')}
     >
@@ -271,7 +325,7 @@ export class UploadList extends ActivityChildBlock {
   <div class="uc-files">
     <div class="uc-files-wrapper">
     ${repeat(
-      this.bag.ctx.read('*uploadList') ?? [],
+      uploadList,
       ({ uid }) => uid,
       ({ uid }) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
     )}
@@ -288,9 +342,9 @@ export class UploadList extends ActivityChildBlock {
   </div>
 
   <div class="uc-common-error"
-  ?hidden=${!this._commonErrorMessage}
+  ?hidden=${!commonErrorMessage}
   >
-  ${this._commonErrorMessage ?? ''}
+  ${commonErrorMessage ?? ''}
   </div>
 
   <div class="uc-toolbar">

--- a/src/blocks/UrlSource/UrlSource.test.ts
+++ b/src/blocks/UrlSource/UrlSource.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RouterController } from '../../abstract/controllers/RouterController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import { PubSub } from '../../lit/PubSubCompat';
+import { UrlSource } from './UrlSource';
+
+// Idempotent (same path as defineComponents(UC)).
+UrlSource.reg('uc-url-source');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `url-source-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (ctxName: string): Promise<UrlSource> => {
+  const el = document.createElement('uc-url-source') as UrlSource;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+describe('UrlSource (M-god step 6b-1 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(UrlSource.uses).toEqual([TelemetryManager, RouterController]);
+  });
+
+  it('routes header back/close navigation through the container-resolved RouterController (use())', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const router = PubSub.getContainer(ctxName)!.get(RouterController);
+    const spy = vi.spyOn(router, 'traverse').mockImplementation(() => {});
+
+    const el = await mount(ctxName);
+    await el.updateComplete;
+
+    const backBtn = el.querySelector<HTMLButtonElement>('.uc-mini-btn:not(.uc-close-btn)');
+    const closeBtn = el.querySelector<HTMLButtonElement>('.uc-close-btn');
+    expect(backBtn).toBeTruthy();
+    expect(closeBtn).toBeTruthy();
+
+    backBtn!.click();
+    expect(spy).toHaveBeenCalledWith('onBack');
+
+    closeBtn!.click();
+    expect(spy).toHaveBeenCalledWith('onClose');
+  });
+});

--- a/src/blocks/UrlSource/UrlSource.ts
+++ b/src/blocks/UrlSource/UrlSource.ts
@@ -1,6 +1,8 @@
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
+import { RouterController } from '../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { ChildBlock } from '../../lit/ChildBlock';
 import { UploadSource } from '../../utils/UploadSource';
 import { InternalEventType } from '../UploadCtxProvider/EventEmitter';
@@ -10,6 +12,8 @@ import '../ActivityHeader/ActivityHeader';
 import '../Icon/Icon';
 
 export class UrlSource extends ChildBlock {
+  public static override readonly uses = [TelemetryManager, RouterController] as const;
+
   @state()
   private _url = '';
 
@@ -23,7 +27,7 @@ export class UrlSource extends ChildBlock {
 
   private _handleUpload = (event: Event) => {
     event.preventDefault();
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
@@ -36,8 +40,10 @@ export class UrlSource extends ChildBlock {
     if (!url) {
       return;
     }
+    // `api` (UploaderPublicApi) is not container-resolved (set via
+    // UploaderController.setApi, no DI token), so it stays on the v1 `bag`.
     this.bag.api.addFileFromUrl(url, { source: UploadSource.URL });
-    this.bag.router.traverse('onFileAdd');
+    this.use(RouterController).traverse('onFileAdd');
   };
 
   public override render() {
@@ -46,7 +52,7 @@ export class UrlSource extends ChildBlock {
         <button
           type="button"
           class="uc-mini-btn"
-          @click=${() => this.bag.router.traverse('onBack')}
+          @click=${() => this.use(RouterController).traverse('onBack')}
           title=${this.l10n('back')}
           aria-label=${this.l10n('back')}
         >
@@ -59,7 +65,7 @@ export class UrlSource extends ChildBlock {
         <button
           type="button"
           class="uc-mini-btn uc-close-btn"
-          @click=${() => this.bag.router.traverse('onClose')}
+          @click=${() => this.use(RouterController).traverse('onClose')}
           title=${this.l10n('a11y-activity-header-button-close')}
           aria-label=${this.l10n('a11y-activity-header-button-close')}
         >

--- a/src/lit/ActivityChildBlock.test.ts
+++ b/src/lit/ActivityChildBlock.test.ts
@@ -1,0 +1,217 @@
+import { html } from 'lit';
+import { afterEach, describe, expect, it } from 'vitest';
+import { RouterController } from '../abstract/controllers/RouterController';
+import { delay } from '../utils/delay';
+import { ActivityChildBlock } from './ActivityChildBlock';
+import { ACTIVITY_TYPES } from './activity-constants';
+import { PubSub } from './PubSubCompat';
+
+// ─── Test-only ActivityChildBlock subclasses ─────────────────────────────────
+// A background activity block (rendered inline, not inside `<uc-modal>`): its
+// `[active]` tracks the router's background `activity` slot.
+class BgActivityBlock extends ActivityChildBlock {
+  public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
+  public override render() {
+    return html``;
+  }
+}
+BgActivityBlock.reg('uc-test-bg-activity');
+
+// A foreground activity block (rendered inside `<uc-modal>`): its `[active]`
+// tracks the router's foreground `modal` slot.
+class ModalActivityBlock extends ActivityChildBlock {
+  public override activityType = ACTIVITY_TYPES.CAMERA;
+  public override render() {
+    return html``;
+  }
+}
+ModalActivityBlock.reg('uc-test-modal-activity');
+
+// A null-`activityType` host (e.g. a `PluginActivityHost` before its
+// registration arrives): the base wires the router subscription but skips all
+// activity-id-dependent work. Exposes the protected surface for direct probing.
+class NullActivityBlock extends ActivityChildBlock {
+  public override render() {
+    return html``;
+  }
+  public callReport(): void {
+    this.reportActivityMounted();
+  }
+  public get isActive(): boolean {
+    return this.isActivityActive;
+  }
+  public get params(): unknown {
+    return this.activityParams;
+  }
+}
+NullActivityBlock.reg('uc-test-null-activity');
+
+// ─── Harness ─────────────────────────────────────────────────────────────────
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `activity-childblock-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+const router = (ctxName: string): RouterController => {
+  const container = PubSub.getContainer(ctxName);
+  if (!container) throw new Error(`no container for ctx "${ctxName}"`);
+  return container.get(RouterController);
+};
+
+const flush = async (el: HTMLElement & { updateComplete: Promise<unknown> }): Promise<void> => {
+  await delay(0);
+  await el.updateComplete;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+describe('ActivityChildBlock [active] host attribute', () => {
+  it('toggles [active] on the host when the background activity slot matches, reactively both ways', async () => {
+    const ctxName = freshCtxName();
+    const el = document.createElement('uc-test-bg-activity') as BgActivityBlock & { updateComplete: Promise<unknown> };
+    el.setAttribute('ctx-name', ctxName);
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    // Base reflects its activity type onto the host — the `[activity="…"]` half
+    // of the CSS selectors (`[activity="camera"][active]`, …).
+    expect(el.getAttribute('activity')).toBe(ACTIVITY_TYPES.UPLOAD_LIST);
+    // Nothing navigated yet → not active.
+    expect(el.hasAttribute('active')).toBe(false);
+
+    // Background slot becomes this block's activity → [active] appears.
+    router(ctxName).setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(true);
+
+    // Background slot moves elsewhere → [active] clears (reactive, other way).
+    router(ctxName).setActivity(ACTIVITY_TYPES.START_FROM);
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(false);
+  });
+
+  it('toggles [active] off the router modal slot when nested inside <uc-modal>', async () => {
+    const ctxName = freshCtxName();
+    // `closest('uc-modal')` selects the foreground (modal) slot; the tag need
+    // not be an upgraded custom element for `closest` to match by name.
+    const modal = document.createElement('uc-modal');
+    const el = document.createElement('uc-test-modal-activity') as ModalActivityBlock & {
+      updateComplete: Promise<unknown>;
+    };
+    el.setAttribute('ctx-name', ctxName);
+    modal.append(el);
+    document.body.append(modal);
+    mounted.push(modal);
+    await el.updateComplete;
+
+    expect(el.hasAttribute('active')).toBe(false);
+
+    // Foreground modal slot opens on this block's activity → [active] appears,
+    // even though the background slot is untouched.
+    router(ctxName).openModal(ACTIVITY_TYPES.CAMERA);
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(true);
+
+    // Modal closes → [active] clears reactively.
+    router(ctxName).closeModal();
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(false);
+  });
+
+  it('does not gain [active] from a background transition while nested in a modal', async () => {
+    // A modal-slot block keys off `router.modal`, never the background slot: a
+    // background `setActivity` to its own type must NOT activate it.
+    const ctxName = freshCtxName();
+    const modal = document.createElement('uc-modal');
+    const el = document.createElement('uc-test-modal-activity') as ModalActivityBlock & {
+      updateComplete: Promise<unknown>;
+    };
+    el.setAttribute('ctx-name', ctxName);
+    modal.append(el);
+    document.body.append(modal);
+    mounted.push(modal);
+    await el.updateComplete;
+
+    router(ctxName).setActivity(ACTIVITY_TYPES.CAMERA);
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(false);
+  });
+
+  it('reports its activity as mounted with the router while connected', async () => {
+    const ctxName = freshCtxName();
+    const el = document.createElement('uc-test-bg-activity') as BgActivityBlock & { updateComplete: Promise<unknown> };
+    el.setAttribute('ctx-name', ctxName);
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    expect(router(ctxName).hasMountedActivity(ACTIVITY_TYPES.UPLOAD_LIST)).toBe(true);
+  });
+
+  it('keeps a pre-existing activity attribute instead of overwriting it', async () => {
+    const ctxName = freshCtxName();
+    const el = document.createElement('uc-test-bg-activity') as BgActivityBlock & { updateComplete: Promise<unknown> };
+    el.setAttribute('ctx-name', ctxName);
+    // Preset the attribute before adoption: the base must not clobber it.
+    el.setAttribute('activity', 'preset-value');
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    expect(el.getAttribute('activity')).toBe('preset-value');
+  });
+
+  it('exposes the router params via activityParams', async () => {
+    const ctxName = freshCtxName();
+    const el = document.createElement('uc-test-bg-activity') as BgActivityBlock & { updateComplete: Promise<unknown> };
+    el.setAttribute('ctx-name', ctxName);
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    router(ctxName).setActivity(ACTIVITY_TYPES.UPLOAD_LIST, { some: 'value' });
+    await flush(el);
+    expect(el.activityParams).toEqual({ some: 'value' });
+  });
+});
+
+describe('ActivityChildBlock with a null activityType', () => {
+  it('wires the router subscription but reports nothing and never activates', async () => {
+    const ctxName = freshCtxName();
+    const el = document.createElement('uc-test-null-activity') as NullActivityBlock & {
+      updateComplete: Promise<unknown>;
+    };
+    el.setAttribute('ctx-name', ctxName);
+    document.body.append(el);
+    mounted.push(el);
+    await el.updateComplete;
+
+    // No activity id → nothing reported, host never reflects `activity`/`active`.
+    expect(el.hasAttribute('activity')).toBe(false);
+    expect(el.hasAttribute('active')).toBe(false);
+    expect(el.isActive).toBe(false);
+    expect(router(ctxName).hasMountedActivity(ACTIVITY_TYPES.UPLOAD_LIST)).toBe(false);
+
+    // `reportActivityMounted()` is a no-op (after releasing any prior report)
+    // while `activityType` is null.
+    el.callReport();
+    expect(el.params).toEqual({});
+
+    // A router transition still re-renders it (subscription wired even for a
+    // null activityType) without ever toggling `[active]`.
+    router(ctxName).setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
+    await flush(el);
+    expect(el.hasAttribute('active')).toBe(false);
+  });
+});

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -1,6 +1,7 @@
 import type { PropertyValues } from 'lit';
 import { RouterController } from '../abstract/controllers/RouterController';
 import type { UploaderController } from '../abstract/controllers/UploaderController';
+import type { Token } from '../abstract/di/ControllerContainer';
 import { ACTIVITY_TYPES, type ActivityParamsMap, type ActivityType } from './activity-constants';
 import { ChildBlock } from './ChildBlock';
 
@@ -15,7 +16,13 @@ const ACTIVE_ATTR = 'active';
  * Subclasses overriding `controllerReady` MUST call `super.controllerReady(ctrl)`.
  */
 export class ActivityChildBlock extends ChildBlock {
-  public static override readonly uses = [RouterController] as const;
+  // Widened to the same `readonly Token<unknown>[]` shape `ChildBlock` declares
+  // (not a narrow `as const` tuple) so a subclass can override `uses` with its
+  // own controller set — e.g. `UploadList` adds Config/CollectionState/Telemetry
+  // (M-god step 6b-8). The value still pre-warms `RouterController` for every
+  // activity block (the base's `[active]` toggle reads it); a non-overriding
+  // subclass inherits exactly that, unchanged.
+  public static override readonly uses: readonly Token<unknown>[] = [RouterController];
 
   public activityType: ActivityType = null;
 

--- a/src/lit/ActivityChildBlock.ts
+++ b/src/lit/ActivityChildBlock.ts
@@ -1,4 +1,5 @@
 import type { PropertyValues } from 'lit';
+import { RouterController } from '../abstract/controllers/RouterController';
 import type { UploaderController } from '../abstract/controllers/UploaderController';
 import { ACTIVITY_TYPES, type ActivityParamsMap, type ActivityType } from './activity-constants';
 import { ChildBlock } from './ChildBlock';
@@ -14,6 +15,8 @@ const ACTIVE_ATTR = 'active';
  * Subclasses overriding `controllerReady` MUST call `super.controllerReady(ctrl)`.
  */
 export class ActivityChildBlock extends ChildBlock {
+  public static override readonly uses = [RouterController] as const;
+
   public activityType: ActivityType = null;
 
   public static activities = ACTIVITY_TYPES;
@@ -22,14 +25,26 @@ export class ActivityChildBlock extends ChildBlock {
   private _unreportActivityMounted?: () => void;
 
   protected override controllerReady(_ctrl: UploaderController): void {
-    // Wire the router subscription unconditionally, even when `activityType`
+    // Re-render on every router transition so `updated()` re-evaluates the
+    // `[active]` host attribute. Wired unconditionally, even when `activityType`
     // is still null at adoption time (e.g. a `PluginActivityHost` whose
     // `.registration` arrives later, in `updated()`). Otherwise a host that
     // starts with a null activityType and only later syncs a real one ends up
     // with no router subscription, so subsequent navigation never re-renders
     // it and its mounted content is never torn down. Harmless extra
     // re-renders for a null-activity host in the meantime.
-    this.subRouter(() => this.requestUpdate());
+    //
+    // Kept as a coarse `router.subscribe` (M-god step 6b-7) rather than a
+    // tracked signal read in `updated()`: the background-slot branch of
+    // `isActivityActive` reads `router.activity`, which is NOT signal-backed
+    // (only `router.modal`/`router.currentActivity` are), so a background
+    // transition — e.g. the background slot changing underneath an open modal —
+    // would not re-track and the toggle would go stale. The coarse subscription
+    // fires on every transition (both slots), preserving the exact re-render
+    // timing of the v1 `subRouter(() => this.requestUpdate())` this replaces.
+    const router = this.use(RouterController);
+    this.requestUpdate();
+    this.trackSub(router.subscribe(() => this.requestUpdate()));
     if (!this.activityType) {
       return;
     }
@@ -54,7 +69,7 @@ export class ActivityChildBlock extends ChildBlock {
     if (!this.activityType) {
       return;
     }
-    this._unreportActivityMounted = this.bag.router.activityBlockMounted(this.activityType);
+    this._unreportActivityMounted = this.use(RouterController).activityBlockMounted(this.activityType);
   }
 
   protected override controllerReleased(ctrl: UploaderController): void {
@@ -74,8 +89,12 @@ export class ActivityChildBlock extends ChildBlock {
     if (!this.activityType) {
       return false;
     }
-    const router = this.bag.router;
+    const router = this.use(RouterController);
     const isInModal = this.closest('uc-modal') !== null;
+    // `router.modal` is a tracked signal (read here under `SignalWatcher` when
+    // `updated()` calls in); `router.activity` is a plain field — the coarse
+    // subscription wired in `controllerReady` is what re-runs the update for a
+    // background-slot change (see the note there).
     const slot = isInModal ? router.modal : router.activity;
     return slot === this.activityType;
   }
@@ -88,6 +107,6 @@ export class ActivityChildBlock extends ChildBlock {
   }
 
   public get activityParams(): ActivityParamsMap[keyof ActivityParamsMap] {
-    return this.bag.router.params as ActivityParamsMap[keyof ActivityParamsMap];
+    return this.use(RouterController).params as ActivityParamsMap[keyof ActivityParamsMap];
   }
 }

--- a/src/lit/ChildBlock.test.ts
+++ b/src/lit/ChildBlock.test.ts
@@ -1,0 +1,173 @@
+import { html } from 'lit';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { ConfigController } from '../abstract/controllers/ConfigController';
+import type { Token } from '../abstract/di/ControllerContainer';
+import { ChildBlock } from './ChildBlock';
+import { PubSub } from './PubSubCompat';
+
+// ─── Test-only controllers (zero-arg ctors, container-constructable) ──────────
+class ProbeController {
+  public static instances = 0;
+  public constructor() {
+    ProbeController.instances++;
+  }
+}
+
+class ThrowingController {
+  public constructor() {
+    throw new Error('boom in ctor');
+  }
+}
+
+// ─── Test-only ChildBlock subclasses ──────────────────────────────────────────
+class UseBlock extends ChildBlock {
+  public callUse<T>(token: Token<T>): T {
+    return this.use(token);
+  }
+  public override render() {
+    return html``;
+  }
+}
+UseBlock.reg('uc-test-use-block');
+
+class PrewarmBlock extends ChildBlock {
+  public static override readonly uses = [ProbeController] as const;
+  public override render() {
+    return html``;
+  }
+}
+PrewarmBlock.reg('uc-test-prewarm-block');
+
+class ThrowingPrewarmBlock extends ChildBlock {
+  public static override readonly uses = [ThrowingController] as const;
+  public override render() {
+    return html``;
+  }
+}
+ThrowingPrewarmBlock.reg('uc-test-throwing-prewarm-block');
+
+// ─── Harness ──────────────────────────────────────────────────────────────────
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `childblock-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+const mount = async <T extends HTMLElement>(tag: string, ctxName: string): Promise<T> => {
+  const el = document.createElement(tag) as T & { updateComplete: Promise<unknown> };
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  return el;
+};
+
+// `setTimeout(0)` teardown deferral + a microtask margin.
+const flushTeardown = () => new Promise((r) => setTimeout(r, 10));
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+describe('ChildBlock.use()', () => {
+  it('throws when the container is not adopted yet', () => {
+    const el = document.createElement('uc-test-use-block') as UseBlock;
+    mounted.push(el);
+    expect(() => el.callUse(ConfigController)).toThrow(/container is not available/);
+  });
+
+  it('resolves a controller from the ctx container after adoption', async () => {
+    const ctxName = freshCtxName();
+    const el = await mount<UseBlock>('uc-test-use-block', ctxName);
+
+    const config = el.callUse(ConfigController);
+    expect(config).toBeInstanceOf(ConfigController);
+    // Same singleton the container owns for this ctx.
+    expect(config).toBe(PubSub.getContainer(ctxName)?.get(ConfigController));
+  });
+});
+
+describe('ChildBlock consumer lifecycle (M-god step 6a)', () => {
+  it('registers as a container consumer on adoption', async () => {
+    const ctxName = freshCtxName();
+    await mount<UseBlock>('uc-test-use-block', ctxName);
+
+    const container = PubSub.getContainer(ctxName);
+    expect(container).not.toBeNull();
+    expect(container?.isUnreferenced()).toBe(false);
+  });
+
+  it('drops the container consumer on disconnect', async () => {
+    const ctxName = freshCtxName();
+    const el = await mount<UseBlock>('uc-test-use-block', ctxName);
+    const container = PubSub.getContainer(ctxName);
+
+    el.remove(); // synchronous _releaseController → removeConsumer
+
+    // The captured container reports itself unreferenced (consumer dropped;
+    // dispose, when it fires, also clears the set).
+    expect(container?.isUnreferenced()).toBe(true);
+  });
+
+  it('tears the ctx down after the last consumer disconnects', async () => {
+    const ctxName = freshCtxName();
+    const el = await mount<UseBlock>('uc-test-use-block', ctxName);
+    expect(PubSub.hasCtx(ctxName)).toBe(true);
+
+    el.remove();
+    await flushTeardown();
+
+    expect(PubSub.hasCtx(ctxName)).toBe(false);
+    expect(PubSub.getContainer(ctxName)).toBeNull();
+  });
+
+  it('keeps the ctx alive while another consumer stays connected', async () => {
+    const ctxName = freshCtxName();
+    const a = await mount<UseBlock>('uc-test-use-block', ctxName);
+    const b = await mount<UseBlock>('uc-test-use-block', ctxName);
+    const container = PubSub.getContainer(ctxName);
+
+    a.remove();
+    await flushTeardown();
+
+    expect(PubSub.hasCtx(ctxName)).toBe(true);
+    expect(container?.isUnreferenced()).toBe(false);
+
+    b.remove();
+    await flushTeardown();
+
+    expect(PubSub.hasCtx(ctxName)).toBe(false);
+  });
+});
+
+describe('ChildBlock static uses pre-warm', () => {
+  it('resolves declared dependencies from the container on adoption', async () => {
+    const ctxName = freshCtxName();
+    const before = ProbeController.instances;
+
+    await mount('uc-test-prewarm-block', ctxName);
+
+    const container = PubSub.getContainer(ctxName);
+    expect(container?.has(ProbeController)).toBe(true);
+    expect(ProbeController.instances).toBe(before + 1);
+  });
+
+  it('isolates a throwing pre-warm: adoption still completes and the block renders', async () => {
+    const ctxName = freshCtxName();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const el = await mount('uc-test-throwing-prewarm-block', ctxName);
+
+    expect(el.isConnected).toBe(true);
+    expect(warn.mock.calls.some((c) => String(c[0]).includes('pre-warming a declared dependency'))).toBe(true);
+
+    warn.mockRestore();
+  });
+});

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -1,7 +1,9 @@
 import { ContextConsumer, ContextProvider } from '@lit/context';
+import { SignalWatcher } from '@lit-labs/signals';
 import { LitElement, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import type { UploaderController } from '../abstract/controllers/UploaderController';
+import type { ControllerContainer, Token } from '../abstract/di/ControllerContainer';
 import { resolveSecureDeliveryProxyUrl } from '../abstract/secureDeliveryProxyUrl';
 import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import type { EventEmitter } from '../blocks/UploadCtxProvider/EventEmitter';
@@ -19,7 +21,14 @@ import type { SharedState } from './SharedState';
 import { createSharedInstancesBag, type SharedInstancesBag } from './shared-instances';
 import { TestModeController } from './TestModeController';
 
-const ChildBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
+// `SignalWatcher` sits at the base of the mixin chain so it wraps
+// `performUpdate` (not `render()`): a fully-overridden `render()`/`shouldUpdate()`
+// in a leaf block still auto-tracks any `@lit-labs/signals` signal read during
+// its update, and re-renders when that signal changes. Non-migrated blocks read
+// state imperatively (`bag`/`subConfigValue`/`this.uploader.*`, none of which
+// touch a signal), so the watcher tracks nothing for them and their update cycle
+// is behavior-identical — it only adds a per-element watcher no signal notifies.
+const ChildBlockBase = SignalWatcher(RegisterableElementMixin(LightDomMixin(LitElement)));
 
 /**
  * Base class for blocks ported off `SymbioteCompatMixin` (M9). Resolves the
@@ -45,6 +54,18 @@ const ChildBlockBase = RegisterableElementMixin(LightDomMixin(LitElement));
 export abstract class ChildBlock extends ChildBlockBase {
   public static styleAttrs: string[] = [];
 
+  /**
+   * The container-owned controllers this block depends on. A migrated block
+   * declares them here (`static override readonly uses = [ConfigController] as
+   * const`) and reads them at render time via `this.use(Token)`. `uses` is
+   * documentation + pre-warm + drives nothing type-wise (`use()` is generically
+   * typed off its token argument, not off this list): on adoption every entry is
+   * eagerly resolved from this ctx's container so the dep exists before first
+   * render. Empty by default — non-migrated blocks still read via
+   * `bag`/`subConfigValue`/`this.uploader.*`.
+   */
+  public static readonly uses: readonly Token<unknown>[] = [];
+
   @property({ attribute: 'ctx-name' })
   public ctxName: string | undefined = undefined;
 
@@ -52,6 +73,10 @@ export abstract class ChildBlock extends ChildBlockBase {
   private _inheritedCtxName: string | undefined = undefined;
 
   private _controller: UploaderController | null = null;
+  // This ctx's DI container, adopted alongside the controller (`ctrl.container`).
+  // It is the resolution source for `use()` and the consumer-refcount anchor for
+  // teardown (`addConsumer`/`removeConsumer`/`isUnreferenced`).
+  private _container: ControllerContainer | null = null;
   private _watchedCtxName: string | undefined = undefined;
   private _registryUnsub?: () => void;
   private _subs: Array<() => void> = [];
@@ -96,6 +121,27 @@ export abstract class ChildBlock extends ChildBlockBase {
     return this._controller;
   }
 
+  /**
+   * Resolve a single-responsibility controller from this ctx's DI container —
+   * the v2 successor to reading off the monolithic `this.uploader`. Read it at
+   * render time (or in/after `controllerReady`); the render gate guarantees the
+   * container is adopted by then. Reading a `@signalState`/`SignalMap`-backed
+   * value off the returned controller (e.g. `ConfigController.getTracked`)
+   * inside `render()` auto-tracks it via `SignalWatcher`.
+   *
+   * Throws if the container isn't adopted yet (pre-adoption access is a bug,
+   * matching `this.uploader`'s guard).
+   */
+  protected use<T>(token: Token<T>): T {
+    if (!this._container) {
+      throw new Error(
+        `${this.tagName.toLowerCase()}: controller container is not available yet. ` +
+          'Call use() in render() or controllerReady(), not connectedCallback().',
+      );
+    }
+    return this._container.get(token);
+  }
+
   private _requireCtx(): PubSub<SharedState> {
     const ctxName = this.effectiveCtxName;
     const ctx = ctxName ? PubSub.getCtx<SharedState>(ctxName) : null;
@@ -109,6 +155,10 @@ export abstract class ChildBlock extends ChildBlockBase {
    * Shared v1 manager/controller instances for this ctx. Getters throw until
    * the instance registers — inside `controllerReady` prefer `bag.when(name,
    * cb)` (async-safe) over direct getters.
+   *
+   * @deprecated Transitional v1 compat. Migrated blocks resolve controllers via
+   * `this.use(Token)` and read reactive state through signals (e.g.
+   * `ConfigController.getTracked`). Removed once every block is migrated.
    */
   protected bag: SharedInstancesBag = createSharedInstancesBag(() => this._requireCtx());
 
@@ -302,6 +352,26 @@ export abstract class ChildBlock extends ChildBlockBase {
     if (this._controller === ctrl) return;
     this._releaseController();
     this._controller = ctrl;
+    // Anchor the consumer refcount on the container (M-god step 6a): this block
+    // now keeps its ctx alive by being a container consumer, not by holding a
+    // `UploaderRegistry.whenAvailable` subscription. `addConsumer`/`removeConsumer`
+    // run at adopt/release, which — because `whenAvailable` fires synchronously
+    // once `ensureUploaderCtx` has forced the controller into existence — is the
+    // same instant the registry subscription used to be the refcount, preserving
+    // exact teardown timing (`isCtxUnreferenced` now reads `container.isUnreferenced()`).
+    const container = ctrl.container;
+    this._container = container;
+    container.addConsumer(this);
+    // Pre-warm declared dependencies so they exist before first render. Isolate-
+    // and-warn: one dep's construction failure must not abort adoption (mirrors
+    // controllerReady / teardown / EventBus fan-out).
+    for (const token of (this.constructor as typeof ChildBlock).uses) {
+      try {
+        container.get(token);
+      } catch (err) {
+        console.warn(`[uc] ${this.tagName.toLowerCase()}: pre-warming a declared dependency threw`, err);
+      }
+    }
     const rerender = () => this.requestUpdate();
     for (const subscribe of this.subscriptionsFor(ctrl)) {
       this._subs.push(subscribe(rerender));
@@ -321,6 +391,7 @@ export abstract class ChildBlock extends ChildBlockBase {
 
   private _releaseController(): void {
     const ctrl = this._controller;
+    const container = this._container;
     for (const unsub of this._subs) {
       try {
         unsub();
@@ -335,6 +406,13 @@ export abstract class ChildBlock extends ChildBlockBase {
     }
     this._subs = [];
     this._controller = null;
+    // Drop the container refcount BEFORE the deferred teardown check fires: once
+    // the last consumer is gone `container.isUnreferenced()` reports the ctx dead
+    // and `_teardownCtxIfUnreferenced` disposes it (via `destroyCtx`). A disposed
+    // container has already cleared its consumer set, so a late `removeConsumer`
+    // here (e.g. a null-notify after teardown) is a harmless no-op.
+    container?.removeConsumer(this);
+    this._container = null;
     if (ctrl) this.controllerReleased(ctrl);
   }
 
@@ -372,7 +450,13 @@ export abstract class ChildBlock extends ChildBlockBase {
     });
   }
 
-  /** Track a subscription for auto-teardown on controller release / disconnect. */
+  /**
+   * Track a subscription for auto-teardown on controller release / disconnect.
+   *
+   * @deprecated Transitional v1 compat — a migrated block tracks reactive state
+   * with signals (`SignalWatcher` auto-tracks + auto-disposes), not manual
+   * subscriptions. Removed once every block is migrated.
+   */
   protected trackSub(unsub: () => void): void {
     this._subs.push(unsub);
   }
@@ -382,6 +466,10 @@ export abstract class ChildBlock extends ChildBlockBase {
    * then on every change of that key (`Object.is` dedup over the coarse
    * config notification). Same contract as v1 `LitBlock.subConfigValue`.
    * Call from `controllerReady` or later; auto-tracked.
+   *
+   * @deprecated Transitional v1 compat. A migrated block reads config
+   * reactively in `render()` via `this.use(ConfigController).getTracked(key)`,
+   * which `SignalWatcher` auto-tracks. Removed once every block is migrated.
    */
   protected subConfigValue<K extends keyof ConfigType>(key: K, callback: (value: ConfigType[K]) => void): () => void {
     const config = this.uploader.config;
@@ -402,6 +490,10 @@ export abstract class ChildBlock extends ChildBlockBase {
    * Subscribe to *any* router change. Fires immediately, then on every
    * notification — no value dedup. Auto-tracked. Call from `controllerReady`
    * or later (`bag.router` requires the ctx).
+   *
+   * @deprecated Transitional v1 compat — a migrated block reads router state
+   * reactively via signals under `SignalWatcher`. Removed once every block is
+   * migrated.
    */
   protected subRouter(callback: () => void): () => void {
     callback();
@@ -414,6 +506,10 @@ export abstract class ChildBlock extends ChildBlockBase {
    * Subscribe to the effective current activity (foreground modal, else
    * background). Fires immediately with the current value, then on change
    * (reference dedup). Auto-tracked.
+   *
+   * @deprecated Transitional v1 compat — a migrated block reads activity state
+   * reactively via signals under `SignalWatcher`. Removed once every block is
+   * migrated.
    */
   protected subActivity(callback: (activity: ActivityId | null) => void): () => void {
     const router = this.bag.router;

--- a/src/lit/PubSubCompat.ts
+++ b/src/lit/PubSubCompat.ts
@@ -396,6 +396,18 @@ export class PubSub<T extends Record<string, unknown>> {
     }
   }
 
+  /**
+   * The per-ctx `ControllerContainer` for `ctxId`, or `null` if none has been
+   * created yet (a ctx map can exist without a container — created by a bare
+   * `registerCtx` before any config/controller touch). Exposed for the
+   * consumer-refcount teardown predicate (`ctx-lifecycle.isCtxUnreferenced`),
+   * which routes through `container.isUnreferenced()` (M-god step 6a) — the
+   * container is the single owner of both the controllers and the consumer set.
+   */
+  public static getContainer(ctxId: string): ControllerContainer | null {
+    return PubSub._controllers.get(ctxId) ?? null;
+  }
+
   public static getCtx<T extends Record<string, unknown> = Record<string, unknown>>(ctxId: string): PubSub<T> | null {
     const store = PubSub._contexts.get(ctxId);
     if (!store) {

--- a/src/lit/ctx-lifecycle.test.ts
+++ b/src/lit/ctx-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import { destroyCtx, isCtxUnreferenced } from './ctx-lifecycle';
+import { ensureUploaderCtx } from './ensureUploaderCtx';
 import { PubSub } from './PubSubCompat';
 import type { SharedState } from './SharedState';
 
@@ -27,17 +27,34 @@ describe('isCtxUnreferenced', () => {
     expect(isCtxUnreferenced(ctxName)).toBe(true);
   });
 
-  it('is true when the ctx exists but there are no whenAvailable consumers', () => {
+  it('is true when the ctx exists as a bare map with no container', () => {
     const ctxName = freshCtxName();
+    // A raw `registerCtx` (no config/controller touch) has no ControllerContainer,
+    // so the predicate reports it unreferenced.
     PubSub.registerCtx<SharedState>({} as SharedState, ctxName);
+    expect(PubSub.getContainer(ctxName)).toBeNull();
     expect(isCtxUnreferenced(ctxName)).toBe(true);
   });
 
-  it('is false while a UploaderRegistry whenAvailable consumer is watching', () => {
+  it('is true when the ctx has a container but no consumers', () => {
     const ctxName = freshCtxName();
-    const off = UploaderRegistry.whenAvailable(ctxName, vi.fn());
+    ensureUploaderCtx(ctxName); // creates the per-ctx ControllerContainer
+    expect(PubSub.getContainer(ctxName)).not.toBeNull();
+    expect(isCtxUnreferenced(ctxName)).toBe(true);
+  });
+
+  it('is false while a container consumer is registered, true after it is removed (M-god step 6a)', () => {
+    // The refcount moved from UploaderRegistry.whenAvailable to the per-ctx
+    // ControllerContainer: a ChildBlock is a container consumer for the span of
+    // its controller adoption, and this predicate reads container.isUnreferenced().
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const container = PubSub.getContainer(ctxName);
+    expect(container).not.toBeNull();
+    const consumer = {};
+    container?.addConsumer(consumer);
     expect(isCtxUnreferenced(ctxName)).toBe(false);
-    off();
+    container?.removeConsumer(consumer);
     expect(isCtxUnreferenced(ctxName)).toBe(true);
   });
 });

--- a/src/lit/ctx-lifecycle.ts
+++ b/src/lit/ctx-lifecycle.ts
@@ -1,20 +1,30 @@
-import { UploaderRegistry } from '../abstract/UploaderRegistry';
 import { PubSub } from './PubSubCompat';
 import type { SharedState } from './SharedState';
 import { controllerOwnedInstanceKeys, type ISharedInstance } from './shared-instances';
 
 /**
  * Consumer-refcount teardown predicate: a ctx is dead — nothing left
- * referencing it — when no `ChildBlock` is still watching it via
- * `UploaderRegistry.whenAvailable` (`UploaderRegistry.hasConsumers`).
+ * referencing it — when its `ControllerContainer` has no consumers
+ * (`container.isUnreferenced()`). A ctx with no container at all (a bare
+ * `registerCtx` never touched by a controller/config) is likewise unreferenced.
+ *
+ * M-god step 6a retargeted this from `UploaderRegistry.hasConsumers` to the
+ * container: a `ChildBlock` now registers as a container consumer on controller
+ * adoption (`container.addConsumer`) and drops it on release, so the container
+ * is the single owner of both the controllers and the consumer set. Because
+ * `UploaderRegistry.whenAvailable` fires synchronously once `ensureUploaderCtx`
+ * has forced the controller into existence, adopt/release happen at the same
+ * instant the registry subscription used to be the refcount — teardown timing is
+ * preserved. (The v1 `*blocksRegistry` half was removed with the v1 element
+ * layer in M11 — no `LitBlock` populates it anymore.)
  *
  * `ChildBlock.disconnectedCallback` schedules a deferred (`setTimeout(0)`)
  * call to this predicate before running `destroyCtx`, so a still-connected
- * consumer keeps the ctx alive. (The v1 `*blocksRegistry` half was removed
- * with the v1 element layer in M11 — no `LitBlock` populates it anymore.)
+ * consumer keeps the ctx alive.
  */
 export function isCtxUnreferenced(ctxName: string): boolean {
-  return !UploaderRegistry.hasConsumers(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  return container ? container.isUnreferenced() : true;
 }
 
 /**

--- a/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { CollectionStateController } from '../../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../../abstract/controllers/ConfigController';
+import { RouterController } from '../../../abstract/controllers/RouterController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../../lit/ensureUploaderCtx';
+import { PubSub } from '../../../lit/PubSubCompat';
+import type { Uid } from '../../../lit/Uid';
+import { delay } from '../../../utils/delay';
+import { FileUploaderInline } from './FileUploaderInline';
+
+// Idempotent (same path as defineComponents(UC)).
+FileUploaderInline.reg('uc-file-uploader-inline');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `fu-inline-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+): Promise<{
+  el: FileUploaderInline;
+  config: ConfigController;
+  router: RouterController;
+  collection: CollectionStateController;
+}> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const config = container?.get(ConfigController);
+  const router = container?.get(RouterController);
+  const collection = container?.get(CollectionStateController);
+  if (!config || !router || !collection) throw new Error('controllers not resolved');
+  const el = document.createElement('uc-file-uploader-inline') as FileUploaderInline;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config, router, collection };
+};
+
+const settle = async (el: FileUploaderInline): Promise<void> => {
+  await el.updateComplete;
+  await delay(0);
+};
+
+const cancelBtn = (el: FileUploaderInline): HTMLButtonElement | null => el.querySelector('button.uc-cancel-btn');
+
+describe('FileUploaderInline (M-god step 6b-4 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(FileUploaderInline.uses).toEqual([
+      RouterController,
+      ConfigController,
+      CollectionStateController,
+      TelemetryManager,
+    ]);
+  });
+
+  it('routes every activity to the background slot', async () => {
+    const ctxName = freshCtxName();
+    const { router } = await mount(ctxName);
+    expect(router.navigationStrategy('start-from')).toBe('background');
+    expect(router.navigationStrategy('upload-list')).toBe('background');
+  });
+
+  it('hides the cancel button initially (empty list, no history to go back to)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+  });
+
+  it('reveals the cancel button reactively when showEmptyList flips on (config getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+
+    config.set('showEmptyList', true);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(false);
+
+    config.set('showEmptyList', false);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+  });
+
+  it('reveals the cancel button reactively when the upload list becomes non-empty (collectionState getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collection } = await mount(ctxName);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+
+    collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(false);
+
+    // Emptying the list again keeps the button visible: the non-empty list drove
+    // a navigation to `upload-list`, so history-back is now available (v1 parity —
+    // the v1 `*uploadList` sub was a no-op on the empty transition and retained
+    // the previously-computed visible state; the tracked read recomputes to the
+    // same result via `_couldHistoryBack`).
+    collection.set('uploadList', []);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(false);
+  });
+
+  it('hides the cancel button when the list empties with no back-history (guarded revalidate path)', async () => {
+    const ctxName = freshCtxName();
+    const { el, collection, router } = await mount(ctxName);
+    // Stay on start-from (no navigation), so there is no back-history; a list
+    // that grows then empties leaves the cancel button hidden.
+    collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    await settle(el);
+    // Force back to start-from so history has nothing below the top.
+    router.setActivity('start-from');
+    collection.set('uploadList', []);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+  });
+});

--- a/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
@@ -82,50 +82,81 @@ describe('FileUploaderInline (M-god step 6b-4 migration)', () => {
     expect(cancelBtn(el)?.hidden).toBe(true);
   });
 
-  it('reveals the cancel button reactively when showEmptyList flips on (config getTracked)', async () => {
+  it('recomputes cancel-button visibility for showEmptyList only on a router notify (v1 stale-by-design)', async () => {
     const ctxName = freshCtxName();
-    const { el, config } = await mount(ctxName);
+    const { el, config, router } = await mount(ctxName);
     expect(cancelBtn(el)?.hidden).toBe(true);
 
+    // v1 read `showEmptyList` imperatively INSIDE the `subRouter` recompute, not
+    // reactively in `render()`. So flipping the config alone does NOT re-show the
+    // button — `_couldCancel` (`@state`) is rewritten only on a router notify.
+    // Asserting the config flip is a no-op here locks in that stale-by-design v1
+    // semantics; do NOT "fix" this into a reactive tracked config read (that was
+    // the M-god step 6b-4 regression this test now guards against).
     config.set('showEmptyList', true);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(true);
+
+    // A router notify (a same-activity `setActivity`, which still notifies) runs
+    // the recompute, which now reads the true `showEmptyList` → button revealed.
+    router.setActivity('start-from');
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(false);
 
+    // Same asymmetry the other way: config flip is stale until the next notify.
     config.set('showEmptyList', false);
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(false);
+    router.setActivity('start-from');
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(true);
   });
 
-  it('reveals the cancel button reactively when the upload list becomes non-empty (collectionState getTracked)', async () => {
+  it('reveals the cancel button when the upload list becomes non-empty, and keeps it visible when it empties (router-notify driven, v1 parity)', async () => {
     const ctxName = freshCtxName();
     const { el, collection } = await mount(ctxName);
     expect(cancelBtn(el)?.hidden).toBe(true);
 
+    // A non-empty list drives a navigation to `upload-list` (the `*uploadList`
+    // sub), and THAT router notify runs the recompute (history-back is now
+    // available) → button visible. Visibility is router-notify driven, not a
+    // reactive read of the list.
     collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(false);
 
-    // Emptying the list again keeps the button visible: the non-empty list drove
-    // a navigation to `upload-list`, so history-back is now available (v1 parity —
-    // the v1 `*uploadList` sub was a no-op on the empty transition and retained
-    // the previously-computed visible state; the tracked read recomputes to the
-    // same result via `_couldHistoryBack`).
+    // Emptying the list again keeps the button visible (v1 parity): the empty
+    // transition is a no-op in the `*uploadList` sub (no `setActivity`), so no
+    // router notify fires and `_couldCancel` retains its previously-computed
+    // visible value — stale-by-design, exactly as v1's `subRouter`-only recompute.
     collection.set('uploadList', []);
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(false);
   });
 
-  it('hides the cancel button when the list empties with no back-history (guarded revalidate path)', async () => {
+  it('keeps the cancel button visible when the list empties after a forced start-from (v1 stale-by-design)', async () => {
     const ctxName = freshCtxName();
     const { el, collection, router } = await mount(ctxName);
-    // Stay on start-from (no navigation), so there is no back-history; a list
-    // that grows then empties leaves the cancel button hidden.
+    // A non-empty list navigates to `upload-list` (router notify → visible).
     collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
     await settle(el);
-    // Force back to start-from so history has nothing below the top.
+    expect(cancelBtn(el)?.hidden).toBe(false);
+    // Force back to start-from: this is the LAST router notify, and the list is
+    // still non-empty here, so the recompute leaves `_couldCancel` visible.
     router.setActivity('start-from');
+    await settle(el);
+    expect(cancelBtn(el)?.hidden).toBe(false);
+    // Now empty the list. The `*uploadList` sub is a no-op on the empty
+    // transition (no `setActivity`), so NO router notify fires and `_couldCancel`
+    // is NOT recomputed — it retains the previously-computed VISIBLE value.
+    //
+    // This is the exact v1 behavior the M-god step 6b-4 migration accidentally
+    // changed: it had made `_couldCancel` a reactive tracked read that re-hid the
+    // button here (flipping the inline `:has(.uc-cancel-btn[hidden])` layout).
+    // The migration contract is behavior-preservation — v1 keeps it visible, so
+    // we assert visible. A later, separate change may fix this genuine v1 quirk.
     collection.set('uploadList', []);
     await settle(el);
-    expect(cancelBtn(el)?.hidden).toBe(true);
+    expect(cancelBtn(el)?.hidden).toBe(false);
   });
 });

--- a/src/solutions/file-uploader/inline/FileUploaderInline.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.ts
@@ -1,4 +1,5 @@
 import { html } from 'lit';
+import { state } from 'lit/decorators.js';
 import { CollectionStateController } from '../../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../../abstract/controllers/ConfigController';
 import { RouterController } from '../../../abstract/controllers/RouterController';
@@ -37,6 +38,24 @@ export class FileUploaderInline extends SolutionChildBlock {
     TelemetryManager,
   ] as const;
 
+  /**
+   * Whether the cancel button shows — drives `.uc-cancel-btn[hidden]`, which the
+   * inline `:has(.uc-cancel-btn[hidden])` CSS keys off.
+   *
+   * Behavior-preservation (M-god step 6b-4 review): this is recomputed ONLY on a
+   * router notify (see the subscription in `controllerReady`), stored in `@state`
+   * — exactly as v1 did via `subRouter`. It is deliberately NOT a tracked render
+   * read of `uploadList`/`showEmptyList`: v1 read those imperatively inside the
+   * router-notify callback, so an upload-list change that does NOT coincide with
+   * a router transition (e.g. the list emptying without a `setActivity`) never
+   * refires the recompute and the previously-computed value is retained
+   * (stale-by-design). A tracked getter would re-hide the button on such a
+   * change and diverge from v1 (flipping the inline `:has(.uc-cancel-btn[hidden])`
+   * layout). Do not "re-fix" this into a reactive read.
+   */
+  @state()
+  private _couldCancel = false;
+
   private _handleCancel = (): void => {
     if (this._couldHistoryBack) {
       this.use(RouterController).traverse('onBack');
@@ -57,27 +76,13 @@ export class FileUploaderInline extends SolutionChildBlock {
   }
 
   private get _couldShowList(): boolean {
-    // Tracked reads: `uploadList` (CollectionStateController) + `showEmptyList`
-    // (ConfigController) auto-track under `SignalWatcher`, so the cancel button's
-    // `?hidden=` re-renders when either changes — replacing the v1 `subRouter`
-    // recompute (which only caught these via a coincident router change).
-    const uploadList = this.use(CollectionStateController).getTracked('uploadList');
-    return this.use(ConfigController).getTracked('showEmptyList') || uploadList.length > 0;
-  }
-
-  /**
-   * Whether the cancel button shows — drives `.uc-cancel-btn[hidden]`, which the
-   * inline `:has(.uc-cancel-btn[hidden])` CSS keys off. A tracked getter read in
-   * `render()` (drops the v1 `@state` + `subRouter`): `_couldShowList` tracks
-   * `uploadList`/`showEmptyList`; the explicit `router.currentActivity` read
-   * tracks history changes (history only mutates alongside an effective-activity
-   * transition, and `currentActivity` is the `@signalState` that captures it),
-   * so a navigation re-renders the button exactly as the v1 `subRouter` did.
-   */
-  private get _couldCancel(): boolean {
-    // Track the router's effective activity so history-driven changes re-render.
-    void this.use(RouterController).currentActivity;
-    return this._couldHistoryBack || this._couldShowList;
+    // Imperative (non-tracking) reads — v1 read `*uploadList`/`showEmptyList` off
+    // the store inside the router-notify callback, NOT reactively. `get()` (not
+    // `getTracked()`) preserves that: this getter feeds the router-driven
+    // `_couldCancel` recompute, so it must not itself subscribe the render to
+    // these keys.
+    const uploadList = this.use(CollectionStateController).get('uploadList');
+    return this.use(ConfigController).get('showEmptyList') || uploadList.length > 0;
   }
 
   protected override controllerReady(ctrl: UploaderController): void {
@@ -112,6 +117,18 @@ export class FileUploaderInline extends SolutionChildBlock {
         }
       }),
     );
+
+    // v1-exact cancel-button recompute: fires immediately, then on every router
+    // notify (the v1 `subRouter` contract). `_couldCancel` is written ONLY here —
+    // never from an `uploadList`/`showEmptyList` change — so it is stale-by-design
+    // between router transitions (see the `_couldCancel` doc comment). The read
+    // is imperative (`_couldShowList`/`_couldHistoryBack` use `get()`), so this
+    // subscription is the sole re-render trigger for the button's `?hidden`.
+    const recomputeCouldCancel = () => {
+      this._couldCancel = this._couldHistoryBack || this._couldShowList;
+    };
+    recomputeCouldCancel();
+    this.trackSub(router.subscribe(recomputeCouldCancel));
   }
 
   protected override subscriptionsFor(ctrl: UploaderController) {

--- a/src/solutions/file-uploader/inline/FileUploaderInline.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.ts
@@ -1,6 +1,9 @@
 import { html } from 'lit';
-import { state } from 'lit/decorators.js';
+import { CollectionStateController } from '../../../abstract/controllers/CollectionStateController';
+import { ConfigController } from '../../../abstract/controllers/ConfigController';
+import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
 import { InternalEventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import { ACTIVITY_TYPES } from '../../../lit/activity-constants';
 import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
@@ -27,22 +30,26 @@ export class FileUploaderInline extends SolutionChildBlock {
   };
   public static override styleAttrs = [...super.styleAttrs, 'uc-file-uploader-inline'];
 
-  @state()
-  private _couldCancel = false;
+  public static override readonly uses = [
+    RouterController,
+    ConfigController,
+    CollectionStateController,
+    TelemetryManager,
+  ] as const;
 
   private _handleCancel = (): void => {
     if (this._couldHistoryBack) {
-      this.bag.router.traverse('onBack');
+      this.use(RouterController).traverse('onBack');
       return;
     }
 
     if (this._couldShowList) {
-      this.bag.router.setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
+      this.use(RouterController).setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
     }
   };
 
   private get _couldHistoryBack(): boolean {
-    const history = this.bag.router.history;
+    const history = this.use(RouterController).history;
     if (history.length <= 1) {
       return false;
     }
@@ -50,14 +57,33 @@ export class FileUploaderInline extends SolutionChildBlock {
   }
 
   private get _couldShowList(): boolean {
-    const uploadList = this.bag.ctx.read('*uploadList') ?? [];
-    return this.uploader.config.get('showEmptyList') || (Array.isArray(uploadList) && uploadList.length > 0);
+    // Tracked reads: `uploadList` (CollectionStateController) + `showEmptyList`
+    // (ConfigController) auto-track under `SignalWatcher`, so the cancel button's
+    // `?hidden=` re-renders when either changes — replacing the v1 `subRouter`
+    // recompute (which only caught these via a coincident router change).
+    const uploadList = this.use(CollectionStateController).getTracked('uploadList');
+    return this.use(ConfigController).getTracked('showEmptyList') || uploadList.length > 0;
+  }
+
+  /**
+   * Whether the cancel button shows — drives `.uc-cancel-btn[hidden]`, which the
+   * inline `:has(.uc-cancel-btn[hidden])` CSS keys off. A tracked getter read in
+   * `render()` (drops the v1 `@state` + `subRouter`): `_couldShowList` tracks
+   * `uploadList`/`showEmptyList`; the explicit `router.currentActivity` read
+   * tracks history changes (history only mutates alongside an effective-activity
+   * transition, and `currentActivity` is the `@signalState` that captures it),
+   * so a navigation re-renders the button exactly as the v1 `subRouter` did.
+   */
+  private get _couldCancel(): boolean {
+    // Track the router's effective activity so history-driven changes re-render.
+    void this.use(RouterController).currentActivity;
+    return this._couldHistoryBack || this._couldShowList;
   }
 
   protected override controllerReady(ctrl: UploaderController): void {
     super.controllerReady(ctrl);
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.INIT_SOLUTION,
     });
 
@@ -65,26 +91,27 @@ export class FileUploaderInline extends SolutionChildBlock {
 
     // Inline renders every activity in place (no modal), so all navigation
     // targets the background slot; a completed flow returns to start-from.
-    this.bag.router.navigationStrategy = () => 'background';
-    this.bag.router.configure({ doneActivity: ACTIVITY_TYPES.START_FROM });
+    const router = this.use(RouterController);
+    router.navigationStrategy = () => 'background';
+    router.configure({ doneActivity: ACTIVITY_TYPES.START_FROM });
 
+    // Side-effecting activity coordination (re-seeds start-from when everything
+    // closes) — stays imperative.
     this.subActivity((val) => {
       if (!val) {
-        this.bag.router.setActivity(initActivity);
+        router.setActivity(initActivity);
       }
     });
 
+    // Imperative side-effecting sub (drives `router.setActivity`, not a render
+    // read), so it stays on the v1 `bag.ctx` subscription.
     this.trackSub(
       this.bag.ctx.sub('*uploadList', (list) => {
-        if (list.length > 0 && this.bag.router.currentActivity === initActivity) {
-          this.bag.router.setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
+        if (list.length > 0 && router.currentActivity === initActivity) {
+          router.setActivity(ACTIVITY_TYPES.UPLOAD_LIST);
         }
       }),
     );
-
-    this.subRouter(() => {
-      this._couldCancel = this._couldHistoryBack || this._couldShowList;
-    });
   }
 
   protected override subscriptionsFor(ctrl: UploaderController) {

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
@@ -1,0 +1,116 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { ConfigController } from '../../../abstract/controllers/ConfigController';
+import { RouterController } from '../../../abstract/controllers/RouterController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
+import { ACTIVITY_TYPES } from '../../../lit/activity-constants';
+import { ensureUploaderCtx } from '../../../lit/ensureUploaderCtx';
+import { PubSub } from '../../../lit/PubSubCompat';
+import { delay } from '../../../utils/delay';
+import { FileUploaderMinimal } from './FileUploaderMinimal';
+
+// Idempotent (same path as defineComponents(UC)).
+FileUploaderMinimal.reg('uc-file-uploader-minimal');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `fu-minimal-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+): Promise<{ el: FileUploaderMinimal; config: ConfigController; router: RouterController }> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const config = container?.get(ConfigController);
+  const router = container?.get(RouterController);
+  if (!config || !router) throw new Error('controllers not resolved');
+  const el = document.createElement('uc-file-uploader-minimal') as FileUploaderMinimal;
+  el.setAttribute('ctx-name', ctxName);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, config, router };
+};
+
+const settle = async (el: FileUploaderMinimal): Promise<void> => {
+  await el.updateComplete;
+  await delay(0);
+};
+
+// The inline drop-area is the first `<uc-drop-area>` in the persistent
+// `<uc-start-from>` (the modal picker's drop-area is second).
+const inlineDropArea = (el: FileUploaderMinimal): Element | null => el.querySelector('uc-start-from uc-drop-area');
+
+describe('FileUploaderMinimal (M-god step 6b-4 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(FileUploaderMinimal.uses).toEqual([RouterController, ConfigController, TelemetryManager]);
+  });
+
+  it('routes upload-list to the background and everything else to the foreground', async () => {
+    const ctxName = freshCtxName();
+    const { router } = await mount(ctxName);
+    expect(router.navigationStrategy(ACTIVITY_TYPES.UPLOAD_LIST)).toBe('background');
+    expect(router.navigationStrategy(ACTIVITY_TYPES.START_FROM)).toBe('foreground');
+    expect(router.doneActivity).toBe(ACTIVITY_TYPES.UPLOAD_LIST);
+  });
+
+  it('forces confirmUpload off', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    expect(config.get('confirmUpload')).toBe(false);
+    // A later external attempt to turn it on is corrected back to false.
+    config.set('confirmUpload', true);
+    await settle(el);
+    expect(config.get('confirmUpload')).toBe(false);
+  });
+
+  it('reactively mirrors filesViewMode into the host [mode] attribute (getTracked, no subConfigValue)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    expect(el.getAttribute('mode')).toBe(config.get('filesViewMode'));
+
+    config.set('filesViewMode', 'grid');
+    await settle(el);
+    expect(el.getAttribute('mode')).toBe('grid');
+
+    config.set('filesViewMode', 'list');
+    await settle(el);
+    expect(el.getAttribute('mode')).toBe('list');
+  });
+
+  it('reactively toggles --uc-grid-col and the drop-area [single] attr for grid + non-multiple', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mount(ctxName);
+    config.set('filesViewMode', 'grid');
+    config.set('multiple', false);
+    await settle(el);
+    expect(el.style.getPropertyValue('--uc-grid-col')).toBe('1');
+    expect(inlineDropArea(el)?.hasAttribute('single')).toBe(true);
+
+    // Turning on multiple drops the single-column constraint.
+    config.set('multiple', true);
+    await settle(el);
+    expect(el.style.getPropertyValue('--uc-grid-col')).toBe('');
+    expect(inlineDropArea(el)?.hasAttribute('single')).toBe(false);
+
+    // Leaving grid mode also drops it.
+    config.set('multiple', false);
+    config.set('filesViewMode', 'list');
+    await settle(el);
+    expect(el.style.getPropertyValue('--uc-grid-col')).toBe('');
+    expect(inlineDropArea(el)?.hasAttribute('single')).toBe(false);
+  });
+});

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
@@ -1,6 +1,8 @@
-import { html } from 'lit';
-import { state } from 'lit/decorators.js';
+import { html, type PropertyValues } from 'lit';
+import { ConfigController } from '../../../abstract/controllers/ConfigController';
+import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
 import { InternalEventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import { ACTIVITY_TYPES } from '../../../lit/activity-constants';
 import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
@@ -27,16 +29,28 @@ export class FileUploaderMinimal extends SolutionChildBlock {
   };
   public static override styleAttrs = [...super.styleAttrs, 'uc-file-uploader-minimal'];
 
-  @state()
-  private _singleUpload = false;
+  public static override readonly uses = [RouterController, ConfigController, TelemetryManager] as const;
 
-  @state()
-  private _buttonTextKey = 'choose-file';
+  /**
+   * Grid single-upload flag feeding `?single=` on the inline drop-area — true
+   * only in grid mode without `multiple`. A tracked `getTracked` getter (drops
+   * the v1 `@state` + nested `subConfigValue`): reading it in `render()`
+   * auto-tracks both keys under `SignalWatcher`, so a config change re-renders.
+   */
+  private get _singleUpload(): boolean {
+    const config = this.use(ConfigController);
+    return config.getTracked('filesViewMode') === 'grid' && !config.getTracked('multiple');
+  }
+
+  /** Trigger label key, derived reactively from `multiple` (drops the v1 `@state`). */
+  private get _buttonTextKey(): string {
+    return this.use(ConfigController).getTracked('multiple') ? 'choose-files' : 'choose-file';
+  }
 
   protected override controllerReady(ctrl: UploaderController): void {
     super.controllerReady(ctrl);
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.INIT_SOLUTION,
     });
 
@@ -47,59 +61,67 @@ export class FileUploaderMinimal extends SolutionChildBlock {
     // and `<uc-upload-list>` light up via the background slot's `[active]`
     // attribute (no manual class toggling). A completed flow lands on the
     // upload list.
-    this.bag.router.navigationStrategy = (to) => (to === ACTIVITY_TYPES.UPLOAD_LIST ? 'background' : 'foreground');
-    this.bag.router.configure({ doneActivity: ACTIVITY_TYPES.UPLOAD_LIST });
+    const router = this.use(RouterController);
+    router.navigationStrategy = (to) => (to === ACTIVITY_TYPES.UPLOAD_LIST ? 'background' : 'foreground');
+    router.configure({ doneActivity: ACTIVITY_TYPES.UPLOAD_LIST });
 
     // Background slot follows file state: the upload list once files exist,
-    // otherwise the start-from trigger.
+    // otherwise the start-from trigger. Imperative side-effecting sub (drives
+    // `router.setActivity`, not a render read), so it stays on the v1 `bag.ctx`
+    // subscription — the `*uploadList` CollectionStateController token is only
+    // adopted for pure render reads (see FormInput/UploadList).
     this.trackSub(
       this.bag.ctx.sub('*uploadList', (list) => {
         const hasFiles = list.length > 0;
-        this.bag.router.setActivity(hasFiles ? ACTIVITY_TYPES.UPLOAD_LIST : ACTIVITY_TYPES.START_FROM);
+        router.setActivity(hasFiles ? ACTIVITY_TYPES.UPLOAD_LIST : ACTIVITY_TYPES.START_FROM);
       }),
     );
 
+    // Side-effecting activity coordination (closes the modal on upload-list,
+    // re-seeds start-from when everything closes) — stays imperative.
     this.subActivity((val) => {
       if (val === ACTIVITY_TYPES.UPLOAD_LIST) {
-        this.bag.router.closeModal();
+        router.closeModal();
       }
       if (!val) {
-        this.bag.router.setActivity(ACTIVITY_TYPES.START_FROM);
+        router.setActivity(ACTIVITY_TYPES.START_FROM);
       }
     });
 
+    // Side-effecting config write (minimal forces `confirmUpload` off) — stays
+    // an imperative `subConfigValue`, not a render read.
     this.subConfigValue('confirmUpload', (confirmUpload) => {
       if (confirmUpload !== false) {
-        this.uploader.config.set('confirmUpload', false);
+        this.use(ConfigController).set('confirmUpload', false);
       }
-    });
-
-    this.subConfigValue('filesViewMode', (mode) => {
-      this.setAttribute('mode', mode);
-
-      this.subConfigValue('multiple', (multiple) => {
-        if (mode === 'grid') {
-          if (multiple) {
-            this.style.removeProperty('--uc-grid-col');
-          } else {
-            this.style.setProperty('--uc-grid-col', '1');
-          }
-
-          this._singleUpload = !multiple;
-        } else {
-          this.style.removeProperty('--uc-grid-col');
-          this._singleUpload = false;
-        }
-      });
-    });
-
-    this.subConfigValue('multiple', (val) => {
-      this._buttonTextKey = val ? 'choose-files' : 'choose-file';
     });
   }
 
   protected override subscriptionsFor(ctrl: UploaderController) {
     return [(listener: () => void) => ctrl.locale.subscribe(listener)];
+  }
+
+  protected override willUpdate(changed: PropertyValues<this>): void {
+    super.willUpdate(changed);
+
+    // Host `[mode]` attribute + `--uc-grid-col` style side-effects: the CSS
+    // `[uc-file-uploader-minimal][mode="list"|"grid"]` selectors key off the
+    // host attribute, so drive it here from the tracked config signals (the
+    // Modal `willUpdate` + `getTracked` recipe, replacing the v1
+    // `subConfigValue('filesViewMode')` with a nested `subConfigValue('multiple')`).
+    // Reading both keys via `getTracked` auto-tracks them under `SignalWatcher`,
+    // so a config change re-runs this update and re-applies the attribute/style —
+    // matching the v1 subscription's reactivity. Neither is a reactive property,
+    // so toggling them schedules no further update.
+    const config = this.use(ConfigController);
+    const mode = config.getTracked('filesViewMode');
+    const multiple = config.getTracked('multiple');
+    this.setAttribute('mode', mode);
+    if (mode === 'grid' && !multiple) {
+      this.style.setProperty('--uc-grid-col', '1');
+    } else {
+      this.style.removeProperty('--uc-grid-col');
+    }
   }
 
   public override render() {
@@ -123,7 +145,7 @@ export class FileUploaderMinimal extends SolutionChildBlock {
           <button
             type="button"
             class="uc-secondary-btn"
-            @click=${() => this.bag.router.traverse('onCancel')}
+            @click=${() => this.use(RouterController).traverse('onCancel')}
           >${this.l10n('start-from-cancel')}</button>
         </uc-start-from>
       </uc-modal>

--- a/src/solutions/file-uploader/regular/FileUploaderRegular.test.ts
+++ b/src/solutions/file-uploader/regular/FileUploaderRegular.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { RouterController } from '../../../abstract/controllers/RouterController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
+import { ensureUploaderCtx } from '../../../lit/ensureUploaderCtx';
+import { PubSub } from '../../../lit/PubSubCompat';
+import { delay } from '../../../utils/delay';
+import { FileUploaderRegular } from './FileUploaderRegular';
+
+// Idempotent (same path as defineComponents(UC)).
+FileUploaderRegular.reg('uc-file-uploader-regular');
+
+let seq = 0;
+const mounted: HTMLElement[] = [];
+const ctxNames: string[] = [];
+
+const freshCtxName = (): string => {
+  const name = `fu-regular-spec-${seq++}`;
+  ctxNames.push(name);
+  return name;
+};
+
+afterEach(() => {
+  for (const el of mounted.splice(0)) el.remove();
+  for (const name of ctxNames.splice(0)) {
+    if (PubSub.hasCtx(name)) PubSub.deleteCtx(name);
+  }
+});
+
+const mount = async (
+  ctxName: string,
+  attrs: Record<string, string> = {},
+): Promise<{ el: FileUploaderRegular; router: RouterController }> => {
+  ensureUploaderCtx(ctxName);
+  const container = PubSub.getContainer(ctxName);
+  const router = container?.get(RouterController);
+  if (!router) throw new Error('router controller not resolved');
+  const el = document.createElement('uc-file-uploader-regular') as FileUploaderRegular;
+  el.setAttribute('ctx-name', ctxName);
+  for (const [k, v] of Object.entries(attrs)) el.setAttribute(k, v);
+  document.body.append(el);
+  mounted.push(el);
+  await el.updateComplete;
+  await delay(0);
+  return { el, router };
+};
+
+describe('FileUploaderRegular (M-god step 6b-4 migration)', () => {
+  it('declares its dependencies via static uses', () => {
+    expect(FileUploaderRegular.uses).toEqual([RouterController, TelemetryManager]);
+  });
+
+  it('routes every activity to the foreground (modal) slot', async () => {
+    const ctxName = freshCtxName();
+    const { router } = await mount(ctxName);
+    expect(router.navigationStrategy('start-from')).toBe('foreground');
+    expect(router.navigationStrategy('upload-list')).toBe('foreground');
+  });
+
+  it('renders the static button by default and the dynamic button when dynamic-button is set', async () => {
+    const staticCtx = freshCtxName();
+    const { el: staticEl } = await mount(staticCtx);
+    expect(staticEl.querySelector('uc-simple-btn')).not.toBeNull();
+    expect(staticEl.querySelector('uc-dynamic-btn')).toBeNull();
+
+    const dynCtx = freshCtxName();
+    const { el: dynEl } = await mount(dynCtx, { 'dynamic-button': '' });
+    expect(dynEl.isDynamicButtonActive).toBe(true);
+    expect(dynEl.querySelector('uc-dynamic-btn')).not.toBeNull();
+    expect(dynEl.querySelector('uc-simple-btn')).toBeNull();
+  });
+
+  it('renders no button in headless mode', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName, { headless: '' });
+    expect(el.querySelector('uc-simple-btn')).toBeNull();
+    expect(el.querySelector('uc-dynamic-btn')).toBeNull();
+  });
+
+  it('wires the start-from modal + upload-list modal into the template', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    expect(el.querySelector('uc-modal#start-from')).not.toBeNull();
+    expect(el.querySelector('uc-modal#upload-list')).not.toBeNull();
+    expect(el.querySelector('uc-plugin-activity-renderer')).not.toBeNull();
+  });
+
+  it('traverses onCancel via the RouterController when the cancel button is clicked', async () => {
+    const ctxName = freshCtxName();
+    const { el, router } = await mount(ctxName);
+    const traverse = vi.spyOn(router, 'traverse');
+    const cancelBtn = el.querySelector<HTMLButtonElement>('button.uc-secondary-btn');
+    expect(cancelBtn).not.toBeNull();
+    cancelBtn?.click();
+    expect(traverse).toHaveBeenCalledWith('onCancel');
+  });
+});

--- a/src/solutions/file-uploader/regular/FileUploaderRegular.ts
+++ b/src/solutions/file-uploader/regular/FileUploaderRegular.ts
@@ -1,6 +1,8 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
+import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { UploaderController } from '../../../abstract/controllers/UploaderController';
+import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
 import { InternalEventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
 import './index.css';
@@ -19,6 +21,8 @@ import '../../../blocks/PluginActivityRenderer/PluginActivityRenderer';
 
 export class FileUploaderRegular extends SolutionChildBlock {
   public static override lazyPlugins = fileUploaderLazyPlugins;
+
+  public static override readonly uses = [RouterController, TelemetryManager] as const;
 
   // Type-only: feeds the JSX attribute typing (`ReflectAttributes` in
   // `types/jsx.d.ts` reads `attributesMeta`). Kept on the ChildBlock port —
@@ -41,9 +45,9 @@ export class FileUploaderRegular extends SolutionChildBlock {
 
     // Regular renders every activity inside a `<uc-modal>`, so all navigation
     // targets the foreground (modal) slot.
-    this.bag.router.navigationStrategy = () => 'foreground';
+    this.use(RouterController).navigationStrategy = () => 'foreground';
 
-    this.bag.telemetryManager.sendEvent({
+    this.use(TelemetryManager).sendEvent({
       eventType: InternalEventType.INIT_SOLUTION,
     });
   }
@@ -90,7 +94,7 @@ export class FileUploaderRegular extends SolutionChildBlock {
     <uc-start-from>
       <uc-drop-area with-icon clickable></uc-drop-area>
       <uc-source-list role="list" wrap></uc-source-list>
-      <button type="button" class="uc-secondary-btn" @click=${() => this.bag.router.traverse('onCancel')}>${this.l10n('start-from-cancel')}</button>
+      <button type="button" class="uc-secondary-btn" @click=${() => this.use(RouterController).traverse('onCancel')}>${this.l10n('start-from-cancel')}</button>
       <uc-copyright></uc-copyright>
     </uc-start-from>
   </uc-modal>

--- a/tests/blocks/copyright.e2e.test.tsx
+++ b/tests/blocks/copyright.e2e.test.tsx
@@ -31,21 +31,28 @@ describe('uc-copyright', () => {
   });
 
   it('hides when removeCopyright is set, shows again when unset', async () => {
-    // M-god step 6a: Copyright now reads `removeCopyright` through the tracked
-    // config signal inside `render()`, so a `SignalWatcher` re-render toggles
-    // `?hidden` on the `<a>` (was an imperative `toggleAttribute('hidden')` on
-    // the host). This asserts the reactive path end-to-end in a real browser:
-    // an external `<uc-config>` change re-renders the overridden `render()`.
+    // M-god step 6a review: Copyright reads `removeCopyright` through the tracked
+    // config signal in `willUpdate()` and toggles `[hidden]` on the HOST
+    // `<uc-copyright>` (not the inner `<a>`), matching pre-6a behavior. The host
+    // attribute is what the inline solution's `:has(uc-copyright[hidden])` layout
+    // CSS keys off, so it must land on the host. This asserts the reactive path
+    // end-to-end in a real browser: an external `<uc-config>` change re-runs the
+    // update and re-toggles the host attribute, in both directions.
     const { config } = renderCopyright();
+    const host = () => document.querySelector<HTMLElement>('uc-copyright')!;
     const link = () => document.querySelector<HTMLAnchorElement>('uc-copyright .uc-credits')!;
     await expect.element(page.getByText('Powered by Uploadcare', { exact: true })).toBeVisible();
+    expect(host().hasAttribute('hidden')).toBe(false);
     expect(link().hasAttribute('hidden')).toBe(false);
 
     config.removeCopyright = true;
-    await expect.poll(() => link().hasAttribute('hidden')).toBe(true);
+    await expect.poll(() => host().hasAttribute('hidden')).toBe(true);
+    // The inner <a> must stay free of `hidden` — only the host carries it.
+    expect(link().hasAttribute('hidden')).toBe(false);
 
     config.removeCopyright = false;
-    await expect.poll(() => link().hasAttribute('hidden')).toBe(false);
+    await expect.poll(() => host().hasAttribute('hidden')).toBe(false);
+    expect(link().hasAttribute('hidden')).toBe(false);
   });
 
   it('reflects data-testid under testMode', async () => {

--- a/tests/blocks/copyright.e2e.test.tsx
+++ b/tests/blocks/copyright.e2e.test.tsx
@@ -31,15 +31,21 @@ describe('uc-copyright', () => {
   });
 
   it('hides when removeCopyright is set, shows again when unset', async () => {
+    // M-god step 6a: Copyright now reads `removeCopyright` through the tracked
+    // config signal inside `render()`, so a `SignalWatcher` re-render toggles
+    // `?hidden` on the `<a>` (was an imperative `toggleAttribute('hidden')` on
+    // the host). This asserts the reactive path end-to-end in a real browser:
+    // an external `<uc-config>` change re-renders the overridden `render()`.
     const { config } = renderCopyright();
-    const el = () => document.querySelector('uc-copyright')!;
+    const link = () => document.querySelector<HTMLAnchorElement>('uc-copyright .uc-credits')!;
     await expect.element(page.getByText('Powered by Uploadcare', { exact: true })).toBeVisible();
+    expect(link().hasAttribute('hidden')).toBe(false);
 
     config.removeCopyright = true;
-    await expect.poll(() => el().hasAttribute('hidden')).toBe(true);
+    await expect.poll(() => link().hasAttribute('hidden')).toBe(true);
 
     config.removeCopyright = false;
-    await expect.poll(() => el().hasAttribute('hidden')).toBe(false);
+    await expect.poll(() => link().hasAttribute('hidden')).toBe(false);
   });
 
   it('reflects data-testid under testMode', async () => {

--- a/tests/file-uploader-inline.e2e.test.tsx
+++ b/tests/file-uploader-inline.e2e.test.tsx
@@ -1,6 +1,6 @@
 import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
 import { page, userEvent } from 'vitest/browser';
-import type { FileUploaderInline } from '@/index';
+import type { Config, FileUploaderInline } from '@/index';
 import { ACTIVITY_TYPES } from '@/lit/activity-constants.js';
 import { PubSub } from '@/lit/PubSubCompat.js';
 import { getCtxName } from './utils/getCtxName';
@@ -125,6 +125,45 @@ describe('File uploader inline — M9r solution-block safety net', () => {
       // is visually active), never inside a `<uc-modal>`.
       expect(page.getByTestId('uc-upload-list').query()).not.toBeNull();
       expect(page.getByTestId('uc-modal').query()).toBeNull();
+    });
+  });
+
+  describe('removeCopyright inline layout (M-god step 6a review)', () => {
+    // The inline solution's layout CSS keys off the HOST attribute via
+    // `[uc-file-uploader-inline] uc-start-from:has(uc-copyright[hidden]) uc-drop-area`
+    // (index.css). If `[hidden]` lands on the inner `<a>` instead of the host,
+    // the `:has(uc-copyright[hidden])` selector never matches and the drop-area
+    // layout regresses. This pins the host attribute — the CSS precondition — on
+    // the real inline composition, in both directions, and guards that the inner
+    // `<a>` never carries `[hidden]` (which is what regressed the selector).
+    it('toggles [hidden] on the host uc-copyright inside the inline solution (not the inner <a>)', async () => {
+      cleanup();
+      const ctxName = getCtxName();
+      page.render(
+        <>
+          <uc-file-uploader-inline ctx-name={ctxName}></uc-file-uploader-inline>
+          <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+        </>,
+      );
+      await expect.poll(() => PubSub.hasCtx(ctxName)).toBe(true);
+      await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+
+      const config = page.getByTestId('uc-config').query()! as Config;
+      const copyright = () => document.querySelector<HTMLElement>('[uc-file-uploader-inline] uc-copyright');
+      const credits = () => copyright()?.querySelector<HTMLElement>('.uc-credits');
+
+      await expect.poll(() => copyright()).not.toBeNull();
+      expect(copyright()?.hasAttribute('hidden')).toBe(false);
+
+      config.removeCopyright = true;
+      // Host gains `[hidden]` so `:has(uc-copyright[hidden])` matches; the inner
+      // `<a>` must stay free of it.
+      await expect.poll(() => copyright()?.hasAttribute('hidden')).toBe(true);
+      expect(credits()?.hasAttribute('hidden')).toBe(false);
+
+      config.removeCopyright = false;
+      await expect.poll(() => copyright()?.hasAttribute('hidden')).toBe(false);
+      expect(credits()?.hasAttribute('hidden')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
## God-object decomposition — PR 2/4: blocks → `@inject` + signals (step 6)

Second of four sequential PRs dissolving the monolithic `UploaderController` into a per-ctx DI container of small controllers. **PR 1/4 (#1039)** landed the DI foundation + controller decomposition (steps 1–5). This PR makes the **elements reactive**: every block's render-feeding state read moves off the v1 imperative `subConfigValue`/`bag` path onto the container (`this.use(X)`) + `@lit-labs/signals` (`getTracked`), under a `SignalWatcher` base.

The documented public API is unchanged; this is a behavior-preserving, render-path-only migration.

### What's in it
- **`ChildBlock` base** gains `SignalWatcher` + `static uses`/`this.use()` and retargets its consumer lifecycle to the container (6a). `ConfigController.getTracked` adds the tracked signal read (`get()` stays a fast, non-tracking bag read for imperative callers).
- **All render-feeding reads across ~19 blocks** migrated to `use()` + tracked signals (6b-1…6b-9): source buttons, `Icon`/`DynamicBtn`/`ExternalSource`/`ProgressBarCommon`/`PluginActivityRenderer`, `Modal`/`CameraSource`/`DropArea`/`SourceList`, the `FileUploader{Regular,Minimal,Inline}`/`FormInput` solutions, `Config`, `FileItem`/`Thumb`, `ActivityChildBlock`, `UploadList`, `CloudImageEditorActivity`.
- **Host-attribute CSS contract preserved** — attributes that solution/theme CSS targets on the host (`uc-copyright[hidden]`, `uc-*[active]`, `uc-file-item[mode]`, …) stay on the host (via `willUpdate` + `toggleAttribute`, or imperative `subConfigValue` for lazy-rendered blocks like `FileItem`), never moved to inner elements.
- **Residual `api`/`plugin-manager`/`uploadCollection`-observer reads** stay on the old path in this PR — they resolve when `UploaderPublicApi`/`PluginController` become container-resolved in **PR 3/4** (steps 7–9).

### Notable review finds fixed in-branch
- **6a:** `Copyright` migration first moved `[hidden]` from the host to an inner `<a>`, breaking the inline solution's `:has(uc-copyright[hidden])` drop-area layout — restored to the host (`099613b0`). e2e didn't catch it; added an inline e2e guard.
- **6b-4 (Critical):** `FileUploaderInline`'s cancel button was no longer a strict superset of v1 (v1 kept it visible on list-empty without a router change; v2 hid it) — reverted to the v1 router-notify-driven recompute (`a1c056d0`), with tests asserting v1 semantics.
- **Perf gate:** signal-read-in-`render()` under `SignalWatcher` was validated on hot blocks (`FileItem`/`Thumb`) — full e2e ran clean twice with no new flakiness.

### Verification
Full green gate on HEAD:
- `tsc:app` ✅
- `build` ✅ (attw/publint/size-limit) — editor bundle `web/uc-cloud-image-editor.min.js` **49.59 kB / 50 kB** (drops to ~47.6 kB once PR 3 deletes `UploaderController`)
- `test:specs` ✅ **951 passed** (99 files)
- `test:locales` ✅
- `test:e2e` ✅ **385 passed** (54 files)
- `lint` ✅ 0 errors (5 pre-existing lit-analyzer warnings, unchanged by this PR)

Each step was implemented, gated, and independently reviewed one at a time (13 commits). Ahead: **PR 3/4** dissolves `UploaderController` + deletes the v1 ctx layer (steps 7–9); **PR 4/4** does the DI cleanups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved reactive updates for configuration, upload progress, modal state, icons, file views, and uploader controls.
  * Updated camera mirroring, cloud image editing, copyright visibility, validation fields, and upload-list behavior to respond more reliably to changes.
  * Improved routing and navigation across uploader activities, dialogs, source controls, and cancel/close actions.
  * Added broader controller-based dependency handling for more consistent component behavior.

* **Bug Fixes**
  * Fixed stale UI states and improved synchronization of attributes, styles, validation inputs, progress indicators, and modal visibility.

* **Tests**
  * Added extensive component and end-to-end coverage for reactive rendering, navigation, configuration changes, telemetry, and lifecycle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->