### PR TITLE
refactor(v2): l10n reactive via getTracked; delete subscriptionsFor + its 13 overrides (9e-3)

### DIFF
--- a/src/blocks/CameraSource/CameraSource.ts
+++ b/src/blocks/CameraSource/CameraSource.ts
@@ -1,9 +1,7 @@
 import { html, type PropertyValues } from 'lit';
 import { state } from 'lit/decorators.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
@@ -167,10 +165,6 @@ export class CameraSource extends ChildBlock {
 
   @state()
   private _mutableClassButton = 'uc-shot-btn uc-camera-action';
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
-  }
 
   private _chooseActionWithCamera = () => {
     this._telemetry.sendEvent({

--- a/src/blocks/DropArea/DropArea.ts
+++ b/src/blocks/DropArea/DropArea.ts
@@ -2,7 +2,6 @@ import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { createRef, type Ref, ref } from 'lit/directives/ref.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
 import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
@@ -224,10 +223,6 @@ export class DropArea extends ChildBlock {
     this._destroyDropzone = null;
     this._destroyContentWrapperDropzone?.();
     this._destroyContentWrapperDropzone = null;
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer): Array<(listener: () => void) => () => void> {
-    return [(l: () => void) => container.get(LocaleController).subscribe(l)];
   }
 
   protected override willUpdate(changedProperties: PropertyValues<this>): void {

--- a/src/blocks/DynamicBtn/PrimaryAction.ts
+++ b/src/blocks/DynamicBtn/PrimaryAction.ts
@@ -1,9 +1,7 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { ChildBlock } from '../../lit/ChildBlock';
 import type { Uid } from '../../lit/Uid';
@@ -45,10 +43,6 @@ export class PrimaryAction extends ChildBlock {
 
   private get _isMultiple(): boolean {
     return this._config.getTracked('multiple');
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   private get hasEntries(): boolean {

--- a/src/blocks/ExternalSource/ExternalSource.ts
+++ b/src/blocks/ExternalSource/ExternalSource.ts
@@ -8,9 +8,7 @@ import { html } from 'lit';
 import { state } from 'lit/decorators.js';
 import { createRef, ref } from 'lit/directives/ref.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { ChildBlock } from '../../lit/ChildBlock';
@@ -82,10 +80,6 @@ export class ExternalSource extends ChildBlock {
       count: selectedCount,
       total,
     });
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   protected override controllerReady(): void {

--- a/src/blocks/FileItem/FileActionButton.ts
+++ b/src/blocks/FileItem/FileActionButton.ts
@@ -1,8 +1,6 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { styleMap } from 'lit/directives/style-map.js';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { ChildBlock } from '../../lit/ChildBlock';
 
 import '../Icon/Icon';
@@ -35,10 +33,6 @@ export class FileActionButton extends ChildBlock {
 
   private get _normalizedProgress(): number {
     return Math.min(Math.max(this.progress || 0, 0), 100);
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   private _handleAction() {

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -2,10 +2,8 @@ import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import { UploadController } from '../../abstract/controllers/UploadController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { PluginController, type PluginFileActionRegistration } from '../../abstract/managers/plugin';
 import type { Owned } from '../../abstract/managers/plugin/PluginTypes';
@@ -421,10 +419,6 @@ export class FileItem extends FileItemConfig {
 
   protected override controllerReleased(): void {
     this._pluginManager = null;
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   public override connectedCallback(): void {

--- a/src/blocks/SimpleBtn/SimpleBtn.test.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { UploaderRegistry } from '../../abstract/UploaderRegistry';
 import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
@@ -80,5 +81,32 @@ describe('SimpleBtn (M-god step 6b-1 migration)', () => {
     await el.updateComplete;
     await delay(0);
     expect(buttonText(el)).toBe(multiText);
+  });
+
+  it('re-renders the button text reactively on a locale change with no explicit subscription (l10n getTracked)', async () => {
+    const ctxName = freshCtxName();
+    const { el, config } = await mountWithConfig(ctxName);
+
+    // Pin the single-file key so the locale key under test (`upload-file`) is
+    // the one actually rendered, regardless of the `multiple` default.
+    config.set('multiple', false);
+    await el.updateComplete;
+    await delay(0);
+
+    // Default English dictionary value, resolved through `this.l10n('upload-file')`.
+    expect(buttonText(el)).toBe('Upload file');
+
+    // This block declares no `subscriptionsFor` override (removed — M-god step
+    // 9e-3): `createL10n` now reads `LocaleController.getTracked`, so the
+    // `l10n('upload-file')` call inside `render()` auto-tracks that key under
+    // `SignalWatcher` on its own. Writing the key directly on the controller
+    // (bypassing any block-level subscription) must still re-render the block.
+    const locale = UploaderRegistry.get(ctxName)?.get(LocaleController);
+    if (!locale) throw new Error('locale controller not resolved');
+    locale.set('upload-file', 'CUSTOM');
+    await el.updateComplete;
+    await delay(0);
+
+    expect(buttonText(el)).toBe('CUSTOM');
   });
 });

--- a/src/blocks/SimpleBtn/SimpleBtn.ts
+++ b/src/blocks/SimpleBtn/SimpleBtn.ts
@@ -1,8 +1,6 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { ChildBlock } from '../../lit/ChildBlock';
@@ -25,10 +23,6 @@ export class SimpleBtn extends ChildBlock {
   private readonly _handleClick = () => {
     this._api.initFlow();
   };
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
-  }
 
   public override render() {
     const buttonTextKey = this._config.getTracked('multiple') ? 'upload-files' : 'upload-file';

--- a/src/blocks/SourceBtn/SourceBtn.ts
+++ b/src/blocks/SourceBtn/SourceBtn.ts
@@ -1,7 +1,5 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { ChildBlock } from '../../lit/ChildBlock';
@@ -60,10 +58,6 @@ export class SourceBtn extends ChildBlock {
     const { label, icon, id } = source;
     this._srcTypeKey = label;
     this._iconName = icon ?? id ?? 'default';
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   public activate(): void {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -2,7 +2,6 @@ import { html, type PropertyValues } from 'lit';
 import { state } from 'lit/decorators.js';
 import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
 import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
@@ -311,10 +310,6 @@ export class UploadList extends ActivityChildBlock {
     // eager `subConfigValue` fire. `mode` is not a reactive property, so setting
     // it schedules no further update.
     this.setAttribute('mode', this._config.getTracked('filesViewMode'));
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   public override render() {

--- a/src/blocks/UrlSource/UrlSource.ts
+++ b/src/blocks/UrlSource/UrlSource.ts
@@ -1,8 +1,6 @@
 import { html } from 'lit';
 import { state } from 'lit/decorators.js';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { RouterController } from '../../abstract/controllers/RouterController';
-import type { ControllerContainer } from '../../abstract/di/ControllerContainer';
 import { inject } from '../../abstract/di/inject';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
@@ -23,10 +21,6 @@ export class UrlSource extends ChildBlock {
 
   @state()
   private _url = '';
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
-  }
 
   private _handleInput = (event: Event) => {
     this._url = (event.target as HTMLInputElement | null)?.value ?? '';

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -170,9 +170,10 @@ export abstract class ChildBlock extends ChildBlockBase {
    * key fallback, template variables, pluralization. Reads directly from this
    * ctx's `LocaleController` (M-god step 7: off the `*l10n/*` PubSub facade).
    * Call at render time (the render gate guarantees the container is adopted, so
-   * `use()` resolves); blocks that render l10n text should add
-   * `(l) => ctrl.locale.subscribe(l)` to `subscriptionsFor` so the text
-   * re-renders when the dictionary loads or the locale switches.
+   * `use()` resolves). Lookups go through `LocaleController.getTracked`, so an
+   * `l10n(key)` read inside `render()`/`willUpdate()` auto-tracks that key under
+   * `SignalWatcher` and re-renders the block when the dictionary loads or the
+   * locale switches — no explicit subscription needed.
    */
   public l10n = createL10n(() => this.use(LocaleController));
 
@@ -375,10 +376,6 @@ export abstract class ChildBlock extends ChildBlockBase {
     // each block's `@inject` fields (and via `use()`/`whenController` for the
     // scope-bound ones), so there is no eager pre-warm here — adoption only tags
     // the container and wires the subscriptions below.
-    const rerender = () => this.requestUpdate();
-    for (const subscribe of this.subscriptionsFor(container)) {
-      this._subs.push(subscribe(rerender));
-    }
     this._subs.push(container.get(ConfigController).subscribe(() => this._syncTestId(container)));
     this._syncTestId(container);
     try {
@@ -510,15 +507,6 @@ export abstract class ChildBlock extends ChildBlockBase {
     const unsub = this.use(RouterController).subscribe(callback);
     this.trackSub(unsub);
     return unsub;
-  }
-
-  /**
-   * Controller-change subscriptions that should trigger a re-render — return
-   * `subscribe` functions (e.g. `(l) => container.get(LocaleController).subscribe(l)`).
-   * Wired on adoption, torn down on release.
-   */
-  protected subscriptionsFor(_container: ControllerContainer): Array<(listener: () => void) => () => void> {
-    return [];
   }
 
   /** Called after the ctx's container is adopted (initial and on re-adoption). */

--- a/src/lit/l10n.ts
+++ b/src/lit/l10n.ts
@@ -18,6 +18,13 @@ export const createPluralizer = (getL10n: () => L10nFunction) => {
  * ctx's {@link LocaleController} (M-god step 7: off the `*l10n/*` PubSub facade).
  * `getLocale` is called live on every lookup so a later dictionary load / locale
  * switch is reflected without re-creating the function.
+ *
+ * Lookups use the controller's `getTracked`, so calling `l10n(key)` inside a
+ * `SignalWatcher` render (every `ChildBlock`) auto-tracks that key and re-renders
+ * the block when the dictionary loads or the locale switches — replacing the
+ * explicit `subscriptionsFor` locale subscription blocks used to declare. Outside
+ * a watcher (e.g. `api.l10n(...)`) `getTracked` is a plain read, so callers that
+ * are not reactive consumers are unaffected.
  */
 export const createL10n = (getLocale: () => LocaleController) => {
   const pluralizer = createPluralizer(() => l10n);
@@ -25,7 +32,7 @@ export const createL10n = (getLocale: () => LocaleController) => {
     if (!str) {
       return '';
     }
-    const template = getLocale().get(str) || str;
+    const template = getLocale().getTracked(str) || str;
     const pluralObjects = getPluralObjects(template);
     for (const pluralObject of pluralObjects) {
       variables[pluralObject.variable] = pluralizer(

--- a/src/solutions/file-uploader/inline/FileUploaderInline.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.ts
@@ -2,7 +2,6 @@ import { html } from 'lit';
 import { state } from 'lit/decorators.js';
 import { CollectionStateController } from '../../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../../abstract/controllers/LocaleController';
 import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { ControllerContainer } from '../../../abstract/di/ControllerContainer';
 import { inject } from '../../../abstract/di/inject';
@@ -157,10 +156,6 @@ export class FileUploaderInline extends SolutionChildBlock {
     };
     recomputeCouldCancel();
     this.trackSub(router.subscribe(recomputeCouldCancel));
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   public override render() {

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
@@ -1,7 +1,6 @@
 import { html, type PropertyValues } from 'lit';
 import { CollectionStateController } from '../../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../../abstract/controllers/LocaleController';
 import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { ControllerContainer } from '../../../abstract/di/ControllerContainer';
 import { inject } from '../../../abstract/di/inject';
@@ -140,10 +139,6 @@ export class FileUploaderMinimal extends SolutionChildBlock {
         }
       }),
     );
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   protected override willUpdate(changed: PropertyValues<this>): void {

--- a/src/solutions/file-uploader/regular/FileUploaderRegular.ts
+++ b/src/solutions/file-uploader/regular/FileUploaderRegular.ts
@@ -1,6 +1,5 @@
 import { html } from 'lit';
 import { property } from 'lit/decorators.js';
-import { LocaleController } from '../../../abstract/controllers/LocaleController';
 import { RouterController } from '../../../abstract/controllers/RouterController';
 import type { ControllerContainer } from '../../../abstract/di/ControllerContainer';
 import { inject } from '../../../abstract/di/inject';
@@ -53,13 +52,6 @@ export class FileUploaderRegular extends SolutionChildBlock {
     this._telemetry.sendEvent({
       eventType: InternalEventType.INIT_SOLUTION,
     });
-  }
-
-  protected override subscriptionsFor(container: ControllerContainer) {
-    // The cancel button's label is rendered through `this.l10n(...)` — re-render
-    // when the dictionary loads or the locale switches (same convention as every
-    // other l10n-rendering ChildBlock, e.g. SimpleBtn/UploadList).
-    return [(listener: () => void) => container.get(LocaleController).subscribe(listener)];
   }
 
   /**

--- a/tests/blocks/child-block.e2e.test.tsx
+++ b/tests/blocks/child-block.e2e.test.tsx
@@ -2,7 +2,6 @@ import { html } from 'lit';
 import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
 import { page } from 'vitest/browser';
 import { ConfigController } from '@/abstract/controllers/ConfigController';
-import { LocaleController } from '@/abstract/controllers/LocaleController';
 import { RouterController } from '@/abstract/controllers/RouterController';
 import { ControllerContainer } from '@/abstract/di/ControllerContainer';
 import { UploaderRegistry } from '@/abstract/UploaderRegistry';
@@ -29,13 +28,6 @@ class TestChildBlock extends ChildBlock {
     return this.useOrNull(RouterController);
   }
 
-  protected override subscriptionsFor(container: ControllerContainer) {
-    return [
-      (listener: () => void) => container.get(ConfigController).subscribe(listener),
-      (listener: () => void) => container.get(LocaleController).subscribe(listener),
-    ];
-  }
-
   protected override controllerReady(): void {
     if (this.throwInReady) {
       throw new Error('boom in controllerReady');
@@ -56,7 +48,7 @@ class TestChildBlock extends ChildBlock {
   }
 
   public override render() {
-    return html`<span class="pk">${this.useOrNull(ConfigController)?.get('pubkey') ?? ''}</span
+    return html`<span class="pk">${this.useOrNull(ConfigController)?.getTracked('pubkey') ?? ''}</span
       ><span class="l10n">${this.l10n('upload-file')}</span
       ><span class="inner" data-testid="inner"></span>`;
   }
@@ -144,7 +136,7 @@ describe('ChildBlock', () => {
     expect(containerOf(ctxName)).toBe(container);
   });
 
-  it('re-renders on controller change notifications (subscriptionsFor)', async () => {
+  it('re-renders on controller change notifications (getTracked)', async () => {
     const ctxName = getCtxName();
     page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
     const child = append('test-child-block', { 'ctx-name': ctxName });


### PR DESCRIPTION
## v2: l10n reactive via `getTracked`; delete `subscriptionsFor` + its 13 overrides (9e-3)

Follow-up to the god-object decomposition. Blocks used to re-render on a locale change by declaring a `subscriptionsFor` override that explicitly subscribed to `LocaleController` and called `requestUpdate`. Now that `ChildBlock` is a `SignalWatcher` and `LocaleController` exposes a per-key `getTracked`, that subscription is redundant: making `l10n(key)` a tracked read means every block that renders l10n text auto-re-renders on the exact keys it reads. Behavior-preserving; documented public API unchanged.

### Change
- **`createL10n`** now looks keys up via `LocaleController.getTracked(str)` (was `.get(str)`). Called inside a `SignalWatcher` render, each `l10n(key)` auto-tracks that locale key and re-renders when the dictionary loads or the locale switches — more granular than the old blanket "any locale change → requestUpdate". Outside a watcher (e.g. `api.l10n(...)`) `getTracked` is a plain read, so non-reactive callers are unaffected.
- **Deleted** the `subscriptionsFor` base method + the `_adoptController` loop that wired it, and **all 13 identical locale-only overrides** (SourceBtn, SimpleBtn, PrimaryAction, UploadList, FileItem, UrlSource, ExternalSource, FileActionButton, CameraSource, DropArea, FileUploader{Regular,Minimal,Inline}). The `_syncTestId` config subscription is kept.
- Per-file unused-import cleanup (`LocaleController`/`ControllerContainer` where no longer referenced).

### Why it's safe (verified per block)
All 13 overrides were identical and locale-only. Every one of those blocks reads its user-facing l10n inside `render()`/`willUpdate()` (or a getter invoked during render), so the tracked read re-establishes the dependency on each render and a locale change re-fires it. The couple of imperative l10n reads (e.g. `FileItem._itemName`'s `file-no-name` fallback, camera device labels) were never render-reactive even under `subscriptionsFor` — they're only recomputed in their own handlers — so nothing regresses.

### Tests
- New `SimpleBtn.test.ts` case: render → `container.get(LocaleController).set('upload-file', 'CUSTOM')` (no subscription registered) → asserts the button text updates — proving reactivity flows through `getTracked` alone.
- `child-block.e2e.test.tsx`'s `TestChildBlock` (which had its own `subscriptionsFor` purely to make a `.get()` render read reactive) switched to a `.getTracked()` render read; the existing "re-renders on controller change" test now verifies the real replacement mechanism.

### Not included (separate follow-up)
The centralized logger (replacing `createDebugPrinter`/`deps.debug` threading) is a distinct piece and will come with its own design.

### Verification
Full green gate on HEAD:
- `tsc:app` ✅
- `build` ✅ (attw/publint/size-limit) — editor bundle **47.77 kB / 50 kB**
- `test:specs` ✅ **1014 passed** (103 files)
- `test:locales` ✅
- `test:e2e` ✅ **384 passed** (54 files)
- `lint` ✅ 0 errors (4 pre-existing warnings, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
