### PR TITLE
refactor(store): unify keyed reactive stores behind ReactiveStore + SignalMap

### DIFF
--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TypedData } from './TypedData';
 
-describe('TypedData (legacy aliases)', () => {
+describe('TypedData (ReactiveStore)', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
+
+  const make = () => new TypedData<{ a: number; b: string }>({ a: 0, b: '' });
 
   it('creates a unique uid and is discoverable via the registry', () => {
     const ctx1 = new TypedData<{ a: number }>({ a: 1 });
@@ -22,125 +24,12 @@ describe('TypedData (legacy aliases)', () => {
     ctx2.destroy();
   });
 
-  it('snapshot() returns the full current field object', () => {
-    const ctx = new TypedData<{ a: number; b: string }>({ a: 1, b: 'x' });
-    expect(ctx.snapshot()).toEqual({ a: 1, b: 'x' });
-    ctx.setValue('a', 2);
-    expect(ctx.snapshot().a).toBe(2);
-    ctx.destroy();
-  });
-
-  it('getValue/setValue read and update values; setValue only notifies when changed', () => {
-    const ctx = new TypedData<{ a: number }>({ a: 1 });
-
-    expect(ctx.getValue('a')).toBe(1);
-
-    const handler = vi.fn();
-    // Old per-key `subscribe(prop, handler)` immediate-fire semantics now live
-    // in `observe(key, handler, { immediate: true })`.
-    ctx.observe('a', handler, { immediate: true });
-
-    // observe fires the initial value immediately (parity with the previous
-    // PubSub.sub(..., init=true) behavior).
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenLastCalledWith(1);
-    handler.mockClear();
-
-    // Same value => no notify.
-    ctx.setValue('a', 1);
-    expect(handler).not.toHaveBeenCalled();
-
-    // Changed value => notify.
-    ctx.setValue('a', 2);
-    expect(ctx.getValue('a')).toBe(2);
-    expect(handler).toHaveBeenCalledTimes(1);
-    expect(handler).toHaveBeenLastCalledWith(2);
-
-    ctx.destroy();
-  });
-
-  it('unsubscribe stops notifications', () => {
-    const ctx = new TypedData<{ a: number }>({ a: 1 });
-    const handler = vi.fn();
-    const off = ctx.observe('a', handler, { immediate: true });
-    handler.mockClear();
-    off();
-
-    ctx.setValue('a', 2);
-    expect(handler).not.toHaveBeenCalled();
-    ctx.destroy();
-  });
-
-  it('only notifies subscribers of the changed property (per-key)', () => {
-    const ctx = new TypedData<{ a: number; b: number }>({ a: 1, b: 1 });
-    const onA = vi.fn();
-    const onB = vi.fn();
-    ctx.observe('a', onA, { immediate: true });
-    ctx.observe('b', onB, { immediate: true });
-    onA.mockClear();
-    onB.mockClear();
-
-    ctx.setValue('a', 2);
-    expect(onA).toHaveBeenCalledTimes(1);
-    expect(onB).not.toHaveBeenCalled();
-
-    ctx.destroy();
-  });
-
-  it('isolates a throwing subscriber so other subscribers still run', () => {
-    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const ctx = new TypedData<{ a: number }>({ a: 1 });
-    const bad = vi.fn(() => {
-      throw new Error('boom');
-    });
-    const good = vi.fn();
-    // Registered WITHOUT `{ immediate: true }`: this test isolates a throwing
-    // subscriber during a change NOTIFICATION (the `setValue` below), which is
-    // what `Listeners.notify` isolates. An immediate registration-time fire is
-    // not wrapped in the same isolation, so it's out of scope here.
-    ctx.observe('a', bad);
-    ctx.observe('a', good);
-
-    expect(() => ctx.setValue('a', 2)).not.toThrow();
-    expect(good).toHaveBeenCalledWith(2);
-    expect(warn).toHaveBeenCalled();
-
-    ctx.destroy();
-  });
-
-  it('setMultipleValues updates multiple properties via setValue', () => {
-    const ctx = new TypedData<{ a: number; b: number }>({ a: 1, b: 10 });
-
-    ctx.setMultipleValues({ a: 2, b: 20 });
-
-    expect(ctx.getValue('a')).toBe(2);
-    expect(ctx.getValue('b')).toBe(20);
-
-    ctx.destroy();
-  });
-
-  it('warns and does nothing when setting an unknown property', () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const ctx = new TypedData<{ a: number }>({ a: 1 });
-    // biome-ignore lint/suspicious/noExplicitAny: testing the unknown-key guard
-    ctx.setValue('missing' as any, 123);
-
-    expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0]?.[0]).toBe('[uc][typed-data]');
-    expect(warnSpy.mock.calls[0]?.[1]).toMatch(/\[Typed State\] Wrong property name:/);
-    expect(ctx.getValue('a')).toBe(1);
-
-    ctx.destroy();
-  });
-
-  it('destroy() removes the entry from the registry', () => {
-    const ctx = new TypedData<{ a: number }>({ a: 1 });
-    const id = ctx.uid;
-    expect(TypedData.getByUid(id)).toBe(ctx);
-
-    ctx.destroy();
-    expect(TypedData.getByUid(id)).toBeNull();
+  it('get/set with Object.is dedup', () => {
+    const d = make();
+    expect(d.get('a')).toBe(0);
+    d.set('a', 1);
+    expect(d.get('a')).toBe(1);
+    d.destroy();
   });
 
   it('warns when reading an unknown property and returns undefined', () => {
@@ -148,7 +37,7 @@ describe('TypedData (legacy aliases)', () => {
     const ctx = new TypedData<{ a: number }>({ a: 1 });
 
     // biome-ignore lint/suspicious/noExplicitAny: exercising the unknown-key read guard
-    const value = ctx.getValue('missing' as any);
+    const value = ctx.get('missing' as any);
 
     expect(value).toBeUndefined();
     expect(warn).toHaveBeenCalledWith(
@@ -158,22 +47,6 @@ describe('TypedData (legacy aliases)', () => {
 
     ctx.destroy();
     warn.mockRestore();
-  });
-});
-
-describe('TypedData (ReactiveStore)', () => {
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  const make = () => new TypedData<{ a: number; b: string }>({ a: 0, b: '' });
-
-  it('get/set with Object.is dedup', () => {
-    const d = make();
-    expect(d.get('a')).toBe(0);
-    d.set('a', 1);
-    expect(d.get('a')).toBe(1);
-    d.destroy();
   });
 
   it('setMany applies several keys', () => {
@@ -226,6 +99,58 @@ describe('TypedData (ReactiveStore)', () => {
     d.set('a', 3);
     d.set('b', 'y'); // unrelated
     expect(seen).toEqual([0, 3]);
+    d.destroy();
+  });
+
+  it('observe only notifies when the value actually changes (Object.is dedup)', () => {
+    const d = make();
+    const handler = vi.fn();
+    d.observe('a', handler, { immediate: true });
+    handler.mockClear();
+
+    // Same value => no notify.
+    d.set('a', 0);
+    expect(handler).not.toHaveBeenCalled();
+
+    // Changed value => notify.
+    d.set('a', 2);
+    expect(d.get('a')).toBe(2);
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenLastCalledWith(2);
+
+    d.destroy();
+  });
+
+  it('unobserve (the returned unsubscribe fn) stops notifications', () => {
+    const d = make();
+    const handler = vi.fn();
+    const off = d.observe('a', handler, { immediate: true });
+    handler.mockClear();
+    off();
+
+    d.set('a', 2);
+    expect(handler).not.toHaveBeenCalled();
+    d.destroy();
+  });
+
+  it('isolates a throwing observer so other observers still run', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const d = make();
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+    const good = vi.fn();
+    // Registered WITHOUT `{ immediate: true }`: this isolates a throwing
+    // observer during a change NOTIFICATION (the `set` below), which is what
+    // `Listeners.notify` isolates. An immediate registration-time fire is not
+    // wrapped in the same isolation, so it's out of scope here.
+    d.observe('a', bad);
+    d.observe('a', good);
+
+    expect(() => d.set('a', 2)).not.toThrow();
+    expect(good).toHaveBeenCalledWith(2);
+    expect(warn).toHaveBeenCalled();
+
     d.destroy();
   });
 

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -24,7 +24,7 @@ describe('TypedData (ReactiveStore)', () => {
     ctx2.destroy();
   });
 
-  it('get/set with Object.is dedup', () => {
+  it('get/set round-trip', () => {
     const d = make();
     expect(d.get('a')).toBe(0);
     d.set('a', 1);
@@ -140,15 +140,30 @@ describe('TypedData (ReactiveStore)', () => {
       throw new Error('boom');
     });
     const good = vi.fn();
-    // Registered WITHOUT `{ immediate: true }`: this isolates a throwing
-    // observer during a change NOTIFICATION (the `set` below), which is what
-    // `Listeners.notify` isolates. An immediate registration-time fire is not
-    // wrapped in the same isolation, so it's out of scope here.
+    // Registered WITHOUT `{ immediate: true }`: isolates a throwing observer
+    // during a change NOTIFICATION (the `set` below) — `Listeners.notify`
+    // catches per-listener and warns rather than aborting the fan-out.
     d.observe('a', bad);
     d.observe('a', good);
 
     expect(() => d.set('a', 2)).not.toThrow();
     expect(good).toHaveBeenCalledWith(2);
+    expect(warn).toHaveBeenCalled();
+
+    d.destroy();
+  });
+
+  it('isolates a throwing observer registered with { immediate: true }', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const d = make();
+    const bad = vi.fn(() => {
+      throw new Error('boom');
+    });
+
+    // The immediate registration-time fire is isolated the same way as a
+    // later notification (`Listeners.observe` wraps it in try/catch + warn).
+    expect(() => d.observe('a', bad, { immediate: true })).not.toThrow();
+    expect(bad).toHaveBeenCalledWith(0);
     expect(warn).toHaveBeenCalled();
 
     d.destroy();

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -57,6 +57,18 @@ describe('TypedData (ReactiveStore)', () => {
     d.destroy();
   });
 
+  it('clearing an optional key to undefined is observed (not dropped)', () => {
+    // The behavior FileItemConfig.subEntry relies on: setting a field back to
+    // `undefined` (e.g. a removed thumbUrl/fileName) must reach observers.
+    const d = new TypedData<{ a?: number }>({ a: 5 });
+    const seen: (number | undefined)[] = [];
+    d.observe('a', (v) => seen.push(v)); // no immediate
+    d.set('a', undefined);
+    expect(d.get('a')).toBeUndefined();
+    expect(seen).toEqual([undefined]);
+    d.destroy();
+  });
+
   it('values returns the live bag', () => {
     const d = make();
     d.set('a', 9);

--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { TypedData } from './TypedData';
 
-describe('TypedData', () => {
+describe('TypedData (legacy aliases)', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
@@ -36,9 +36,11 @@ describe('TypedData', () => {
     expect(ctx.getValue('a')).toBe(1);
 
     const handler = vi.fn();
-    ctx.subscribe('a', handler);
+    // Old per-key `subscribe(prop, handler)` immediate-fire semantics now live
+    // in `observe(key, handler, { immediate: true })`.
+    ctx.observe('a', handler, { immediate: true });
 
-    // subscribe emits the initial value immediately (parity with the previous
+    // observe fires the initial value immediately (parity with the previous
     // PubSub.sub(..., init=true) behavior).
     expect(handler).toHaveBeenCalledTimes(1);
     expect(handler).toHaveBeenLastCalledWith(1);
@@ -60,7 +62,7 @@ describe('TypedData', () => {
   it('unsubscribe stops notifications', () => {
     const ctx = new TypedData<{ a: number }>({ a: 1 });
     const handler = vi.fn();
-    const off = ctx.subscribe('a', handler);
+    const off = ctx.observe('a', handler, { immediate: true });
     handler.mockClear();
     off();
 
@@ -73,8 +75,8 @@ describe('TypedData', () => {
     const ctx = new TypedData<{ a: number; b: number }>({ a: 1, b: 1 });
     const onA = vi.fn();
     const onB = vi.fn();
-    ctx.subscribe('a', onA);
-    ctx.subscribe('b', onB);
+    ctx.observe('a', onA, { immediate: true });
+    ctx.observe('b', onB, { immediate: true });
     onA.mockClear();
     onB.mockClear();
 
@@ -92,10 +94,12 @@ describe('TypedData', () => {
       throw new Error('boom');
     });
     const good = vi.fn();
-    ctx.subscribe('a', bad);
-    ctx.subscribe('a', good);
-    bad.mockClear();
-    good.mockClear();
+    // Registered WITHOUT `{ immediate: true }`: this test isolates a throwing
+    // subscriber during a change NOTIFICATION (the `setValue` below), which is
+    // what `Listeners.notify` isolates. An immediate registration-time fire is
+    // not wrapped in the same isolation, so it's out of scope here.
+    ctx.observe('a', bad);
+    ctx.observe('a', good);
 
     expect(() => ctx.setValue('a', 2)).not.toThrow();
     expect(good).toHaveBeenCalledWith(2);
@@ -154,5 +158,104 @@ describe('TypedData', () => {
 
     ctx.destroy();
     warn.mockRestore();
+  });
+});
+
+describe('TypedData (ReactiveStore)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const make = () => new TypedData<{ a: number; b: string }>({ a: 0, b: '' });
+
+  it('get/set with Object.is dedup', () => {
+    const d = make();
+    expect(d.get('a')).toBe(0);
+    d.set('a', 1);
+    expect(d.get('a')).toBe(1);
+    d.destroy();
+  });
+
+  it('setMany applies several keys', () => {
+    const d = make();
+    d.setMany({ a: 2, b: 'x' });
+    expect(d.get('a')).toBe(2);
+    expect(d.get('b')).toBe('x');
+    d.destroy();
+  });
+
+  it('values returns the live bag', () => {
+    const d = make();
+    d.set('a', 9);
+    expect(d.values.a).toBe(9);
+    d.destroy();
+  });
+
+  it('getTracked reads the current value', () => {
+    const d = make();
+    expect(d.getTracked('a')).toBe(0);
+    d.set('a', 5);
+    expect(d.getTracked('a')).toBe(5);
+    d.destroy();
+  });
+
+  it('subscribe fires coarsely on any key change', () => {
+    const d = make();
+    const listener = vi.fn();
+    d.subscribe(listener);
+    d.set('a', 1);
+    expect(listener).toHaveBeenCalledTimes(1);
+    d.set('b', 'y');
+    expect(listener).toHaveBeenCalledTimes(2);
+    d.destroy();
+  });
+
+  it('notify() forces a coarse notification with no state change', () => {
+    const d = make();
+    const listener = vi.fn();
+    d.subscribe(listener);
+    d.notify();
+    expect(listener).toHaveBeenCalledTimes(1);
+    d.destroy();
+  });
+
+  it('observe fires immediately then per-key', () => {
+    const d = make();
+    const seen: (number | undefined)[] = [];
+    d.observe('a', (v) => seen.push(v), { immediate: true });
+    d.set('a', 3);
+    d.set('b', 'y'); // unrelated
+    expect(seen).toEqual([0, 3]);
+    d.destroy();
+  });
+
+  it('warns and skips an unknown key on set', () => {
+    const d = make();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // @ts-expect-error unknown key
+    d.set('nope', 1);
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    expect('nope' in d.values).toBe(false);
+    d.destroy();
+  });
+
+  it('warns and skips an unknown key on setMany, but still applies known keys', () => {
+    const d = make();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    // @ts-expect-error unknown key mixed with a known one
+    d.setMany({ a: 7, nope: 1 });
+    expect(warn).toHaveBeenCalled();
+    warn.mockRestore();
+    expect(d.get('a')).toBe(7);
+    expect('nope' in d.values).toBe(false);
+    d.destroy();
+  });
+
+  it('getByUid returns the entry until destroyed', () => {
+    const d = make();
+    expect(TypedData.getByUid(d.uid)).toBe(d);
+    d.destroy();
+    expect(TypedData.getByUid(d.uid)).toBeNull();
   });
 });

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -21,11 +21,8 @@ const MSG_NAME = '[Typed State] Wrong property name: ';
  * collection defers `destroy()` ~10s after removal, `getByUid` keeps
  * returning a removed entry's data during that window, exactly as before.
  *
- * `getValue`/`setValue`/`setMultipleValues`/`snapshot` remain as temporary
- * `@deprecated` aliases over `get`/`set`/`setMany`/`values` — a migration
- * scaffold for existing callers, removed once they're ported to the
- * canonical names. The old immediate per-key `subscribe(prop, handler)` has
- * no alias: it maps to `observe(key, handler, { immediate: true })`.
+ * The old immediate per-key `subscribe(prop, handler)` form has been removed;
+ * callers use `observe(key, handler, { immediate: true })` instead.
  */
 export class TypedData<T extends Record<string, unknown>> implements ReactiveStore<T> {
   private static _registry = new Map<string, TypedData<Record<string, unknown>>>();
@@ -84,14 +81,8 @@ export class TypedData<T extends Record<string, unknown>> implements ReactiveSto
     this.#store.setMany(known);
   }
 
-  /** @deprecated use `observe(key, handler, { immediate: true })` — the old per-key immediate-fire form. */
-  public subscribe<K extends keyof T>(key: K, handler: (value: T[K]) => void): () => void;
-  public subscribe(listener: () => void): () => void;
-  public subscribe<K extends keyof T>(keyOrListener: K | (() => void), handler?: (value: T[K]) => void): () => void {
-    if (handler) {
-      return this.observe(keyOrListener as K, handler as (value: T[K] | undefined) => void, { immediate: true });
-    }
-    return this.#store.subscribe(keyOrListener as () => void);
+  public subscribe(listener: () => void): () => void {
+    return this.#store.subscribe(listener);
   }
 
   public observe<K extends keyof T>(
@@ -109,23 +100,5 @@ export class TypedData<T extends Record<string, unknown>> implements ReactiveSto
   public destroy(): void {
     TypedData._registry.delete(this._uid);
     this.#store.destroy();
-  }
-
-  // ── Deprecated aliases (removed in the follow-up rename task) ──
-  /** @deprecated use `values` */
-  public snapshot(): Readonly<T> {
-    return this.values;
-  }
-  /** @deprecated use `get` */
-  public getValue<K extends keyof T>(key: K): T[K] {
-    return this.get(key);
-  }
-  /** @deprecated use `set` */
-  public setValue<K extends keyof T>(key: K, value: T[K]): void {
-    this.set(key, value);
-  }
-  /** @deprecated use `setMany` */
-  public setMultipleValues(patch: Partial<T>): void {
-    this.setMany(patch);
   }
 }

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -50,14 +50,20 @@ export class TypedData<T extends Record<string, unknown>> implements ReactiveSto
     return this.#store.values;
   }
 
-  public get<K extends keyof T>(key: K): T[K] {
+  /** Shared has-check-and-warn for an unknown key, used by both `get` and `getTracked`. */
+  #read<K extends keyof T>(key: K): void {
     if (!this.#store.has(key)) {
       log.warn(`${MSG_NAME}${String(key)}`);
     }
+  }
+
+  public get<K extends keyof T>(key: K): T[K] {
+    this.#read(key);
     return this.#store.get(key) as T[K];
   }
 
   public getTracked<K extends keyof T>(key: K): T[K] {
+    this.#read(key);
     return this.#store.getTracked(key) as T[K];
   }
 

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -1,40 +1,42 @@
 import type { Uid } from '../lit/Uid';
 import { UID } from '../utils/UID';
+import type { ReactiveStore } from './di/ReactiveStore';
+import { SignalMap } from './di/SignalMap';
+import type { ObserveOptions } from './host-subscription';
 import { logger } from './logger';
 
 const log = logger.scope('typed-data');
-
 const MSG_NAME = '[Typed State] Wrong property name: ';
 
 /**
  * Per-entry reactive store. Each upload entry is one `TypedData`.
  *
- * As of the v1 → v2 strangler (M3a) this is self-contained — a plain
- * null-prototype field object plus per-key listener sets — rather than a
- * per-ctx store `PubSub` context per entry. A module-level registry keyed by the
- * entry's `uid` replaces the old `PubSub.getCtx(uid)` lookup that hot paths
- * (`getOutputItem`, event emission) used to read entry state by id; because
- * the collection defers `destroy()` ~10s after removal, `getByUid` keeps
- * returning a removed entry's data during that window, exactly as the old
- * per-entry context did.
+ * Composes a `SignalMap` (the same keyed reactive store backing
+ * `ConfigController`/`LocaleController`) rather than hand-rolling its own
+ * per-key `Set` bookkeeping, so it gets the canonical `ReactiveStore<T>`
+ * surface (`get`/`set`/`setMany`/`values`/`subscribe`/`observe`/`getTracked`/
+ * `notify`/`destroy`) — plus this class's own module-level `uid` registry,
+ * which replaces the old per-entry `PubSub.getCtx(uid)` lookup that hot paths
+ * (`getOutputItem`, event emission) use to read entry state by id. Because the
+ * collection defers `destroy()` ~10s after removal, `getByUid` keeps
+ * returning a removed entry's data during that window, exactly as before.
  *
- * Public API (`uid`, `getValue`, `setValue`, `setMultipleValues`, `subscribe`,
- * `destroy`) is unchanged, so the collection and all consumers are
- * untouched. `subscribe` fires immediately with the current value, matching
- * the previous `PubSub.sub(..., init=true)` behavior.
+ * `getValue`/`setValue`/`setMultipleValues`/`snapshot` remain as temporary
+ * `@deprecated` aliases over `get`/`set`/`setMany`/`values` — a migration
+ * scaffold for existing callers, removed once they're ported to the
+ * canonical names. The old immediate per-key `subscribe(prop, handler)` has
+ * no alias: it maps to `observe(key, handler, { immediate: true })`.
  */
-export class TypedData<T extends Record<string, unknown>> {
+export class TypedData<T extends Record<string, unknown>> implements ReactiveStore<T> {
   private static _registry = new Map<string, TypedData<Record<string, unknown>>>();
 
-  private _ctxId: Uid;
-  private _data: T;
-  private _subs = new Map<keyof T, Set<(value: unknown) => void>>();
+  private _uid: Uid;
+  #store: SignalMap<T>;
 
   public constructor(initialValue: T) {
-    this._ctxId = UID.generateFastUid();
-    // Null-prototype so a field name like `__proto__` can't touch the chain.
-    this._data = Object.assign(Object.create(null), initialValue);
-    TypedData._registry.set(this._ctxId, this as unknown as TypedData<Record<string, unknown>>);
+    this._uid = UID.generateFastUid();
+    this.#store = new SignalMap<T>(initialValue);
+    TypedData._registry.set(this._uid, this as unknown as TypedData<Record<string, unknown>>);
   }
 
   /** Look up a live entry store by its uid (returns removed-but-not-yet-destroyed entries too). */
@@ -43,74 +45,87 @@ export class TypedData<T extends Record<string, unknown>> {
   }
 
   public get uid(): Uid {
-    return this._ctxId;
+    return this._uid;
   }
 
-  /** Full current field object — the replacement for the old `PubSub#store`. */
-  public snapshot(): Readonly<T> {
-    return this._data;
+  /** Live field object — the former `snapshot()`. */
+  public get values(): Readonly<T> {
+    return this.#store.values;
   }
 
-  public setValue<K extends keyof T>(prop: K, value: T[K]): void {
-    if (!Object.hasOwn(this._data, prop as PropertyKey)) {
-      log.warn(`${MSG_NAME}${String(prop)}`);
+  public get<K extends keyof T>(key: K): T[K] {
+    if (!this.#store.has(key)) {
+      log.warn(`${MSG_NAME}${String(key)}`);
+    }
+    return this.#store.get(key) as T[K];
+  }
+
+  public getTracked<K extends keyof T>(key: K): T[K] {
+    return this.#store.getTracked(key) as T[K];
+  }
+
+  public set<K extends keyof T>(key: K, value: T[K]): void {
+    if (!this.#store.has(key)) {
+      log.warn(`${MSG_NAME}${String(key)}`);
       return;
     }
-    if (this._data[prop] === value) {
-      return;
-    }
-    this._data[prop] = value;
-    const set = this._subs.get(prop);
-    if (set) {
-      // Isolate each subscriber so one that throws can't abort notification of
-      // the rest — notably the collection watch-list observer, whose
-      // failure to run would stall collection/event updates. Matches the
-      // fan-out semantics of `Listeners.notify` / `EventBus.emit`.
-      for (const handler of [...set]) this._emit(prop, handler, value);
-    }
+    this.#store.set(key, value);
   }
 
-  /** Invoke a subscriber, isolating (and logging) any error it throws. */
-  private _emit(prop: keyof T, handler: (value: unknown) => void, value: unknown): void {
-    try {
-      handler(value);
-    } catch (err) {
-      log.warn(`subscriber for "${String(prop)}" threw`, err);
+  public setMany(patch: Partial<T>): void {
+    const known: Partial<T> = {};
+    for (const key of Object.keys(patch) as (keyof T)[]) {
+      if (!this.#store.has(key)) {
+        log.warn(`${MSG_NAME}${String(key)}`);
+        continue;
+      }
+      known[key] = patch[key];
     }
+    this.#store.setMany(known);
   }
 
-  public setMultipleValues(updObj: Partial<T>): void {
-    for (const [prop, value] of Object.entries(updObj)) {
-      this.setValue(prop as keyof T, value as T[keyof T]);
+  /** @deprecated use `observe(key, handler, { immediate: true })` — the old per-key immediate-fire form. */
+  public subscribe<K extends keyof T>(key: K, handler: (value: T[K]) => void): () => void;
+  public subscribe(listener: () => void): () => void;
+  public subscribe<K extends keyof T>(keyOrListener: K | (() => void), handler?: (value: T[K]) => void): () => void {
+    if (handler) {
+      return this.observe(keyOrListener as K, handler as (value: T[K] | undefined) => void, { immediate: true });
     }
+    return this.#store.subscribe(keyOrListener as () => void);
   }
 
-  public getValue<K extends keyof T>(prop: K): T[K] {
-    if (!Object.hasOwn(this._data, prop as PropertyKey)) {
-      log.warn(`${MSG_NAME}${String(prop)}`);
-    }
-    return this._data[prop];
+  public observe<K extends keyof T>(
+    key: K,
+    listener: (value: T[K] | undefined) => void,
+    options?: ObserveOptions,
+  ): () => void {
+    return this.#store.observe(key, listener, options);
   }
 
-  public subscribe<K extends keyof T>(prop: K, handler: (newVal: T[K]) => void): () => void {
-    let set = this._subs.get(prop);
-    if (!set) {
-      set = new Set();
-      this._subs.set(prop, set);
-    }
-    const wrapped = handler as (value: unknown) => void;
-    set.add(wrapped);
-    // Fire immediately with the current value (parity with the previous
-    // `PubSub.sub(..., init=true)` subscription semantics), isolated like the
-    // notify path so a throwing subscriber can't break the subscribe call.
-    this._emit(prop, wrapped, this._data[prop]);
-    return () => {
-      set?.delete(wrapped);
-    };
+  public notify(): void {
+    this.#store.notify();
   }
 
   public destroy(): void {
-    TypedData._registry.delete(this._ctxId);
-    this._subs.clear();
+    TypedData._registry.delete(this._uid);
+    this.#store.destroy();
+  }
+
+  // ── Deprecated aliases (removed in the follow-up rename task) ──
+  /** @deprecated use `values` */
+  public snapshot(): Readonly<T> {
+    return this.values;
+  }
+  /** @deprecated use `get` */
+  public getValue<K extends keyof T>(key: K): T[K] {
+    return this.get(key);
+  }
+  /** @deprecated use `set` */
+  public setValue<K extends keyof T>(key: K, value: T[K]): void {
+    this.set(key, value);
+  }
+  /** @deprecated use `setMany` */
+  public setMultipleValues(patch: Partial<T>): void {
+    this.setMany(patch);
   }
 }

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -228,12 +228,12 @@ export class UploaderPublicApi {
       const entry = this._uploadCollection.read(id);
       if (!entry) return false;
       return (
-        !entry.getValue('isRemoved') &&
-        !entry.getValue('isUploading') &&
-        !entry.getValue('fileInfo') &&
-        entry.getValue('errors').length === 0 &&
-        !entry.getValue('isValidationPending') &&
-        !entry.getValue('isQueuedForValidation')
+        !entry.get('isRemoved') &&
+        !entry.get('isUploading') &&
+        !entry.get('fileInfo') &&
+        entry.get('errors').length === 0 &&
+        !entry.get('isValidationPending') &&
+        !entry.get('isQueuedForValidation')
       );
     });
 
@@ -324,7 +324,7 @@ export class UploaderPublicApi {
     if (!entry) {
       throw new Error(`UploaderPublicApi#getOutputItem: Entry with ID "${entryId}" not found in the upload collection`);
     }
-    const uploadEntryData = entry.snapshot();
+    const uploadEntryData = entry.values;
     const fileInfo = uploadEntryData.fileInfo as UploadcareFile | null;
 
     const status: OutputFileEntry['status'] = uploadEntryData.isRemoved

--- a/src/abstract/applyInitialCrop.test.ts
+++ b/src/abstract/applyInitialCrop.test.ts
@@ -40,8 +40,8 @@ describe('applyInitialCrop', () => {
 
     // A rejected preset must not fall through to the 1:1 default crop.
     const entry = collection.read(id);
-    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
-    expect(entry?.getValue('cdnUrl')).toBe(cdnUrl);
+    expect(entry?.get('cdnUrlModifiers')).toBeNull();
+    expect(entry?.get('cdnUrl')).toBe(cdnUrl);
   });
 
   it('applies a centered crop modifier + rewritten cdnUrl to an image entry without an existing crop modifier', () => {
@@ -56,12 +56,12 @@ describe('applyInitialCrop', () => {
     applyInitialCrop(collection, '4:3');
 
     const entry = collection.read(id);
-    const cdnUrlModifiers = entry?.getValue('cdnUrlModifiers');
+    const cdnUrlModifiers = entry?.get('cdnUrlModifiers');
     expect(cdnUrlModifiers).toContain('crop/');
     expect(cdnUrlModifiers).toContain('-/preview/');
     // 800x600 at a 4:3 aspect ratio is already 4:3 — full-frame centered crop.
     expect(cdnUrlModifiers).toContain('crop/800x600/0,0');
-    expect(entry?.getValue('cdnUrl')).toBe(createCdnUrl(cdnUrl, cdnUrlModifiers ?? undefined));
+    expect(entry?.get('cdnUrl')).toBe(createCdnUrl(cdnUrl, cdnUrlModifiers ?? undefined));
   });
 
   it('skips entries that already have /crop/ in cdnUrlModifiers (values unchanged)', () => {
@@ -77,8 +77,8 @@ describe('applyInitialCrop', () => {
     applyInitialCrop(collection, '4:3');
 
     const entry = collection.read(id);
-    expect(entry?.getValue('cdnUrlModifiers')).toBe(existingModifiers);
-    expect(entry?.getValue('cdnUrl')).toBe(cdnUrl);
+    expect(entry?.get('cdnUrlModifiers')).toBe(existingModifiers);
+    expect(entry?.get('cdnUrl')).toBe(cdnUrl);
   });
 
   it('skips non-image entries and entries without fileInfo', () => {
@@ -97,8 +97,8 @@ describe('applyInitialCrop', () => {
 
     applyInitialCrop(collection, '4:3');
 
-    expect(collection.read(nonImageId)?.getValue('cdnUrlModifiers')).toBeNull();
-    expect(collection.read(noFileInfoId)?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(collection.read(nonImageId)?.get('cdnUrlModifiers')).toBeNull();
+    expect(collection.read(noFileInfoId)?.get('cdnUrlModifiers')).toBeNull();
   });
 
   it('warns + skips when fileInfo.imageInfo is missing', () => {
@@ -113,7 +113,7 @@ describe('applyInitialCrop', () => {
     applyInitialCrop(collection, '4:3');
 
     const entry = collection.read(id);
-    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(entry?.get('cdnUrlModifiers')).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith('[uc][initial-crop]', 'Failed to get image info for entry', entry?.uid);
 
     warnSpy.mockRestore();
@@ -131,7 +131,7 @@ describe('applyInitialCrop', () => {
     applyInitialCrop(collection, '4:3');
 
     const entry = collection.read(id);
-    expect(entry?.getValue('cdnUrlModifiers')).toBeNull();
+    expect(entry?.get('cdnUrlModifiers')).toBeNull();
     expect(warnSpy).toHaveBeenCalledWith('[uc][initial-crop]', 'Failed to get cdnUrl for entry', entry?.uid);
 
     warnSpy.mockRestore();
@@ -152,7 +152,7 @@ describe('applyInitialCrop', () => {
     applyInitialCrop(collection, 'free');
 
     const entry = collection.read(id);
-    const cdnUrlModifiers = entry?.getValue('cdnUrlModifiers');
+    const cdnUrlModifiers = entry?.get('cdnUrlModifiers');
     // A 500x500 source at aspect ratio 1 crops to the full square: 500x500 at 0,0.
     expect(cdnUrlModifiers).toContain('crop/500x500/0,0');
   });

--- a/src/abstract/applyInitialCrop.ts
+++ b/src/abstract/applyInitialCrop.ts
@@ -24,16 +24,13 @@ export function applyInitialCrop(collection: UploadCollectionController, cropPre
   const [aspectRatioPreset] = parsed;
   const entries = collection
     .findItems(
-      (entry) =>
-        !!entry.getValue('fileInfo') &&
-        entry.getValue('isImage') &&
-        !entry.getValue('cdnUrlModifiers')?.includes('/crop/'),
+      (entry) => !!entry.get('fileInfo') && entry.get('isImage') && !entry.get('cdnUrlModifiers')?.includes('/crop/'),
     )
     .map((id) => collection.read(id))
     .filter(Boolean);
 
   for (const entry of entries) {
-    const fileInfo = entry.getValue('fileInfo');
+    const fileInfo = entry.get('fileInfo');
     if (!fileInfo || !fileInfo.imageInfo) {
       log.warn('Failed to get image info for entry', entry.uid);
       continue;
@@ -49,12 +46,12 @@ export function applyInitialCrop(collection: UploadCollectionController, cropPre
 
     const crop = calculateMaxCenteredCropFrame(width, height, expectedAspectRatio);
     const cdnUrlModifiers = createCdnUrlModifiers(`crop/${crop.width}x${crop.height}/${crop.x},${crop.y}`, 'preview');
-    const cdnUrl = entry.getValue('cdnUrl');
+    const cdnUrl = entry.get('cdnUrl');
     if (!cdnUrl) {
       log.warn('Failed to get cdnUrl for entry', entry.uid);
       continue;
     }
-    entry.setMultipleValues({
+    entry.setMany({
       cdnUrlModifiers,
       cdnUrl: createCdnUrl(cdnUrl, cdnUrlModifiers),
     });

--- a/src/abstract/controllers/CollectionStateController.test.ts
+++ b/src/abstract/controllers/CollectionStateController.test.ts
@@ -101,11 +101,14 @@ describe('CollectionStateController', () => {
     expect(cb).not.toHaveBeenCalled();
   });
 
-  it('setMany applies several keys with one coalesced notify', () => {
+  it('setMany coalesces multiple genuinely-changed keys into one notify', () => {
     const c = new CollectionStateController();
     const listener = vi.fn();
     c.subscribe(listener);
-    c.setMany({ commonProgress: 50, groupInfo: null });
+    // Two keys that ACTUALLY change: commonProgress (0 -> 50) and a fresh
+    // collectionErrors array reference (Object.is-distinct from the seeded []).
+    // Without coalescing this would notify twice; with it, exactly once.
+    c.setMany({ commonProgress: 50, collectionErrors: [] });
     expect(c.get('commonProgress')).toBe(50);
     expect(listener).toHaveBeenCalledTimes(1);
   });

--- a/src/abstract/controllers/CollectionStateController.test.ts
+++ b/src/abstract/controllers/CollectionStateController.test.ts
@@ -100,4 +100,13 @@ describe('CollectionStateController', () => {
     c.set('commonProgress', 99);
     expect(cb).not.toHaveBeenCalled();
   });
+
+  it('setMany applies several keys with one coalesced notify', () => {
+    const c = new CollectionStateController();
+    const listener = vi.fn();
+    c.subscribe(listener);
+    c.setMany({ commonProgress: 50, groupInfo: null });
+    expect(c.get('commonProgress')).toBe(50);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/abstract/controllers/CollectionStateController.ts
+++ b/src/abstract/controllers/CollectionStateController.ts
@@ -1,6 +1,7 @@
 import type { UploadcareGroup } from '@uploadcare/upload-client';
 import type { Uid } from '../../lit/Uid';
 import type { OutputCollectionState, OutputErrorCollection } from '../../types';
+import type { ReactiveStore } from '../di/ReactiveStore';
 import { type ObserveOptions, SignalMap } from '../di/SignalMap';
 
 /**
@@ -38,7 +39,7 @@ export type CollectionState = {
  * once per construction) so the mutable seeds — the `uploadList`/`collectionErrors`
  * arrays — are never shared across ctxs.
  */
-export class CollectionStateController {
+export class CollectionStateController implements ReactiveStore<CollectionState> {
   #state = new SignalMap<CollectionState>({
     uploadList: [],
     commonProgress: 0,
@@ -72,6 +73,20 @@ export class CollectionStateController {
   /** `Object.is` dedup — a replaced reference fires; mutating a held value in place does not (v1 parity). */
   public set<K extends keyof CollectionState>(key: K, value: CollectionState[K]): void {
     this.#state.set(key, value);
+  }
+
+  /** Batch set collection-state keys — one coalesced notify. */
+  public setMany(patch: Partial<CollectionState>): void {
+    this.#state.setMany(patch);
+  }
+
+  public notify(): void {
+    this.#state.notify();
+  }
+
+  /** The live value bag (a stable reference, mutated in place on write). */
+  public get values(): Readonly<CollectionState> {
+    return this.#state.values;
   }
 
   /** Coarse subscribe — fires on any collection-state change, not per-key. */

--- a/src/abstract/controllers/CollectionStateController.ts
+++ b/src/abstract/controllers/CollectionStateController.ts
@@ -67,7 +67,7 @@ export class CollectionStateController implements ReactiveStore<CollectionState>
    * only during the strangler migration.
    */
   public getTracked<K extends keyof CollectionState>(key: K): CollectionState[K] {
-    return this.#state.signal(key).get() as CollectionState[K];
+    return this.#state.getTracked(key) as CollectionState[K];
   }
 
   /** `Object.is` dedup — a replaced reference fires; mutating a held value in place does not (v1 parity). */

--- a/src/abstract/controllers/ConfigController.test.ts
+++ b/src/abstract/controllers/ConfigController.test.ts
@@ -173,4 +173,14 @@ describe('ConfigController', () => {
     config.setCustom('unsplashApiKey', 'w'); // changed → notify
     expect(listener).toHaveBeenCalledTimes(1);
   });
+
+  it('setMany applies several keys with one coalesced notify', () => {
+    const c = new ConfigController();
+    const listener = vi.fn();
+    c.subscribe(listener);
+    c.setMany({ multiple: true, imgOnly: true });
+    expect(c.get('multiple')).toBe(true);
+    expect(c.get('imgOnly')).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -1,6 +1,7 @@
 import type { CustomConfigDefinition } from '../../abstract/customConfigOptions';
 import { initialConfig } from '../../blocks/Config/initialConfig';
 import type { ConfigType } from '../../types/exported';
+import type { ReactiveStore } from '../di/ReactiveStore';
 import { type ObserveOptions, SignalMap } from '../di/SignalMap';
 
 /**
@@ -25,7 +26,7 @@ import { type ObserveOptions, SignalMap } from '../di/SignalMap';
  * the v1 ctx facade `*cfg/` routing depends on. The map is typed over `ConfigType`
  * intersected with a string index so runtime custom keys type cleanly.
  */
-export class ConfigController {
+export class ConfigController implements ReactiveStore<ConfigType> {
   // Signal-backed store, seeded with the built-in defaults. The `Record<string,
   // unknown>` arm models the dynamic plugin-registered keyspace so custom-key
   // access needs no per-call cast.
@@ -63,6 +64,11 @@ export class ConfigController {
   /** Notifies only when the value actually changes (`Object.is` dedup). */
   public set<K extends keyof ConfigType>(key: K, value: ConfigType[K]): void {
     this.#state.set(key, value);
+  }
+
+  /** Batch set built-in keys — one coalesced notify (see `SignalMap.setMany`). */
+  public setMany(patch: Partial<ConfigType>): void {
+    this.#state.setMany(patch);
   }
 
   /** Coarse subscribe — fires on any config change, not per-key. */

--- a/src/abstract/controllers/ConfigController.ts
+++ b/src/abstract/controllers/ConfigController.ts
@@ -58,7 +58,7 @@ export class ConfigController implements ReactiveStore<ConfigType> {
    * tracked reader, `get()` can route through the signal and this splits away.
    */
   public getTracked<K extends keyof ConfigType>(key: K): ConfigType[K] {
-    return this.#state.signal(key).get() as ConfigType[K];
+    return this.#state.getTracked(key) as ConfigType[K];
   }
 
   /** Notifies only when the value actually changes (`Object.is` dedup). */

--- a/src/abstract/controllers/LocaleController.test.ts
+++ b/src/abstract/controllers/LocaleController.test.ts
@@ -1,93 +1,24 @@
-import { computed } from '@lit-labs/signals';
 import { describe, expect, it, vi } from 'vitest';
 import { LocaleController } from './LocaleController';
 
-describe('LocaleController', () => {
-  it('starts empty and stores values', () => {
-    const locale = new LocaleController();
-    expect(locale.has('upload')).toBe(false);
-    expect(locale.get('upload')).toBeUndefined();
-
-    locale.set('upload', 'Upload');
-    expect(locale.has('upload')).toBe(true);
-    expect(locale.get('upload')).toBe('Upload');
+describe('LocaleController ReactiveStore surface', () => {
+  it('observe fires per-key on change and immediately with { immediate }', () => {
+    const l = new LocaleController();
+    l.set('upload', 'Upload');
+    const seen: (string | undefined)[] = [];
+    l.observe('upload', (v) => seen.push(v), { immediate: true });
+    l.set('upload', 'Send');
+    l.set('cancel', 'Cancel'); // unrelated key — must not fire
+    expect(seen).toEqual(['Upload', 'Send']);
   });
 
-  it('notifies on change and dedupes unchanged writes', () => {
-    const locale = new LocaleController();
+  it('setMany applies several keys with one coalesced notify', () => {
+    const l = new LocaleController();
     const listener = vi.fn();
-    locale.subscribe(listener);
-
-    locale.set('upload', 'Upload');
+    l.subscribe(listener);
+    l.setMany({ upload: 'Upload', cancel: 'Cancel' });
+    expect(l.get('upload')).toBe('Upload');
+    expect(l.get('cancel')).toBe('Cancel');
     expect(listener).toHaveBeenCalledTimes(1);
-
-    locale.set('upload', 'Upload'); // unchanged
-    expect(listener).toHaveBeenCalledTimes(1);
-
-    locale.set('upload', 'Send');
-    expect(listener).toHaveBeenCalledTimes(2);
-  });
-
-  it('getTracked() reads the value and auto-tracks the key under a computed', () => {
-    const locale = new LocaleController();
-    locale.set('upload', 'Upload');
-
-    // A computed that reads through getTracked depends on the per-key signal, so
-    // it recomputes when the key changes — the trackable read the plain,
-    // bag-reading get() deliberately does not provide.
-    const tracked = computed(() => locale.getTracked('upload'));
-    expect(tracked.get()).toBe('Upload');
-
-    locale.set('upload', 'Send');
-    expect(tracked.get()).toBe('Send');
-  });
-
-  it('getTracked() returns undefined for an absent key', () => {
-    const locale = new LocaleController();
-    expect(locale.getTracked('missing')).toBeUndefined();
-  });
-
-  it('unsubscribe stops notifications', () => {
-    const locale = new LocaleController();
-    const listener = vi.fn();
-    const off = locale.subscribe(listener);
-    off();
-
-    locale.set('upload', 'Upload');
-    expect(listener).not.toHaveBeenCalled();
-  });
-
-  it('has() uses own-property semantics, not the prototype chain', () => {
-    const locale = new LocaleController();
-    expect(locale.has('toString')).toBe(false);
-    expect(locale.has('__proto__')).toBe(false);
-  });
-
-  it('does not pollute the prototype for a key named __proto__', () => {
-    const locale = new LocaleController();
-    locale.set('__proto__', 'evil');
-    expect(({} as Record<string, unknown>).evil).toBeUndefined();
-    expect(locale.get('__proto__')).toBe('evil');
-  });
-
-  it('destroy() clears values and listeners', () => {
-    const locale = new LocaleController();
-    locale.set('upload', 'Upload');
-    const listener = vi.fn();
-    locale.subscribe(listener);
-
-    locale.destroy();
-
-    expect(locale.has('upload')).toBe(false);
-    locale.set('upload', 'Upload');
-    expect(listener).not.toHaveBeenCalled();
-  });
-
-  it('values exposes the stored dictionary reflecting writes', () => {
-    const locale = new LocaleController();
-    expect(Object.keys(locale.values)).toEqual([]);
-
-    locale.set('upload', 'Upload');
-    expect(locale.values.upload).toBe('Upload');
   });
 });

--- a/src/abstract/controllers/LocaleController.test.ts
+++ b/src/abstract/controllers/LocaleController.test.ts
@@ -1,5 +1,96 @@
+import { computed } from '@lit-labs/signals';
 import { describe, expect, it, vi } from 'vitest';
 import { LocaleController } from './LocaleController';
+
+describe('LocaleController', () => {
+  it('starts empty and stores values', () => {
+    const locale = new LocaleController();
+    expect(locale.has('upload')).toBe(false);
+    expect(locale.get('upload')).toBeUndefined();
+
+    locale.set('upload', 'Upload');
+    expect(locale.has('upload')).toBe(true);
+    expect(locale.get('upload')).toBe('Upload');
+  });
+
+  it('notifies on change and dedupes unchanged writes', () => {
+    const locale = new LocaleController();
+    const listener = vi.fn();
+    locale.subscribe(listener);
+
+    locale.set('upload', 'Upload');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    locale.set('upload', 'Upload'); // unchanged
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    locale.set('upload', 'Send');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('getTracked() reads the value and auto-tracks the key under a computed', () => {
+    const locale = new LocaleController();
+    locale.set('upload', 'Upload');
+
+    // A computed that reads through getTracked depends on the per-key signal, so
+    // it recomputes when the key changes — the trackable read the plain,
+    // bag-reading get() deliberately does not provide.
+    const tracked = computed(() => locale.getTracked('upload'));
+    expect(tracked.get()).toBe('Upload');
+
+    locale.set('upload', 'Send');
+    expect(tracked.get()).toBe('Send');
+  });
+
+  it('getTracked() returns undefined for an absent key', () => {
+    const locale = new LocaleController();
+    expect(locale.getTracked('missing')).toBeUndefined();
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const locale = new LocaleController();
+    const listener = vi.fn();
+    const off = locale.subscribe(listener);
+    off();
+
+    locale.set('upload', 'Upload');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('has() uses own-property semantics, not the prototype chain', () => {
+    const locale = new LocaleController();
+    expect(locale.has('toString')).toBe(false);
+    expect(locale.has('__proto__')).toBe(false);
+  });
+
+  it('does not pollute the prototype for a key named __proto__', () => {
+    const locale = new LocaleController();
+    locale.set('__proto__', 'evil');
+    expect(({} as Record<string, unknown>).evil).toBeUndefined();
+    expect(locale.get('__proto__')).toBe('evil');
+  });
+
+  it('destroy() clears values and listeners', () => {
+    const locale = new LocaleController();
+    locale.set('upload', 'Upload');
+    const listener = vi.fn();
+    locale.subscribe(listener);
+
+    locale.destroy();
+
+    expect(locale.has('upload')).toBe(false);
+    locale.set('upload', 'Upload');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('values exposes the stored dictionary reflecting writes', () => {
+    const locale = new LocaleController();
+    expect(Object.keys(locale.values)).toEqual([]);
+
+    locale.set('upload', 'Upload');
+    expect(locale.values.upload).toBe('Upload');
+  });
+});
 
 describe('LocaleController ReactiveStore surface', () => {
   it('observe fires per-key on change and immediately with { immediate }', () => {

--- a/src/abstract/controllers/LocaleController.ts
+++ b/src/abstract/controllers/LocaleController.ts
@@ -1,4 +1,6 @@
+import type { ReactiveStore } from '../di/ReactiveStore';
 import { SignalMap } from '../di/SignalMap';
+import type { ObserveOptions } from '../host-subscription';
 
 /**
  * Pure-logic locale string store. Knows nothing about DOM or Lit.
@@ -20,7 +22,7 @@ import { SignalMap } from '../di/SignalMap';
  * change semantics the v1 ctx facade `*l10n/` routing depends on. A locale
  * key named `__proto__` is an ordinary map key, never a prototype write.
  */
-export class LocaleController {
+export class LocaleController implements ReactiveStore<Record<string, string>> {
   #values = new SignalMap<Record<string, string>>();
 
   public get values(): Readonly<Record<string, string>> {
@@ -46,12 +48,25 @@ export class LocaleController {
    * non-tracking `get`.
    */
   public getTracked(key: string): string | undefined {
-    return this.#values.signal(key).get();
+    return this.#values.getTracked(key);
   }
 
   /** Notifies only when the value actually changes (per-key change semantics). */
   public set(key: string, value: string): void {
     this.#values.set(key, value);
+  }
+
+  public observe(key: string, listener: (value: string | undefined) => void, options?: ObserveOptions): () => void {
+    return this.#values.observe(key, listener, options);
+  }
+
+  /** Batch set locale strings — one coalesced notify. */
+  public setMany(patch: Partial<Record<string, string>>): void {
+    this.#values.setMany(patch);
+  }
+
+  public notify(): void {
+    this.#values.notify();
   }
 
   public destroy(): void {

--- a/src/abstract/controllers/StateController.test.ts
+++ b/src/abstract/controllers/StateController.test.ts
@@ -84,3 +84,48 @@ describe('StateController', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 });
+
+describe('StateController ReactiveStore surface', () => {
+  it('getTracked falls back to the plain read (no signal backing)', () => {
+    const controller = new StateController<FixtureState>({ a: 1, b: 'x', ref: null });
+    expect(controller.getTracked('a')).toBe(1);
+    controller.set('a', 2);
+    expect(controller.getTracked('a')).toBe(2);
+  });
+
+  it('observe fires per-key with { immediate }', () => {
+    const s = new StateController<{ a: number; b: number }>({ a: 0, b: 0 });
+    const seen: (number | undefined)[] = [];
+    s.observe('a', (v) => seen.push(v), { immediate: true });
+    s.set('a', 1);
+    s.set('b', 9); // unrelated
+    expect(seen).toEqual([0, 1]);
+  });
+
+  it('observe stops firing after unsubscribe', () => {
+    const s = new StateController<{ a: number }>({ a: 0 });
+    const listener = vi.fn();
+    const off = s.observe('a', listener);
+    off();
+    s.set('a', 1);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('setMany one coalesced notify', () => {
+    const s = new StateController<{ a: number; b: number }>({ a: 0, b: 0 });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.setMany({ a: 1, b: 2 });
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(s.get('a')).toBe(1);
+    expect(s.get('b')).toBe(2);
+  });
+
+  it('setMany does not notify when nothing actually changes', () => {
+    const s = new StateController<{ a: number; b: number }>({ a: 1, b: 2 });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.setMany({ a: 1, b: 2 });
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/abstract/controllers/StateController.test.ts
+++ b/src/abstract/controllers/StateController.test.ts
@@ -128,4 +128,13 @@ describe('StateController ReactiveStore surface', () => {
     s.setMany({ a: 1, b: 2 });
     expect(listener).not.toHaveBeenCalled();
   });
+
+  it('setMany writes an explicit undefined (clears the key), consistent with set', () => {
+    const s = new StateController<{ a?: number }>({ a: 5 });
+    const seen: (number | undefined)[] = [];
+    s.observe('a', (v) => seen.push(v));
+    s.setMany({ a: undefined });
+    expect(s.get('a')).toBeUndefined();
+    expect(seen).toEqual([undefined]);
+  });
 });

--- a/src/abstract/controllers/StateController.ts
+++ b/src/abstract/controllers/StateController.ts
@@ -48,7 +48,9 @@ export class StateController<TState extends object> implements ReactiveStore<TSt
   public setMany(patch: Partial<TState>): void {
     let changed = false;
     for (const key of Object.keys(patch) as (keyof TState)[]) {
-      const value = patch[key] as TState[keyof TState];
+      if (!Object.hasOwn(patch, key)) continue;
+      const value = patch[key];
+      if (value === undefined) continue;
       if (Object.is(this._state[key], value)) continue;
       this._state[key] = value;
       changed = true;

--- a/src/abstract/controllers/StateController.ts
+++ b/src/abstract/controllers/StateController.ts
@@ -1,3 +1,5 @@
+import type { ReactiveStore } from '../di/ReactiveStore';
+import type { ObserveOptions } from '../host-subscription';
 import { Listeners } from '../host-subscription';
 
 /**
@@ -8,8 +10,12 @@ import { Listeners } from '../host-subscription';
  * all subscribers on change; `notify()` lets a subclass force a re-render for
  * a change that isn't itself a keyed state write (e.g. an injected-services
  * swap). No `lit`, no DOM — UI bridging belongs to the element/adapter layer.
+ *
+ * Implements `ReactiveStore<TState>` on the `Listeners`-backed variant: there
+ * is no signal backing here, so `getTracked` falls back to the plain read —
+ * the interface is intentionally satisfiable by a coarse `Listeners` store.
  */
-export class StateController<TState extends object> {
+export class StateController<TState extends object> implements ReactiveStore<TState> {
   protected _state: TState;
   private _listeners = new Listeners();
 
@@ -26,11 +32,37 @@ export class StateController<TState extends object> {
     return this._state[key];
   }
 
+  /** No signal backing here — tracked read falls back to the plain read. */
+  public getTracked<K extends keyof TState>(key: K): TState[K] {
+    return this._state[key];
+  }
+
   /** Notifies only when the value actually changes (`Object.is` dedup). */
   public set<K extends keyof TState>(key: K, value: TState[K]): void {
     if (Object.is(this._state[key], value)) return;
     this._state[key] = value;
     this._listeners.notify();
+  }
+
+  /** Sets several keys at once; per-key `Object.is` dedup, ONE coalesced notify. */
+  public setMany(patch: Partial<TState>): void {
+    let changed = false;
+    for (const key of Object.keys(patch) as (keyof TState)[]) {
+      const value = patch[key] as TState[keyof TState];
+      if (Object.is(this._state[key], value)) continue;
+      this._state[key] = value;
+      changed = true;
+    }
+    if (changed) this._listeners.notify();
+  }
+
+  /** Atomic per-key subscription (`Object.is` dedup); `{ immediate }` also fires once now. */
+  public observe<K extends keyof TState>(
+    key: K,
+    listener: (value: TState[K]) => void,
+    options?: ObserveOptions,
+  ): () => void {
+    return this._listeners.observe(() => this._state[key], listener, options);
   }
 
   /** Coarse subscribe — fires on any state change, not per-key. */

--- a/src/abstract/controllers/StateController.ts
+++ b/src/abstract/controllers/StateController.ts
@@ -47,10 +47,10 @@ export class StateController<TState extends object> implements ReactiveStore<TSt
   /** Sets several keys at once; per-key `Object.is` dedup, ONE coalesced notify. */
   public setMany(patch: Partial<TState>): void {
     let changed = false;
+    // Consistent with `set`: an explicit `undefined` is written (clears the
+    // key), not skipped, so optional state can be cleared through the batch API.
     for (const key of Object.keys(patch) as (keyof TState)[]) {
-      if (!Object.hasOwn(patch, key)) continue;
-      const value = patch[key];
-      if (value === undefined) continue;
+      const value = patch[key] as TState[keyof TState];
       if (Object.is(this._state[key], value)) continue;
       this._state[key] = value;
       changed = true;

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -97,7 +97,7 @@ describe('UploadCollectionController', () => {
     const b = collection.add({ uploadProgress: 90 });
     vi.runOnlyPendingTimers();
 
-    expect(collection.findItems((e) => (e.getValue('uploadProgress') as number) > 50)).toEqual([b]);
+    expect(collection.findItems((e) => (e.get('uploadProgress') as number) > 50)).toEqual([b]);
 
     collection.clearAll();
     expect(collection.size).toBe(0);

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -133,7 +133,7 @@ export class UploadCollectionController {
       keyof UploadEntryData,
       UploadEntryData[keyof UploadEntryData],
     ][]) {
-      item.setValue(prop, value);
+      item.set(prop, value);
     }
     this._items.add(item.uid);
     this._notify();
@@ -146,7 +146,7 @@ export class UploadCollectionController {
         subs = [];
         this._subsMap.set(item.uid, subs);
       }
-      subs.push(item.subscribe(propName, () => this._notifyObservers(propName, item.uid)));
+      subs.push(item.observe(propName, () => this._notifyObservers(propName, item.uid), { immediate: true }));
     }
     return item.uid;
   }
@@ -164,7 +164,7 @@ export class UploadCollectionController {
     if (!item) {
       throw new Error(`UploadCollectionController#readProp: Item with id ${id} not found`);
     }
-    return item.getValue(propName);
+    return item.get(propName);
   }
 
   public publishProp<K extends keyof UploadEntryData>(id: Uid, propName: K, value: UploadEntryData[K]): void {
@@ -172,7 +172,7 @@ export class UploadCollectionController {
     if (!item) {
       throw new Error(`UploadCollectionController#publishProp: Item with id ${id} not found`);
     }
-    item.setValue(propName, value);
+    item.set(propName, value);
   }
 
   public remove(id: Uid): void {
@@ -193,7 +193,7 @@ export class UploadCollectionController {
 
   public abort(id: Uid): void {
     const item = this.read(id);
-    if (item?.getValue('isUploading')) {
+    if (item?.get('isUploading')) {
       this.remove(id);
     }
   }

--- a/src/abstract/controllers/UploadController.test.ts
+++ b/src/abstract/controllers/UploadController.test.ts
@@ -272,7 +272,13 @@ describe('UploadController', () => {
       // Capture progress before the final 100 write.
       const seen: number[] = [];
       const entry = collection.read(id);
-      entry?.observe('uploadProgress', (v) => v !== undefined && seen.push(v), { immediate: true });
+      entry?.observe(
+        'uploadProgress',
+        (v) => {
+          if (v !== undefined) seen.push(v);
+        },
+        { immediate: true },
+      );
 
       await controller.uploadEntry(id);
 
@@ -287,7 +293,13 @@ describe('UploadController', () => {
       const { controller, collection } = setup();
       const id = collection.add({ file: new File(['x'], 'a.txt') });
       const seen: number[] = [];
-      collection.read(id)?.observe('uploadProgress', (v) => v !== undefined && seen.push(v), { immediate: true });
+      collection.read(id)?.observe(
+        'uploadProgress',
+        (v) => {
+          if (v !== undefined) seen.push(v);
+        },
+        { immediate: true },
+      );
 
       await controller.uploadEntry(id);
 

--- a/src/abstract/controllers/UploadController.test.ts
+++ b/src/abstract/controllers/UploadController.test.ts
@@ -165,12 +165,12 @@ describe('UploadController', () => {
       await controller.uploadEntry(id);
 
       const entry = collection.read(id);
-      expect(entry?.getValue('fileInfo')).toMatchObject({ uuid: 'u1' });
-      expect(entry?.getValue('isUploading')).toBe(false);
-      expect(entry?.getValue('isQueuedForUploading')).toBe(false);
-      expect(entry?.getValue('uuid')).toBe('u1');
-      expect(entry?.getValue('uploadProgress')).toBe(100);
-      expect(entry?.getValue('cdnUrl')).toBe('https://cdn/u1/');
+      expect(entry?.get('fileInfo')).toMatchObject({ uuid: 'u1' });
+      expect(entry?.get('isUploading')).toBe(false);
+      expect(entry?.get('isQueuedForUploading')).toBe(false);
+      expect(entry?.get('uuid')).toBe('u1');
+      expect(entry?.get('uploadProgress')).toBe(100);
+      expect(entry?.get('cdnUrl')).toBe('https://cdn/u1/');
     });
 
     it('prefers an existing entry cdnUrl over the server one', async () => {
@@ -180,7 +180,7 @@ describe('UploadController', () => {
 
       await controller.uploadEntry(id);
 
-      expect(collection.read(id)?.getValue('cdnUrl')).toBe('https://cdn/preset/');
+      expect(collection.read(id)?.get('cdnUrl')).toBe('https://cdn/preset/');
     });
 
     it('derives mimeType from contentInfo when present, falls back to isImage=false', async () => {
@@ -197,8 +197,8 @@ describe('UploadController', () => {
       await controller.uploadEntry(id);
 
       const entry = collection.read(id);
-      expect(entry?.getValue('mimeType')).toBe('image/webp');
-      expect(entry?.getValue('isImage')).toBe(false);
+      expect(entry?.get('mimeType')).toBe('image/webp');
+      expect(entry?.get('isImage')).toBe(false);
     });
 
     it('uploads from externalUrl when there is no file', async () => {
@@ -309,10 +309,10 @@ describe('UploadController', () => {
       mockUploadFile.mockImplementation(async () => {
         const e = collection.read(id);
         atUpload = {
-          mimeType: e?.getValue('mimeType'),
-          isImage: e?.getValue('isImage'),
-          fileName: e?.getValue('fileName'),
-          fileSize: e?.getValue('fileSize'),
+          mimeType: e?.get('mimeType'),
+          isImage: e?.get('isImage'),
+          fileName: e?.get('fileName'),
+          fileSize: e?.get('fileSize'),
         };
         return makeFileInfo();
       });
@@ -333,7 +333,7 @@ describe('UploadController', () => {
 
       let fileNameAtUpload: string | null | undefined;
       mockUploadFile.mockImplementation(async () => {
-        fileNameAtUpload = collection.read(id)?.getValue('fileName');
+        fileNameAtUpload = collection.read(id)?.get('fileName');
         return makeFileInfo();
       });
 
@@ -395,14 +395,14 @@ describe('UploadController', () => {
 
       let mimeAtUpload: string | null | undefined;
       mockUploadFile.mockImplementation(async () => {
-        mimeAtUpload = collection.read(id)?.getValue('mimeType');
+        mimeAtUpload = collection.read(id)?.get('mimeType');
         return makeFileInfo();
       });
 
       await controller.uploadEntry(id);
 
       expect(mimeAtUpload).toBeNull(); // file.type '' || null
-      expect(collection.read(id)?.getValue('cdnUrlModifiers')).toBe('-/preview/'); // preset kept over ?? ''
+      expect(collection.read(id)?.get('cdnUrlModifiers')).toBe('-/preview/'); // preset kept over ?? ''
     });
 
     it('does not run hooks for a non-File input (externalUrl)', async () => {
@@ -425,8 +425,8 @@ describe('UploadController', () => {
       await controller.uploadEntry(id);
 
       const entry = collection.read(id);
-      expect(entry?.getValue('isUploading')).toBe(false);
-      expect(entry?.getValue('uploadError')?.message).toBe('Something went wrong');
+      expect(entry?.get('isUploading')).toBe(false);
+      expect(entry?.get('uploadError')?.message).toBe('Something went wrong');
       expect(error).toHaveBeenCalledWith('[uc][upload]', 'Unknown upload error', expect.any(Error));
       expect(onUploadError).toHaveBeenCalledWith(expect.any(Error), expect.stringContaining('file upload'));
     });
@@ -441,9 +441,9 @@ describe('UploadController', () => {
       await controller.uploadEntry(id);
 
       const entry = collection.read(id);
-      expect(entry?.getValue('isUploading')).toBe(false);
-      expect(entry?.getValue('uploadProgress')).toBe(0);
-      expect(entry?.getValue('uploadError')).toBeNull();
+      expect(entry?.get('isUploading')).toBe(false);
+      expect(entry?.get('uploadProgress')).toBe(0);
+      expect(entry?.get('uploadError')).toBeNull();
       expect(onUploadError).not.toHaveBeenCalled();
     });
 
@@ -456,7 +456,7 @@ describe('UploadController', () => {
       await controller.uploadEntry(id);
 
       const entry = collection.read(id);
-      expect(entry?.getValue('uploadError')).toBe(ucError);
+      expect(entry?.get('uploadError')).toBe(ucError);
       expect(onUploadError).toHaveBeenCalled();
     });
 
@@ -476,7 +476,7 @@ describe('UploadController', () => {
       const id = collection.add({ file: new File(['x'], 'a.txt') });
       const ac = new AbortController();
       const spy = vi.spyOn(ac, 'abort');
-      collection.read(id)?.setValue('abortController', ac);
+      collection.read(id)?.set('abortController', ac);
 
       controller.abort(id);
 

--- a/src/abstract/controllers/UploadController.test.ts
+++ b/src/abstract/controllers/UploadController.test.ts
@@ -272,7 +272,7 @@ describe('UploadController', () => {
       // Capture progress before the final 100 write.
       const seen: number[] = [];
       const entry = collection.read(id);
-      entry?.subscribe('uploadProgress', (v) => seen.push(v));
+      entry?.observe('uploadProgress', (v) => v !== undefined && seen.push(v), { immediate: true });
 
       await controller.uploadEntry(id);
 
@@ -287,7 +287,7 @@ describe('UploadController', () => {
       const { controller, collection } = setup();
       const id = collection.add({ file: new File(['x'], 'a.txt') });
       const seen: number[] = [];
-      collection.read(id)?.subscribe('uploadProgress', (v) => seen.push(v));
+      collection.read(id)?.observe('uploadProgress', (v) => v !== undefined && seen.push(v), { immediate: true });
 
       await controller.uploadEntry(id);
 

--- a/src/abstract/controllers/UploadController.ts
+++ b/src/abstract/controllers/UploadController.ts
@@ -163,10 +163,10 @@ export class UploadController {
     }
 
     if (
-      entry.getValue('fileInfo') ||
-      entry.getValue('isUploading') ||
-      entry.getValue('errors').length > 0 ||
-      entry.getValue('isValidationPending')
+      entry.get('fileInfo') ||
+      entry.get('isUploading') ||
+      entry.get('errors').length > 0 ||
+      entry.get('isValidationPending')
     ) {
       return;
     }
@@ -176,7 +176,7 @@ export class UploadController {
       return;
     }
 
-    entry.setMultipleValues({
+    entry.setMany({
       isUploading: true,
       errors: [],
       isQueuedForUploading: true,
@@ -184,11 +184,11 @@ export class UploadController {
 
     try {
       const abortController = new AbortController();
-      entry.setValue('abortController', abortController);
+      entry.set('abortController', abortController);
 
       const uploadTask = async (): Promise<UploadcareFile> => {
-        entry.setValue('isQueuedForUploading', false);
-        let file: File | Blob | null = entry.getValue('file');
+        entry.set('isQueuedForUploading', false);
+        let file: File | Blob | null = entry.get('file');
 
         if (file instanceof File || file instanceof Blob) {
           const beforeUploadHooks = this._host.getFileHooks().filter((h) => h.type === 'beforeUpload');
@@ -201,11 +201,11 @@ export class UploadController {
               const { file: newFile } = await Promise.race([hookPromise, timeoutPromise]);
               if (newFile !== file) {
                 file = newFile;
-                entry.setValue('mimeType', file.type || null);
-                entry.setValue('isImage', fileIsImage(file));
-                entry.setValue('fileSize', file.size);
+                entry.set('mimeType', file.type || null);
+                entry.set('isImage', fileIsImage(file));
+                entry.set('fileSize', file.size);
                 if (file instanceof File) {
-                  entry.setValue('fileName', file.name);
+                  entry.set('fileName', file.name);
                 }
               }
             } catch (error) {
@@ -214,19 +214,19 @@ export class UploadController {
           }
         }
 
-        const fileInput = file || entry.getValue('externalUrl') || entry.getValue('uuid');
+        const fileInput = file || entry.get('externalUrl') || entry.get('uuid');
         if (!fileInput) {
           throw new Error('No file input');
         }
         const baseUploadClientOptions = await this.buildUploadOptions();
         const uploadClientOptions: FileFromOptions = {
           ...baseUploadClientOptions,
-          fileName: entry.getValue('fileName') ?? undefined,
-          source: entry.getValue('source') ?? undefined,
+          fileName: entry.get('fileName') ?? undefined,
+          source: entry.get('source') ?? undefined,
           onProgress: (progress) => {
             if (progress.isComputable) {
               const percentage = progress.value * 100;
-              entry.setValue('uploadProgress', percentage);
+              entry.set('uploadProgress', percentage);
             }
           },
           signal: abortController.signal,
@@ -247,7 +247,7 @@ export class UploadController {
       };
 
       const fileInfo = await this._queue.add(uploadTask);
-      entry.setMultipleValues({
+      entry.setMany({
         fileInfo,
         isQueuedForUploading: false,
         isUploading: false,
@@ -256,27 +256,27 @@ export class UploadController {
         isImage: fileInfo.isImage ?? false,
         mimeType: fileInfo.contentInfo?.mime?.mime ?? fileInfo.mimeType,
         uuid: fileInfo.uuid,
-        cdnUrl: entry.getValue('cdnUrl') ?? fileInfo.cdnUrl,
-        cdnUrlModifiers: entry.getValue('cdnUrlModifiers') ?? '',
+        cdnUrl: entry.get('cdnUrl') ?? fileInfo.cdnUrl,
+        cdnUrlModifiers: entry.get('cdnUrlModifiers') ?? '',
         uploadProgress: 100,
-        source: entry.getValue('source') ?? null,
+        source: entry.get('source') ?? null,
       });
     } catch (cause) {
       const isCancelError = cause instanceof CancelError && cause.isCancel;
       if (isCancelError) {
-        entry.setMultipleValues({
+        entry.setMany({
           isUploading: false,
           uploadProgress: 0,
         });
       } else if (cause instanceof UploadcareError) {
-        entry.setMultipleValues({
+        entry.setMany({
           isUploading: false,
           uploadProgress: 0,
           uploadError: cause,
         });
       } else {
         this._log.error('Unknown upload error', cause);
-        entry.setMultipleValues({
+        entry.setMany({
           isUploading: false,
           uploadProgress: 0,
           // TODO: Add translation?
@@ -293,7 +293,7 @@ export class UploadController {
   }
 
   public abort(uid: Uid): void {
-    this._collection.read(uid)?.getValue('abortController')?.abort();
+    this._collection.read(uid)?.get('abortController')?.abort();
   }
 
   public destroy(): void {

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -199,14 +199,14 @@ describe('UploadEventsController', () => {
       const entry = t.collection.read(id) as Entry;
       const ac = new AbortController();
       const abortSpy = vi.spyOn(ac, 'abort');
-      entry.setValue('abortController', ac);
+      entry.set('abortController', ac);
       const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
       t.fireCollection([], new Set(), new Set([entry]));
 
       expect(t.deps.validation.cleanupValidationForEntry).toHaveBeenCalledWith(entry);
       expect(abortSpy).toHaveBeenCalled();
-      expect(entry.getValue('isRemoved')).toBe(true);
+      expect(entry.get('isRemoved')).toBe(true);
       expect(revokeSpy).toHaveBeenCalledWith('blob:xyz');
       expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.objectContaining({ internalId: id }));
     });
@@ -441,7 +441,7 @@ describe('UploadEventsController', () => {
     it('ignores a non-numeric uploadProgress when averaging', () => {
       const t = setup();
       const id = t.collection.add({ isUploading: true });
-      t.collection.read(id)?.setValue('uploadProgress', 'oops' as never);
+      t.collection.read(id)?.set('uploadProgress', 'oops' as never);
       t.uploadBatchSet.add(id);
 
       expect(() => t.fireProperties({ uploadProgress: new Set([id]) })).not.toThrow();

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -99,7 +99,7 @@ export class UploadEventsController {
     );
 
     for (const entry of added) {
-      if (!entry.getValue('silent')) {
+      if (!entry.get('silent')) {
         emit(UploaderEventType.FILE_ADDED, getOutputItem(entry.uid));
       }
       this._host.runOnAddHooks(entry);
@@ -110,14 +110,14 @@ export class UploadEventsController {
     for (const entry of removed) {
       // (`UploadController` drops removed uids from its own active batch.)
       this._validation.cleanupValidationForEntry(entry);
-      entry.getValue('abortController')?.abort();
-      entry.setMultipleValues({
+      entry.get('abortController')?.abort();
+      entry.setMany({
         isRemoved: true,
         abortController: null,
         isUploading: false,
         uploadProgress: 0,
       });
-      const thumbUrl = entry?.getValue('thumbUrl');
+      const thumbUrl = entry?.get('thumbUrl');
       thumbUrl && URL.revokeObjectURL(thumbUrl);
       emit(UploaderEventType.FILE_REMOVED, getOutputItem(entry.uid));
     }
@@ -154,7 +154,7 @@ export class UploadEventsController {
         // We can't modify entry properties in the same tick, so we need to wait a bit
         const entriesToRunOnUpload = entriesToRunValidation.filter(
           (entryId) =>
-            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.snapshot().fileInfo,
+            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.values.fileInfo,
         );
         if (entriesToRunOnUpload.length > 0) {
           validation.runFileValidators('upload', entriesToRunOnUpload);
@@ -166,7 +166,7 @@ export class UploadEventsController {
       for (const entryId of changeMap.uploadProgress) {
         const entry = TypedData.getByUid<UploadEntryData>(entryId);
         if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
+        const { isUploading, silent } = entry.values;
         if (isUploading && !silent) {
           emit(UploaderEventType.FILE_UPLOAD_PROGRESS, getOutputItem(entryId));
         }
@@ -178,7 +178,7 @@ export class UploadEventsController {
       for (const entryId of changeMap.isUploading) {
         const entry = TypedData.getByUid<UploadEntryData>(entryId);
         if (!entry) continue;
-        const { isUploading, silent } = entry.snapshot();
+        const { isUploading, silent } = entry.values;
         if (isUploading && !silent) {
           emit(UploaderEventType.FILE_UPLOAD_START, getOutputItem(entryId));
         }
@@ -188,7 +188,7 @@ export class UploadEventsController {
       for (const entryId of changeMap.fileInfo) {
         const entry = TypedData.getByUid<UploadEntryData>(entryId);
         if (!entry) continue;
-        const { fileInfo, silent } = entry.snapshot();
+        const { fileInfo, silent } = entry.values;
         if (fileInfo && !silent) {
           emit(UploaderEventType.FILE_UPLOAD_SUCCESS, getOutputItem(entryId));
         }
@@ -203,7 +203,7 @@ export class UploadEventsController {
       for (const entryId of changeMap.errors) {
         const entry = TypedData.getByUid<UploadEntryData>(entryId);
         if (!entry) continue;
-        const { errors } = entry.snapshot();
+        const { errors } = entry.values;
         if (errors.length > 0) {
           emit(UploaderEventType.FILE_UPLOAD_FAILED, getOutputItem(entryId));
           emit(
@@ -213,8 +213,8 @@ export class UploadEventsController {
           );
         }
       }
-      const loadedItems = collection.findItems((entry) => !!entry.getValue('fileInfo'));
-      const errorItems = collection.findItems((entry) => entry.getValue('errors').length > 0);
+      const loadedItems = collection.findItems((entry) => !!entry.get('fileInfo'));
+      const errorItems = collection.findItems((entry) => entry.get('errors').length > 0);
       if (
         collection.size > 0 &&
         errorItems.length === 0 &&
@@ -225,7 +225,7 @@ export class UploadEventsController {
       }
     }
     if (changeMap.cdnUrl) {
-      const uids = [...changeMap.cdnUrl].filter((uid) => !!collection.read(uid)?.getValue('cdnUrl'));
+      const uids = [...changeMap.cdnUrl].filter((uid) => !!collection.read(uid)?.get('cdnUrl'));
       uids.forEach((uid) => {
         emit(UploaderEventType.FILE_URL_CHANGED, getOutputItem(uid));
       });

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -117,7 +117,7 @@ export class UploadEventsController {
         isUploading: false,
         uploadProgress: 0,
       });
-      const thumbUrl = entry?.get('thumbUrl');
+      const thumbUrl = entry.get('thumbUrl');
       thumbUrl && URL.revokeObjectURL(thumbUrl);
       emit(UploaderEventType.FILE_REMOVED, getOutputItem(entry.uid));
     }

--- a/src/abstract/controllers/ValidationController.test.ts
+++ b/src/abstract/controllers/ValidationController.test.ts
@@ -41,7 +41,7 @@ const flush = (ms = QUEUE_FLUSH_MS) => new Promise((resolve) => setTimeout(resol
 function buildOutputItem(collection: UploadCollectionController, uid: Uid) {
   const entry = collection.read(uid);
   if (!entry) throw new Error(`test fixture: entry "${uid}" not found`);
-  const e = entry.snapshot();
+  const e = entry.values;
   const status = e.isRemoved
     ? 'removed'
     : e.errors.length > 0
@@ -171,7 +171,7 @@ describe('ValidationController', () => {
     controller.runFileValidators('change', [id]);
     await flush();
 
-    const errors = collection.read(id)?.getValue('errors') ?? [];
+    const errors = collection.read(id)?.get('errors') ?? [];
     expect(errors).toHaveLength(1);
     expect(errors[0]).toMatchObject({ message: 'nope', type: 'CUSTOM_ERROR' });
   });
@@ -211,7 +211,7 @@ describe('ValidationController', () => {
     await flush(800); // 500 debounce + 50 timeout + margin
 
     expect(warn).toHaveBeenCalledWith('[uc][validation]', expect.stringMatching(/timed out/));
-    expect(collection.read(id)?.getValue('isValidationPending')).toBe(false);
+    expect(collection.read(id)?.get('isValidationPending')).toBe(false);
   });
 
   it('isolates a throwing async validator (reports via onValidatorError) without crashing', async () => {
@@ -229,7 +229,7 @@ describe('ValidationController', () => {
     await flush();
 
     expect(onValidatorError).toHaveBeenCalled();
-    expect(collection.read(id)?.getValue('isValidationPending')).toBe(false);
+    expect(collection.read(id)?.get('isValidationPending')).toBe(false);
   });
 
   it('cleanupValidationForEntry aborts in-flight validation and is a no-op without state', async () => {
@@ -269,7 +269,7 @@ describe('ValidationController', () => {
     controller.runFileValidators('upload', [id]);
     await flush();
 
-    expect(collection.read(id)?.getValue('isValidationPending')).toBe(false);
+    expect(collection.read(id)?.get('isValidationPending')).toBe(false);
   });
 
   it('warns when a file validator returns an error without a message', async () => {
@@ -296,7 +296,7 @@ describe('ValidationController', () => {
     controller.runFileValidators('change', [id]); // add validator filtered out → error carried
     await flush();
 
-    const errors = collection.read(id)?.getValue('errors') ?? [];
+    const errors = collection.read(id)?.get('errors') ?? [];
     expect(errors.some((e) => e.message === 'add-err')).toBe(true);
   });
 
@@ -310,7 +310,7 @@ describe('ValidationController', () => {
     controller.destroy(); // before the microtask resumes → post-await guard returns
     await flush();
 
-    expect(collection.read(id)?.getValue('isValidationPending')).toBe(false);
+    expect(collection.read(id)?.get('isValidationPending')).toBe(false);
   });
 
   it('syncs queue concurrency from config without throwing', () => {
@@ -355,7 +355,7 @@ describe('ValidationController', () => {
     controller.runFileValidators('change', [id]);
     await flush();
 
-    expect(collection.read(id)?.getValue('isValidationPending')).toBe(false);
+    expect(collection.read(id)?.get('isValidationPending')).toBe(false);
   });
 
   it('is inert after destroy', async () => {

--- a/src/abstract/controllers/ValidationController.ts
+++ b/src/abstract/controllers/ValidationController.ts
@@ -214,7 +214,7 @@ export class ValidationController {
       if (entryDescriptors.length === 0 || !this._collection.hasItem(entry.uid)) {
         return;
       }
-      entry.setMultipleValues({
+      entry.setMany({
         isQueuedForValidation: true,
         isValidationPending: true,
       });
@@ -277,7 +277,7 @@ export class ValidationController {
       // runs after teardown — no in-task `_isDestroyed` guard is reachable.
       await this._queue.add(
         async () => {
-          entry.setValue('isQueuedForValidation', false);
+          entry.set('isQueuedForValidation', false);
           await Promise.all(tasks.map((task) => task())).catch(() => {});
         },
         {
@@ -286,14 +286,14 @@ export class ValidationController {
       );
 
       if (abortController.signal.aborted) {
-        entry.setMultipleValues({
+        entry.setMany({
           isQueuedForValidation: false,
           isValidationPending: false,
         });
         return;
       }
 
-      entry.setMultipleValues({
+      entry.setMany({
         isValidationPending: false,
         isQueuedForValidation: false,
         errors,

--- a/src/abstract/di/ReactiveStore.ts
+++ b/src/abstract/di/ReactiveStore.ts
@@ -1,0 +1,31 @@
+import type { ObserveOptions } from '../host-subscription';
+
+/**
+ * The shared contract for the codebase's keyed reactive value stores. Satisfied
+ * by BOTH the signal-backed `SignalMap` (`getTracked` = signal read, `observe` =
+ * `Listeners.observe`) and a `Listeners`-backed store (`getTracked` ≡ `get`,
+ * `observe` = `Listeners.observe`), so the surface unifies regardless of backing.
+ *
+ * `get`/`getTracked` are typed `T[K] | undefined` (the honest lower bound for a
+ * dynamic keyspace); an always-seeded implementer may narrow its own return to
+ * `T[K]` and still satisfy this interface (return-type covariance).
+ */
+export interface ReactiveStore<T extends object> {
+  /** Fast, non-tracking read from the value bag. */
+  get<K extends keyof T>(key: K): T[K] | undefined;
+  /** Trackable read: under a `SignalWatcher` this subscribes the consumer to `key`. */
+  getTracked<K extends keyof T>(key: K): T[K] | undefined;
+  /** Set one key; `Object.is` dedup, coarse notify on real change. */
+  set<K extends keyof T>(key: K, value: T[K]): void;
+  /** Set several keys at once; per-key `Object.is` dedup, ONE coalesced coarse notify. */
+  setMany(patch: Partial<T>): void;
+  /** Coarse subscribe — fires on any change, not per-key. */
+  subscribe(listener: () => void): () => void;
+  /** Atomic per-key subscription (`Object.is` dedup); `{ immediate }` also fires once now. */
+  observe<K extends keyof T>(key: K, listener: (value: T[K] | undefined) => void, options?: ObserveOptions): () => void;
+  /** The live value bag (stable reference, mutated in place on write). */
+  get values(): Readonly<T>;
+  /** Coarse notify with no state change. */
+  notify(): void;
+  destroy(): void;
+}

--- a/src/abstract/di/SignalMap.test.ts
+++ b/src/abstract/di/SignalMap.test.ts
@@ -286,4 +286,16 @@ describe('SignalMap.setMany', () => {
     m.setMany({ a: 5, b: 6 });
     expect(sigA.get()).toBe(5);
   });
+
+  it('writes an explicit undefined (clears the key), consistent with set — not skipped', () => {
+    const m = new SignalMap<{ a?: number }>({ a: 5 });
+    const observed: (number | undefined)[] = [];
+    m.observe('a', (v) => observed.push(v));
+
+    m.setMany({ a: undefined });
+
+    expect(m.get('a')).toBeUndefined();
+    // The clear must reach observers — the regression was silently dropping it.
+    expect(observed).toEqual([undefined]);
+  });
 });

--- a/src/abstract/di/SignalMap.test.ts
+++ b/src/abstract/di/SignalMap.test.ts
@@ -248,3 +248,42 @@ describe('SignalMap', () => {
     expect(listener).not.toHaveBeenCalled();
   });
 });
+
+describe('SignalMap.getTracked', () => {
+  it('returns the current value (same as get)', () => {
+    const m = new SignalMap<{ a: number }>({ a: 1 });
+    expect(m.getTracked('a')).toBe(1);
+    m.set('a', 2);
+    expect(m.getTracked('a')).toBe(2);
+  });
+});
+
+describe('SignalMap.setMany', () => {
+  it('applies every changed key and fires ONE coalesced coarse notify', () => {
+    const m = new SignalMap<{ a: number; b: number; c: number }>({ a: 0, b: 0, c: 0 });
+    const listener = vi.fn();
+    m.subscribe(listener);
+
+    m.setMany({ a: 1, b: 2 });
+
+    expect(m.get('a')).toBe(1);
+    expect(m.get('b')).toBe(2);
+    expect(m.get('c')).toBe(0);
+    expect(listener).toHaveBeenCalledTimes(1); // coalesced, not 2
+  });
+
+  it('does not notify when nothing actually changes (Object.is dedup)', () => {
+    const m = new SignalMap<{ a: number }>({ a: 1 });
+    const listener = vi.fn();
+    m.subscribe(listener);
+    m.setMany({ a: 1 });
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('keeps materialized per-key signals in sync', () => {
+    const m = new SignalMap<{ a: number; b: number }>({ a: 0, b: 0 });
+    const sigA = m.signal('a'); // materialize
+    m.setMany({ a: 5, b: 6 });
+    expect(sigA.get()).toBe(5);
+  });
+});

--- a/src/abstract/di/SignalMap.ts
+++ b/src/abstract/di/SignalMap.ts
@@ -1,5 +1,6 @@
 import { type Signal, signal } from '@lit-labs/signals';
 import { Listeners, type ObserveOptions } from '../host-subscription';
+import type { ReactiveStore } from './ReactiveStore';
 
 // `ObserveOptions` lives with `Listeners.observe` (the shared atomic-observe
 // engine); re-exported here so existing `di/SignalMap` importers are unaffected.
@@ -33,7 +34,7 @@ export type { ObserveOptions };
  * The bag is null-proto and keys live by their string name, so a plugin/locale
  * key named `__proto__` is an ordinary own property, never a prototype write.
  */
-export class SignalMap<T extends object> {
+export class SignalMap<T extends object> implements ReactiveStore<T> {
   // Authoritative value + presence store, and the live view returned by `values`.
   #bag: T = Object.create(null);
   // Lazily-populated per-key signals (created on first `get`), kept in sync with
@@ -75,6 +76,15 @@ export class SignalMap<T extends object> {
     return s as Signal.State<T[K] | undefined>;
   }
 
+  /**
+   * Trackable read — the `ReactiveStore` counterpart to `get`. Reads through the
+   * per-key signal, so under a `SignalWatcher` it auto-tracks `key`. The facades'
+   * hand-rolled `signal(key).get()` wrappers collapse to this.
+   */
+  public getTracked<K extends keyof T>(key: K): T[K] | undefined {
+    return this.signal(key).get();
+  }
+
   public has(key: keyof T): boolean {
     return Object.hasOwn(this.#bag, key);
   }
@@ -95,6 +105,28 @@ export class SignalMap<T extends object> {
     // key stays lazy and its next `get` seeds from the now-updated bag.
     this.#signals.get(key)?.set(value);
     this.#listeners.notify();
+  }
+
+  /**
+   * Batch set: apply each changed key (`Object.is` dedup, updating the bag + any
+   * materialized signal), then fire exactly ONE coarse notify if anything changed.
+   * Per-key `getTracked`/`observe` consumers still fire only for their changed key
+   * (their own signal/`Object.is` filter); coarse `subscribe`rs fire once.
+   */
+  public setMany(patch: Partial<T>): void {
+    let changed = false;
+    for (const key of Object.keys(patch) as (keyof T)[]) {
+      const value = patch[key] as T[keyof T];
+      if (Object.hasOwn(this.#bag, key) && Object.is(this.#bag[key], value)) {
+        continue;
+      }
+      this.#bag[key] = value;
+      this.#signals.get(key)?.set(value);
+      changed = true;
+    }
+    if (changed) {
+      this.#listeners.notify();
+    }
   }
 
   /**

--- a/src/abstract/di/SignalMap.ts
+++ b/src/abstract/di/SignalMap.ts
@@ -115,10 +115,12 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
    */
   public setMany(patch: Partial<T>): void {
     let changed = false;
+    // Consistent with `set`: an explicit `undefined` in the patch is WRITTEN
+    // (clears/materializes the key), not skipped — so optional state can be
+    // cleared through the batch API. `Object.keys` only yields own keys the
+    // caller put in `patch`.
     for (const key of Object.keys(patch) as (keyof T)[]) {
-      if (!Object.hasOwn(patch, key)) continue;
-      const value = patch[key];
-      if (value === undefined) continue;
+      const value = patch[key] as T[keyof T];
       if (Object.hasOwn(this.#bag, key) && Object.is(this.#bag[key], value)) {
         continue;
       }

--- a/src/abstract/di/SignalMap.ts
+++ b/src/abstract/di/SignalMap.ts
@@ -116,7 +116,9 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
   public setMany(patch: Partial<T>): void {
     let changed = false;
     for (const key of Object.keys(patch) as (keyof T)[]) {
-      const value = patch[key] as T[keyof T];
+      if (!Object.hasOwn(patch, key)) continue;
+      const value = patch[key];
+      if (value === undefined) continue;
       if (Object.hasOwn(this.#bag, key) && Object.is(this.#bag[key], value)) {
         continue;
       }

--- a/src/abstract/host-subscription.test.ts
+++ b/src/abstract/host-subscription.test.ts
@@ -46,6 +46,35 @@ describe('Listeners', () => {
     warn.mockRestore();
   });
 
+  it('isolates a listener that throws on the immediate fire', () => {
+    const listeners = new Listeners();
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const bad = () => {
+      throw new Error('boom');
+    };
+    const good = vi.fn();
+
+    let unsubscribe: (() => void) | undefined;
+    expect(() => {
+      unsubscribe = listeners.observe(() => 1, bad, { immediate: true });
+    }).not.toThrow();
+    expect(warn).toHaveBeenCalled();
+
+    // The later-notify path still works after an immediate-fire throw.
+    let value = 2;
+    listeners.observe(
+      () => value,
+      () => good(),
+      { immediate: false },
+    );
+    value = 3;
+    listeners.notify();
+    expect(good).toHaveBeenCalledTimes(1);
+
+    unsubscribe?.();
+    warn.mockRestore();
+  });
+
   it('clear() removes all listeners', () => {
     const listeners = new Listeners();
     const a = vi.fn();

--- a/src/abstract/managers/plugin/PluginController.test.ts
+++ b/src/abstract/managers/plugin/PluginController.test.ts
@@ -251,7 +251,7 @@ describe('PluginController', () => {
   describe('runOnAddHooks', () => {
     const makeEntry = (file: File | null): UploadEntryTypedData => {
       const entry = new TypedData<UploadEntryData>(initialUploadEntryData);
-      if (file) entry.setValue('file', file);
+      if (file) entry.set('file', file);
       return entry;
     };
 
@@ -268,11 +268,11 @@ describe('PluginController', () => {
 
       await t.controller.runOnAddHooks(entry);
 
-      expect(entry.getValue('file')).toBe(newFile);
-      expect(entry.getValue('fileName')).toBe('new.png');
-      expect(entry.getValue('mimeType')).toBe('image/png');
-      expect(entry.getValue('isImage')).toBe(true);
-      expect(entry.getValue('fileSize')).toBe(newFile.size);
+      expect(entry.get('file')).toBe(newFile);
+      expect(entry.get('fileName')).toBe('new.png');
+      expect(entry.get('mimeType')).toBe('image/png');
+      expect(entry.get('isImage')).toBe(true);
+      expect(entry.get('fileSize')).toBe(newFile.size);
     });
 
     it('no-ops when the entry has no file', async () => {
@@ -289,11 +289,11 @@ describe('PluginController', () => {
       const t = setup();
       await t.sync([sourcePlugin('a')]);
       const entry = makeEntry(new File(['x'], 'a.txt'));
-      const original = entry.getValue('file');
+      const original = entry.get('file');
 
       await t.controller.runOnAddHooks(entry);
 
-      expect(entry.getValue('file')).toBe(original);
+      expect(entry.get('file')).toBe(original);
     });
 
     it('isolates a throwing hook and keeps the original file', async () => {
@@ -310,7 +310,7 @@ describe('PluginController', () => {
       await t.controller.runOnAddHooks(entry);
 
       expect(warn).toHaveBeenCalledWith('[uc][plugin-manager]', expect.stringContaining('onAdd'), expect.any(Error));
-      expect(entry.getValue('file')).toBe(original);
+      expect(entry.get('file')).toBe(original);
     });
 
     it('applies a Blob-returning hook without touching fileName', async () => {
@@ -318,13 +318,13 @@ describe('PluginController', () => {
       const newBlob = new Blob(['data'], { type: 'text/plain' });
       await t.sync([withOnAddHook(() => ({ file: newBlob }))]);
       const entry = makeEntry(new File(['x'], 'a.txt'));
-      entry.setValue('fileName', 'original.txt');
+      entry.set('fileName', 'original.txt');
 
       await t.controller.runOnAddHooks(entry);
 
-      expect(entry.getValue('file')).toBe(newBlob);
-      expect(entry.getValue('fileName')).toBe('original.txt'); // unchanged — a Blob has no name
-      expect(entry.getValue('mimeType')).toBe('text/plain');
+      expect(entry.get('file')).toBe(newBlob);
+      expect(entry.get('fileName')).toBe('original.txt'); // unchanged — a Blob has no name
+      expect(entry.get('mimeType')).toBe('text/plain');
     });
 
     it('skips a hook that exceeds its timeout', async () => {

--- a/src/abstract/managers/plugin/PluginController.ts
+++ b/src/abstract/managers/plugin/PluginController.ts
@@ -174,7 +174,7 @@ export class PluginController {
   }
 
   public async runOnAddHooks(entry: UploadEntryTypedData): Promise<void> {
-    const initialFile = entry.getValue('file');
+    const initialFile = entry.get('file');
     if (!initialFile) return;
 
     const onAddHooks = this.registry.snapshot().fileHooks.filter((h) => h.type === 'onAdd');
@@ -196,12 +196,12 @@ export class PluginController {
     }
 
     if (file !== initialFile) {
-      entry.setValue('file', file as File);
-      entry.setValue('fileSize', file.size);
-      entry.setValue('mimeType', file.type || null);
-      entry.setValue('isImage', fileIsImage(file));
+      entry.set('file', file as File);
+      entry.set('fileSize', file.size);
+      entry.set('mimeType', file.type || null);
+      entry.set('isImage', fileIsImage(file));
       if (file instanceof File) {
-        entry.setValue('fileName', file.name);
+        entry.set('fileName', file.name);
       }
     }
   }

--- a/src/abstract/managers/plugin/buildPluginApi.test.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.test.ts
@@ -126,9 +126,9 @@ describe('buildPluginApi', () => {
       });
 
       const entry = collection.read(internalId)!;
-      expect(entry.getValue('cdnUrl')).toBe('https://ucarecdn.com/uuid/');
-      expect(entry.getValue('cdnUrlModifiers')).toBe('-/resize/100x/');
-      expect(entry.getValue('mimeType')).toBe('image/png');
+      expect(entry.get('cdnUrl')).toBe('https://ucarecdn.com/uuid/');
+      expect(entry.get('cdnUrlModifiers')).toBe('-/resize/100x/');
+      expect(entry.get('mimeType')).toBe('image/png');
     });
 
     it('update applies a new file, syncing fileSize', () => {
@@ -140,8 +140,8 @@ describe('buildPluginApi', () => {
       api.files.update(internalId, { file });
 
       const entry = collection.read(internalId)!;
-      expect(entry.getValue('file')).toBe(file);
-      expect(entry.getValue('fileSize')).toBe(file.size);
+      expect(entry.get('file')).toBe(file);
+      expect(entry.get('fileSize')).toBe(file.size);
     });
 
     it('update is a no-op for an unknown internalId (no throw)', () => {

--- a/src/abstract/managers/plugin/buildPluginApi.ts
+++ b/src/abstract/managers/plugin/buildPluginApi.ts
@@ -88,12 +88,12 @@ export function buildPluginApi(
       const entry = container.getOrNull(UploadCollectionController)?.read(internalId as Uid);
       if (!entry) return;
       if (changes.file !== undefined) {
-        entry.setValue('file', changes.file as File);
-        entry.setValue('fileSize', changes.file.size);
+        entry.set('file', changes.file as File);
+        entry.set('fileSize', changes.file.size);
       }
-      if (changes.cdnUrl !== undefined) entry.setValue('cdnUrl', changes.cdnUrl);
-      if (changes.cdnUrlModifiers !== undefined) entry.setValue('cdnUrlModifiers', changes.cdnUrlModifiers);
-      if (changes.mimeType !== undefined) entry.setValue('mimeType', changes.mimeType);
+      if (changes.cdnUrl !== undefined) entry.set('cdnUrl', changes.cdnUrl);
+      if (changes.cdnUrlModifiers !== undefined) entry.set('cdnUrlModifiers', changes.cdnUrlModifiers);
+      if (changes.mimeType !== undefined) entry.set('mimeType', changes.mimeType);
     },
   };
 

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
@@ -32,7 +32,7 @@ afterEach(() => {
 });
 
 type FakeEntry = {
-  setMultipleValues: ReturnType<typeof vi.fn>;
+  setMany: ReturnType<typeof vi.fn>;
 };
 
 // Minimal `UploadCollectionController` fake: `read(uid)` returns an entry whose
@@ -47,7 +47,7 @@ const makeFakeCollection = (entriesById: Record<string, { cdnUrl?: string } & Fa
       if (!entry) return undefined;
       return {
         get: (key: string) => (key === 'cdnUrl' ? entry.cdnUrl : undefined),
-        setMany: entry.setMultipleValues,
+        setMany: entry.setMany,
       } as unknown as TypedData<UploadEntryData>;
     },
   }) as unknown as UploadCollectionController;
@@ -116,7 +116,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     const ctxName = freshCtxName();
     const { el } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany: vi.fn() } },
     });
     const editor = editorEl(el);
     expect(editor).not.toBeNull();
@@ -127,7 +127,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     const ctxName = freshCtxName();
     const { el, config } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany: vi.fn() } },
     });
     config.set('cropPreset', '1:1');
     config.set('cloudImageEditorTabs', 'crop,tuning');
@@ -146,10 +146,10 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
 
   it('applies the editor result to the entry and traverses onBack on the "apply" event', async () => {
     const ctxName = freshCtxName();
-    const setMultipleValues = vi.fn();
+    const setMany = vi.fn();
     const { el, router } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany } },
     });
     const traverse = vi.spyOn(router, 'traverse');
     const editor = editorEl(el);
@@ -161,7 +161,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
       }),
     );
 
-    expect(setMultipleValues).toHaveBeenCalledWith({
+    expect(setMany).toHaveBeenCalledWith({
       cdnUrl: 'https://cdn.test/file-1/-/edited/',
       cdnUrlModifiers: '-/edited/',
     });
@@ -172,7 +172,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     const ctxName = freshCtxName();
     const { el, router } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany: vi.fn() } },
     });
     const traverse = vi.spyOn(router, 'traverse');
     editorEl(el)?.dispatchEvent(new CustomEvent('cancel', { detail: {} }));
@@ -188,7 +188,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     const ctxName = freshCtxName();
     const { el, router } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues: vi.fn() } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany: vi.fn() } },
     });
     const traverse = vi.spyOn(router, 'traverse');
     editorEl(el)?.dispatchEvent(new CustomEvent('change', { detail: { cdnUrlModifiers: '-/x/' } }));
@@ -199,10 +199,10 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
 
   it('ignores the "apply" event when there is no resolved entry', async () => {
     const ctxName = freshCtxName();
-    const setMultipleValues = vi.fn();
+    const setMany = vi.fn();
     const { el, router } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMultipleValues } },
+      entries: { 'file-1': { cdnUrl: 'https://cdn.test/file-1/', setMany } },
     });
     const editor = editorEl(el);
     const traverse = vi.spyOn(router, 'traverse');
@@ -212,7 +212,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     editor?.dispatchEvent(
       new CustomEvent('apply', { detail: { cdnUrl: 'https://cdn.test/x/', cdnUrlModifiers: '-/x/' } }),
     );
-    expect(setMultipleValues).not.toHaveBeenCalled();
+    expect(setMany).not.toHaveBeenCalled();
     expect(traverse).not.toHaveBeenCalled();
   });
 
@@ -228,7 +228,7 @@ describe('CloudImageEditorActivity (M-god step 6b-9 migration)', () => {
     const ctxName = freshCtxName();
     const { el } = await mount(ctxName, {
       internalId: 'file-1',
-      entries: { 'file-1': { setMultipleValues: vi.fn() } },
+      entries: { 'file-1': { setMany: vi.fn() } },
     });
     expect(editorEl(el)).toBeNull();
   });

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.test.ts
@@ -36,7 +36,7 @@ type FakeEntry = {
 };
 
 // Minimal `UploadCollectionController` fake: `read(uid)` returns an entry whose
-// `getValue('cdnUrl')` resolves so `_mountEditor` sets `_cdnUrl`. Absent a
+// `get('cdnUrl')` resolves so `_mountEditor` sets `_cdnUrl`. Absent a
 // `cdnUrl` (or absent the whole collection) the block's
 // `whenController(UploadCollectionController)` observer leaves `_cdnUrl` null and
 // nothing renders — matching the v1 mount gate.
@@ -46,8 +46,8 @@ const makeFakeCollection = (entriesById: Record<string, { cdnUrl?: string } & Fa
       const entry = entriesById[uid as string];
       if (!entry) return undefined;
       return {
-        getValue: (key: string) => (key === 'cdnUrl' ? entry.cdnUrl : undefined),
-        setMultipleValues: entry.setMultipleValues,
+        get: (key: string) => (key === 'cdnUrl' ? entry.cdnUrl : undefined),
+        setMany: entry.setMultipleValues,
       } as unknown as TypedData<UploadEntryData>;
     },
   }) as unknown as UploadCollectionController;

--- a/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
+++ b/src/blocks/CloudImageEditorActivity/CloudImageEditorActivity.ts
@@ -51,7 +51,7 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
     }
     this._log.debug(`editor event "apply"`, e.detail);
     const result = e.detail;
-    this._entry.setMultipleValues({
+    this._entry.setMany({
       cdnUrl: result.cdnUrl,
       cdnUrlModifiers: result.cdnUrlModifiers,
     });
@@ -84,7 +84,7 @@ export class CloudImageEditorActivity extends ActivityChildBlock {
         throw new Error(`Entry with internalId "${internalId}" not found`);
       }
       this._entry = entry;
-      const cdnUrl = this._entry.getValue('cdnUrl');
+      const cdnUrl = this._entry.get('cdnUrl');
       if (!cdnUrl) {
         throw new Error(`Entry with internalId "${internalId}" hasn't uploaded yet`);
       }

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -109,7 +109,7 @@ export class FileItem extends FileItemConfig {
     // scope (teardown race), where the throwing `use()` would be unsafe.
     const collection = this._collection;
     if (this.uid && collection?.hasItem(this.uid)) {
-      this.entry?.getValue('abortController')?.abort();
+      this.entry?.get('abortController')?.abort();
       collection.remove(this.uid);
     }
   };
@@ -122,17 +122,17 @@ export class FileItem extends FileItemConfig {
 
     let state: FileItemStateValue = FileItemState.IDLE;
 
-    if (entry.getValue('errors').length > 0) {
+    if (entry.get('errors').length > 0) {
       state = FileItemState.FAILED;
-    } else if (entry.getValue('isQueuedForUploading')) {
+    } else if (entry.get('isQueuedForUploading')) {
       state = FileItemState.QUEUED_UPLOADING;
-    } else if (entry.getValue('isQueuedForValidation')) {
+    } else if (entry.get('isQueuedForValidation')) {
       state = FileItemState.QUEUED_VALIDATION;
-    } else if (entry.getValue('isValidationPending')) {
+    } else if (entry.get('isValidationPending')) {
       state = FileItemState.VALIDATION;
-    } else if (entry.getValue('isUploading')) {
+    } else if (entry.get('isUploading')) {
       state = FileItemState.UPLOADING;
-    } else if (entry.getValue('fileInfo')) {
+    } else if (entry.get('fileInfo')) {
       state = FileItemState.FINISHED;
     }
 
@@ -150,13 +150,13 @@ export class FileItem extends FileItemConfig {
       if (!this.useOrNull(LocaleController)) {
         return;
       }
-      const errorText = entry.getValue('errors')?.[0]?.message ?? '';
-      const source = entry.getValue('source');
-      const externalUrl = entry.getValue('externalUrl');
+      const errorText = entry.get('errors')?.[0]?.message ?? '';
+      const source = entry.get('source');
+      const externalUrl = entry.get('externalUrl');
       const isFinished = state === FileItemState.FINISHED;
       const isQueuedForValidation = state === FileItemState.QUEUED_VALIDATION;
       const isValidationPending = state === FileItemState.VALIDATION;
-      const fileName = entry.getValue('fileName');
+      const fileName = entry.get('fileName');
       let hint = '';
 
       if (errorText) {
@@ -167,7 +167,7 @@ export class FileItem extends FileItemConfig {
 
       this._hint = hint;
       this._errorText = errorText;
-      this._progressValue = isQueuedForValidation || isValidationPending ? 0 : entry.getValue('uploadProgress');
+      this._progressValue = isQueuedForValidation || isValidationPending ? 0 : entry.get('uploadProgress');
       this._ariaLabelStatusFile = fileName
         ? this.l10n('a11y-file-item-status', {
             fileName,
@@ -243,12 +243,12 @@ export class FileItem extends FileItemConfig {
     });
 
     this.subEntry('fileName', (name) => {
-      this._itemName = name || entry.getValue('externalUrl') || this.l10n('file-no-name');
+      this._itemName = name || entry.get('externalUrl') || this.l10n('file-no-name');
       this._debouncedCalculateState();
     });
 
     this.subEntry('externalUrl', (externalUrl) => {
-      this._itemName = entry.getValue('fileName') || externalUrl || this.l10n('file-no-name');
+      this._itemName = entry.get('fileName') || externalUrl || this.l10n('file-no-name');
     });
 
     this.subEntry('fileInfo', () => {

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -21,12 +21,19 @@ export class FileItemConfig extends ChildBlock {
     };
   }
 
-  protected subEntry<K extends UploadEntryKeys>(prop: K, handler: (value: UploadEntryData[K]) => void): void {
-    this.withEntry<[K, (value: UploadEntryData[K]) => void], void>((entry, propInner, handlerInner) => {
+  protected subEntry<K extends UploadEntryKeys>(
+    prop: K,
+    handler: (value: UploadEntryData[K] | undefined) => void,
+  ): void {
+    this.withEntry<[K, (value: UploadEntryData[K] | undefined) => void], void>((entry, propInner, handlerInner) => {
       const sub = entry.observe(
         propInner,
         (value) => {
-          if (!this.isConnected || value === undefined) return;
+          // Deliver the value even when it's `undefined` — clearing an optional
+          // field (e.g. `thumbUrl`/`fileName` reset to `undefined`) is a real
+          // observation consumers must see, not one to drop. Only bail if we're
+          // no longer connected (a trailing tick after teardown).
+          if (!this.isConnected) return;
           handlerInner(value);
         },
         { immediate: true },

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -1,7 +1,7 @@
 import type { UploadEntryData, UploadEntryKeys, UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
 import { ChildBlock } from '../../lit/ChildBlock';
 
-type EntrySubscription = ReturnType<UploadEntryTypedData['subscribe']>;
+type EntrySubscription = ReturnType<UploadEntryTypedData['observe']>;
 
 export class FileItemConfig extends ChildBlock {
   private _entrySubs: Set<EntrySubscription> = new Set<EntrySubscription>();
@@ -23,11 +23,15 @@ export class FileItemConfig extends ChildBlock {
 
   protected subEntry<K extends UploadEntryKeys>(prop: K, handler: (value: UploadEntryData[K]) => void): void {
     this.withEntry<[K, (value: UploadEntryData[K]) => void], void>((entry, propInner, handlerInner) => {
-      const sub = entry.subscribe(propInner, (value) => {
-        if (this.isConnected) {
-          handlerInner(value);
-        }
-      });
+      const sub = entry.observe(
+        propInner,
+        (value) => {
+          if (this.isConnected) {
+            handlerInner(value);
+          }
+        },
+        { immediate: true },
+      );
       this._entrySubs.add(sub);
     })(prop, handler);
   }

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -26,9 +26,8 @@ export class FileItemConfig extends ChildBlock {
       const sub = entry.observe(
         propInner,
         (value) => {
-          if (this.isConnected) {
-            handlerInner(value);
-          }
+          if (!this.isConnected || value === undefined) return;
+          handlerInner(value);
         },
         { immediate: true },
       );

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.test.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.test.ts
@@ -123,7 +123,7 @@ describe('ProgressBarCommon (M-god step 6b-2 migration)', () => {
       observeProperties: vi.fn(() => vi.fn()),
       observeCollection: vi.fn(() => vi.fn()),
       items: () => ['a'],
-      read: () => ({ getValue: () => true }),
+      read: () => ({ get: () => true }),
     } as unknown as UploadCollectionController;
     container.bind(UploadCollectionController, () => collection);
     container.get(UploadCollectionController); // resolve eagerly (simulates an already-populated scope)
@@ -153,7 +153,7 @@ describe('ProgressBarCommon (M-god step 6b-2 migration)', () => {
         return vi.fn();
       }),
       items: () => (uploading ? ['a'] : []),
-      read: () => ({ getValue: () => uploading }),
+      read: () => ({ get: () => uploading }),
     } as unknown as UploadCollectionController;
     container.bind(UploadCollectionController, () => collection);
 

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
@@ -26,7 +26,7 @@ export class ProgressBarCommon extends ChildBlock {
 
   /** Recompute `_visible` from current collection membership + `isUploading` state. */
   private _recomputeVisible(collection: UploadCollectionController): void {
-    this._visible = collection.items().some((id) => collection.read(id)?.getValue('isUploading') ?? false);
+    this._visible = collection.items().some((id) => collection.read(id)?.get('isUploading') ?? false);
   }
 
   // The uploader-scope `UploadCollectionController` resolves only once the scope

--- a/src/blocks/Thumb/Thumb.ts
+++ b/src/blocks/Thumb/Thumb.ts
@@ -83,10 +83,10 @@ export class Thumb extends FileItemConfig {
 
   // biome-ignore lint/style/noInferrableTypes: Here the type is needed because `_withEntry` could not infer it correctly
   private _generateThumbnail = this.withEntry(async (entry, force: boolean = false) => {
-    const fileInfo = entry.getValue('fileInfo');
-    const isImage = entry.getValue('isImage');
-    const uuid = entry.getValue('uuid');
-    const currentThumbUrl = entry.getValue('thumbUrl');
+    const fileInfo = entry.get('fileInfo');
+    const isImage = entry.get('isImage');
+    const uuid = entry.get('uuid');
+    const currentThumbUrl = entry.get('thumbUrl');
 
     const size = this._calculateThumbSize(force);
 
@@ -94,7 +94,7 @@ export class Thumb extends FileItemConfig {
       const thumbUrl = await this.proxyUrl(
         createCdnUrl(
           createOriginalUrl(this._config.get('cdnCname'), uuid),
-          createCdnUrlModifiers(entry.getValue('cdnUrlModifiers'), `stretch/off`, `scale_crop/${size}x${size}/center`),
+          createCdnUrlModifiers(entry.get('cdnUrlModifiers'), `stretch/off`, `scale_crop/${size}x${size}/center`),
         ),
       );
 
@@ -106,43 +106,43 @@ export class Thumb extends FileItemConfig {
 
       promise
         .then(() => {
-          entry.setValue('thumbUrl', thumbUrl);
+          entry.set('thumbUrl', thumbUrl);
           currentThumbUrl?.startsWith('blob:') && URL.revokeObjectURL(currentThumbUrl);
         })
         .catch(async () => {
           if (currentThumbUrl?.startsWith('blob:')) return;
           try {
-            const file = entry.getValue('file');
+            const file = entry.get('file');
             if (!file) return;
             const blobThumbUrl = await generateThumb(file, size);
-            entry.setValue('thumbUrl', blobThumbUrl);
+            entry.set('thumbUrl', blobThumbUrl);
           } catch (err) {
             this._telemetry.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
             const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
-            entry.setValue('thumbUrl', fileCssBg(color));
+            entry.set('thumbUrl', fileCssBg(color));
           }
         });
 
       return;
     }
 
-    if (entry.getValue('thumbUrl')) {
+    if (entry.get('thumbUrl')) {
       return;
     }
 
-    const file = entry.getValue('file');
+    const file = entry.get('file');
     if (file?.type.includes('image')) {
       try {
         const thumbUrl = await generateThumb(file, size);
-        entry.setValue('thumbUrl', thumbUrl);
+        entry.set('thumbUrl', thumbUrl);
       } catch (err) {
         this._telemetry.sendEventError(err, 'thumbnail generation. Failed to generate thumb from file');
         const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
-        entry.setValue('thumbUrl', fileCssBg(color));
+        entry.set('thumbUrl', fileCssBg(color));
       }
     } else {
       const color = window.getComputedStyle(this).getPropertyValue('--uc-muted-foreground');
-      entry.setValue('thumbUrl', fileCssBg(color));
+      entry.set('thumbUrl', fileCssBg(color));
     }
   });
 

--- a/src/utils/validators/file/validateUploadError.ts
+++ b/src/utils/validators/file/validateUploadError.ts
@@ -10,7 +10,7 @@ export const validateUploadError: FuncFileValidator = (outputEntry, api) => {
   }
   const internalEntry = api._uploadCollection.read(internalId as Uid);
 
-  const cause: unknown = internalEntry?.getValue('uploadError');
+  const cause: unknown = internalEntry?.get('uploadError');
   if (!cause) {
     return;
   }


### PR DESCRIPTION
## What & why

Unifies the codebase's several keyed reactive state stores behind **one contract and one shared implementation**. They had the same conceptual shape (a keyed reactive value store) but were distinct classes with drifting APIs and two backings (signals vs coarse `Listeners`). Now every store reads and behaves identically, and the signals-vs-not split is reconciled.

Internal wiring only — no documented public API change.

## Design (composition, not inheritance)

- **`ReactiveStore<T>` interface** — the canonical contract: `get` (fast, non-tracking) · `getTracked` (signal read) · `set` · `setMany` · `subscribe` (coarse) · `observe` (atomic per-key) · `values` · `notify` · `destroy`. Deliberately satisfiable by **both** backings.
- **`SignalMap<T>`** promoted to the canonical store: gained `getTracked` + `setMany` (one coalesced coarse notify), `implements ReactiveStore<T>`. Hot-path `get()` stays a fast bag read — the signal is write-maintained only for `getTracked()`.
- **`ConfigController` / `LocaleController` / `CollectionStateController`** compose `SignalMap` and forward the full canonical surface (`implements ReactiveStore<…>`), fixing prior API drift (Locale gained `observe`/`setMany`/`notify`, etc.).
- **`TypedData<T>`** rewritten to compose `SignalMap`; its bespoke `getValue`/`setValue`/`setMultipleValues`/`snapshot`/per-key-`subscribe` surface **renamed everywhere** to `get`/`set`/`setMany`/`values`/`observe({immediate:true})` (staged via temporary aliases, then removed). Static `getByUid`/`uid` retained; unknown-key warn, immediate-observe, and removed-but-alive semantics preserved.
- **`Listeners.observe`** immediate fire is now isolate-and-warn wrapped (preserves `TypedData`'s old per-subscriber isolation at the `UploadCollectionController.add` hot path).
- **Editor `StateController` / `CloudImageEditorController`** conform to `ReactiveStore<T>` **Listeners-backed** (interface-only). The signal-backing was gated on `size-limit`: the editor bundle sits at 49.01/50 kB, so signals were deliberately **not** pulled into it — the interface is satisfiable either way, so the surface still unifies.
- `LazyPluginsController` unchanged — already composes `SignalMap`, keeps its narrow single-value API.

## Review

Executed task-by-task with a spec+quality review after each (fresh subagents). Whole-branch review run with **grok** against an external rule set: genuine findings fixed (collapse `getTracked` onto the shared API, finish a `setMultipleValues` test-fake rename, narrow `undefined` in `FileItemConfig.subEntry`, `setMany` skip-undefined, TypedData read-guard consistency, test-hygiene). Findings that conflicted with this repo's own conventions were declined by design decision: `//` comment style and doc density (biome-enforced project style), and `SignalMap`'s public-method count (the intentional result of the one-shared-store design).

## Test plan — full green gate

- `tsc:app` / `tsc:test` / `tsc:e2e`
- `build` (incl. `size-limit`; editor bundle 49.01/50 kB)
- `test:specs` — **1071 passing**
- `test:locales`
- `test:e2e` — **383 passing** (real Chromium)
- `lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a consistent reactive store API for reading, updating, observing, and batch-updating state.
  * Added per-key observation with optional immediate updates and unsubscribe support.
  * Added coalesced notifications for batch changes and explicit notification controls.
  * State updates now support clearing optional values with `undefined`.

* **Bug Fixes**
  * Improved observer reliability by isolating errors so other observers continue receiving updates.
  * Updated upload, validation, cropping, thumbnail, and editor workflows to use the new state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->