### PR TITLE
refactor(a11y,clipboard): per-host scope registration via HostScopeController + A11y symmetric teardown

### DIFF
--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -238,4 +238,39 @@ describe('A11y', () => {
 
     expect(() => a11y.unregisterBlock(asNode(scope))).not.toThrow();
   });
+
+  it('double unregisterBlock is safe: the second call is a no-op and stays disarmed', () => {
+    const a11y = track(new A11y());
+    const { scope, button } = buttonInScope();
+    a11y.registerBlock(asNode(scope));
+
+    a11y.unregisterBlock(asNode(scope)); // last scope → disarm
+    expect(() => a11y.unregisterBlock(asNode(scope))).not.toThrow();
+
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
+
+  it('unregisterBlock for a never-registered scope leaves other scopes armed', () => {
+    const a11y = track(new A11y());
+    const registered = buttonInScope();
+    a11y.registerBlock(asNode(registered.scope));
+
+    a11y.unregisterBlock(asNode(document.createElement('div'))); // never registered → no disarm
+
+    registered.button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(registered.button.classList.contains('is-pressed')).toBe(true);
+  });
+
+  it('registering the same scope twice is idempotent: one unregisterBlock fully detaches it', () => {
+    const a11y = track(new A11y());
+    const { scope, button } = buttonInScope();
+
+    a11y.registerBlock(asNode(scope));
+    a11y.registerBlock(asNode(scope)); // idempotent (Set-backed)
+    a11y.unregisterBlock(asNode(scope)); // single unregister removes it
+
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
 });

--- a/src/abstract/managers/a11y.test.ts
+++ b/src/abstract/managers/a11y.test.ts
@@ -168,4 +168,74 @@ describe('A11y', () => {
 
     expect(button.classList.contains('is-pressed')).toBe(false);
   });
+
+  const buttonInScope = (): { scope: HTMLDivElement; button: HTMLButtonElement } => {
+    const scope = document.createElement('div');
+    document.body.append(scope);
+    const button = document.createElement('button');
+    scope.append(button);
+    return { scope, button };
+  };
+
+  it('unregisterBlock detaches a scope: keydown targeting it goes inert', () => {
+    const a11y = track(new A11y());
+    const { scope, button } = buttonInScope();
+    a11y.registerBlock(asNode(scope));
+
+    a11y.unregisterBlock(asNode(scope));
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+    expect(button.classList.contains('is-pressed')).toBe(false);
+  });
+
+  it('unregistering one of two scopes keeps the other armed and observable', () => {
+    const a11y = track(new A11y());
+    const a = buttonInScope();
+    const b = buttonInScope();
+    a11y.registerBlock(asNode(a.scope));
+    a11y.registerBlock(asNode(b.scope));
+
+    a11y.unregisterBlock(asNode(a.scope));
+
+    a.button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    b.button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(a.button.classList.contains('is-pressed')).toBe(false);
+    expect(b.button.classList.contains('is-pressed')).toBe(true);
+  });
+
+  it('unregistering the last scope disarms the window listeners (paired remove for every add)', () => {
+    const addSpy = vi.spyOn(window, 'addEventListener');
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const a11y = track(new A11y());
+    const { scope } = buttonInScope();
+
+    a11y.registerBlock(asNode(scope));
+    const addedTypes = addSpy.mock.calls.map((call) => call[0]).sort();
+    expect(addedTypes.length).toBeGreaterThan(0);
+
+    a11y.unregisterBlock(asNode(scope));
+    const removedTypes = removeSpy.mock.calls.map((call) => call[0]).sort();
+    expect(removedTypes).toEqual(addedTypes);
+  });
+
+  it('re-arms when a scope is registered again after the last one was unregistered', () => {
+    const a11y = track(new A11y());
+    const { scope, button } = buttonInScope();
+
+    a11y.registerBlock(asNode(scope));
+    a11y.unregisterBlock(asNode(scope)); // last scope → disarm
+    a11y.registerBlock(asNode(scope)); // re-arm
+
+    button.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+    expect(button.classList.contains('is-pressed')).toBe(true);
+  });
+
+  it('unregisterBlock after destroy() is a no-op (does not throw)', () => {
+    const a11y = new A11y();
+    const { scope } = buttonInScope();
+    a11y.registerBlock(asNode(scope));
+    a11y.destroy();
+
+    expect(() => a11y.unregisterBlock(asNode(scope))).not.toThrow();
+  });
 });

--- a/src/abstract/managers/a11y.ts
+++ b/src/abstract/managers/a11y.ts
@@ -20,7 +20,18 @@ class ScopedMinimalWindow implements MinimalWindow {
   // listener (keyux's own teardown removes each listener before `destroy()`).
   private readonly _listeners = new Map<KeyEventListener, { wrapped: KeyEventListener; cancel: () => void }>();
   readonly #disposables = new Disposables();
-  private _scope: Node[] = [];
+  // A `Set` (matching `ClipboardController._scopes`): registering the same node
+  // twice is idempotent, and one `unregisterScope` fully removes it.
+  private _scope = new Set<Node>();
+
+  private _isInScope(target: Node): boolean {
+    for (const el of this._scope) {
+      if (el === target || el.contains(target)) {
+        return true;
+      }
+    }
+    return false;
+  }
 
   public addEventListener(type: 'keydown' | 'keyup', listener: KeyEventListener): void {
     const wrappedListener: KeyEventListener = (event) => {
@@ -28,7 +39,7 @@ class ScopedMinimalWindow implements MinimalWindow {
       if (!(target instanceof Node)) {
         return;
       }
-      if (this._scope.some((el) => el === target || el.contains(target))) {
+      if (this._isInScope(target)) {
         listener(event);
       }
     };
@@ -59,17 +70,17 @@ class ScopedMinimalWindow implements MinimalWindow {
   }
 
   public registerScope(scope: Node): void {
-    this._scope.push(scope);
+    this._scope.add(scope);
   }
 
   /** Drop a scope; returns the number of scopes still registered. */
   public unregisterScope(scope: Node): number {
-    this._scope = this._scope.filter((el) => el !== scope);
-    return this._scope.length;
+    this._scope.delete(scope);
+    return this._scope.size;
   }
 
   public destroy(): void {
-    this._scope = [];
+    this._scope.clear();
     // Runs one `removeEventListener('keydown'/'keyup', …)` teardown per attached
     // wrapped listener (isolate-and-warn), matching the previous manual loop.
     this.#disposables.run();
@@ -142,9 +153,7 @@ export class A11y implements Destroyable {
 
   public destroy(): void {
     this._destroyed = true;
-    this._armed = false;
-    this._destroyKeyUX?.();
-    this._destroyKeyUX = undefined;
+    this._disarm();
     this._scopedWindow.destroy();
   }
 }

--- a/src/abstract/managers/a11y.ts
+++ b/src/abstract/managers/a11y.ts
@@ -62,6 +62,12 @@ class ScopedMinimalWindow implements MinimalWindow {
     this._scope.push(scope);
   }
 
+  /** Drop a scope; returns the number of scopes still registered. */
+  public unregisterScope(scope: Node): number {
+    this._scope = this._scope.filter((el) => el !== scope);
+    return this._scope.length;
+  }
+
   public destroy(): void {
     this._scope = [];
     // Runs one `removeEventListener('keydown'/'keyup', …)` teardown per attached
@@ -110,6 +116,28 @@ export class A11y implements Destroyable {
     }
     this._scopedWindow.registerScope(scope);
     this._arm();
+  }
+
+  /**
+   * Detach a block's scope. When the last scope is removed, disarm the keyux
+   * window listeners (they re-arm on the next `registerBlock`) so a fully
+   * disconnected widget doesn't retain global `keydown`/`keyup` handlers.
+   */
+  public unregisterBlock(scope: Node): void {
+    if (this._destroyed) {
+      return;
+    }
+    const remaining = this._scopedWindow.unregisterScope(scope);
+    if (remaining === 0) {
+      this._disarm();
+    }
+  }
+
+  /** Tear down the keyux window listeners; `_arm()` can re-attach them later. */
+  private _disarm(): void {
+    this._armed = false;
+    this._destroyKeyUX?.();
+    this._destroyKeyUX = undefined;
   }
 
   public destroy(): void {

--- a/src/lit/HostScopeController.test.ts
+++ b/src/lit/HostScopeController.test.ts
@@ -1,0 +1,65 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { describe, expect, it, vi } from 'vitest';
+import { HostScopeController } from './HostScopeController';
+
+// Minimal host: records the controller so the test can drive its lifecycle.
+class FakeHost {
+  public controllers: ReactiveController[] = [];
+  public addController(c: ReactiveController): void {
+    this.controllers.push(c);
+  }
+  public removeController(): void {}
+  public requestUpdate(): void {}
+  public updateComplete = Promise.resolve(true);
+}
+
+const asHost = (host: FakeHost) => host as unknown as ReactiveControllerHost;
+
+describe('HostScopeController', () => {
+  it('adds itself to the host', () => {
+    const host = new FakeHost();
+    const controller = new HostScopeController(asHost(host), () => () => {});
+    expect(host.controllers).toContain(controller);
+  });
+
+  it('registers on hostConnected and unregisters on hostDisconnected', () => {
+    const host = new FakeHost();
+    const unregister = vi.fn();
+    const register = vi.fn(() => unregister);
+    const controller = new HostScopeController(asHost(host), register);
+
+    controller.hostConnected();
+    expect(register).toHaveBeenCalledTimes(1);
+    expect(unregister).not.toHaveBeenCalled();
+
+    controller.hostDisconnected();
+    expect(unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-register while already connected (idempotent hostConnected)', () => {
+    const host = new FakeHost();
+    const register = vi.fn(() => () => {});
+    const controller = new HostScopeController(asHost(host), register);
+
+    controller.hostConnected();
+    controller.hostConnected();
+    expect(register).toHaveBeenCalledTimes(1);
+  });
+
+  it('re-registers across a disconnect → reconnect', () => {
+    const host = new FakeHost();
+    const register = vi.fn(() => () => {});
+    const controller = new HostScopeController(asHost(host), register);
+
+    controller.hostConnected();
+    controller.hostDisconnected();
+    controller.hostConnected();
+    expect(register).toHaveBeenCalledTimes(2);
+  });
+
+  it('hostDisconnected without a prior register is a no-op (does not throw)', () => {
+    const host = new FakeHost();
+    const controller = new HostScopeController(asHost(host), () => () => {});
+    expect(() => controller.hostDisconnected()).not.toThrow();
+  });
+});

--- a/src/lit/HostScopeController.ts
+++ b/src/lit/HostScopeController.ts
@@ -1,0 +1,35 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+
+/**
+ * Per-host reactive controller that registers the host's DOM scope with a
+ * shared, per-ctx aggregator — the `ClipboardController` (`paste`) and `A11y`
+ * (`keydown`/`keyup`) window-listener owners — while the host is connected, and
+ * unregisters it when the host goes away.
+ *
+ * The `register` thunk resolves the aggregator and registers this host's scope,
+ * returning the matching unregister — so this controller stays agnostic of which
+ * aggregator it drives. Because the aggregators are resolved from the ctx's DI
+ * container (only available once adopted), the owning block creates this in
+ * `controllerReady` and tears it down in `controllerReleased`; `hostConnected`
+ * registers (fires immediately on `addController` since the host is already
+ * connected by then) and `hostDisconnected` unregisters (idempotent, so an
+ * explicit teardown followed by Lit's own disconnect callback can't double-fire).
+ */
+export class HostScopeController implements ReactiveController {
+  #register: () => () => void;
+  #unregister: (() => void) | null = null;
+
+  public constructor(host: ReactiveControllerHost, register: () => () => void) {
+    this.#register = register;
+    host.addController(this);
+  }
+
+  public hostConnected(): void {
+    this.#unregister ??= this.#register();
+  }
+
+  public hostDisconnected(): void {
+    this.#unregister?.();
+    this.#unregister = null;
+  }
+}

--- a/src/lit/SolutionChildBlock.ts
+++ b/src/lit/SolutionChildBlock.ts
@@ -8,6 +8,7 @@ import { A11y } from '../abstract/managers/a11y';
 import type { LazyPluginEntry } from '../abstract/managers/plugin/LazyPluginLoader';
 import svgIconsSprite from '../blocks/themes/uc-basic/svg-sprite';
 import { ChildBlock } from './ChildBlock';
+import { HostScopeController } from './HostScopeController';
 
 /**
  * v2 `ChildBlock`-based equivalent of `LitSolutionBlock` (v1). A solution tag
@@ -21,19 +22,29 @@ export abstract class SolutionChildBlock extends ChildBlock {
   public static override styleAttrs = ['uc-wgt-common'];
   public static lazyPlugins: LazyPluginEntry[] | null = null;
 
-  private _unregisterClipboardScope: (() => void) | null = null;
+  // Per-host scope registrations with the shared per-ctx `ClipboardController`
+  // (`paste`) and `A11y` (`keydown`/`keyup`) window-listener aggregators, driven
+  // by `HostScopeController`. Created in `controllerReady` (where the container
+  // resolves the aggregators) and torn down in `controllerReleased`.
+  private _clipboardScope: HostScopeController | null = null;
+  private _a11yScope: HostScopeController | null = null;
 
   protected override controllerReady(container: ControllerContainer): void {
     super.controllerReady(container);
 
-    // Re-adoption safety (teardown-before-resubscribe, mirroring
-    // Config/SolutionBlock): drop the previous cycle's clipboard scope before
-    // registering a new one, so re-adoption doesn't stack two scopes.
-    this._unregisterClipboardScope?.();
-    this._unregisterClipboardScope = null;
+    // Re-adoption safety (teardown-before-resubscribe): drop the previous
+    // cycle's scopes before registering new ones, so re-adoption doesn't stack.
+    this._teardownScopes();
 
-    container.get(A11y).registerBlock(this);
-    this._unregisterClipboardScope = container.get(ClipboardController).registerScope(this) ?? null;
+    const clipboard = container.get(ClipboardController);
+    this._clipboardScope = new HostScopeController(this, () => clipboard.registerScope(this));
+
+    const a11y = container.get(A11y);
+    this._a11yScope = new HostScopeController(this, () => {
+      a11y.registerBlock(this);
+      return () => a11y.unregisterBlock(this);
+    });
+
     // A boot-time identity fact on the container-owned `AppInfo`, not pub/sub
     // state — read lazily by telemetry as the payload's `component`.
     container.get(AppInfo).setSolutionName(this.tagName);
@@ -49,13 +60,20 @@ export abstract class SolutionChildBlock extends ChildBlock {
 
   protected override controllerReleased(container: ControllerContainer): void {
     super.controllerReleased(container);
-    // Drop our scope from the shared clipboard controller so a detached
-    // element isn't retained until ctx teardown. `controllerReady` re-runs on
-    // re-adoption and re-registers the scope. Note: v1 never unregisters the
-    // a11y block in `disconnectedCallback` either — matched here (no paired
-    // unregister exists on `A11y`).
-    this._unregisterClipboardScope?.();
-    this._unregisterClipboardScope = null;
+    // Drop our scopes from the shared aggregators so a detached element isn't
+    // retained until ctx teardown; `controllerReady` re-registers on re-adoption.
+    this._teardownScopes();
+  }
+
+  private _teardownScopes(): void {
+    for (const scope of [this._clipboardScope, this._a11yScope]) {
+      if (scope) {
+        scope.hostDisconnected();
+        this.removeController(scope);
+      }
+    }
+    this._clipboardScope = null;
+    this._a11yScope = null;
   }
 
   public override render() {

--- a/src/lit/SolutionChildBlock.ts
+++ b/src/lit/SolutionChildBlock.ts
@@ -66,10 +66,10 @@ export abstract class SolutionChildBlock extends ChildBlock {
   }
 
   private _teardownScopes(): void {
-    for (const scope of [this._clipboardScope, this._a11yScope]) {
-      if (scope) {
-        scope.hostDisconnected();
-        this.removeController(scope);
+    for (const controller of [this._clipboardScope, this._a11yScope]) {
+      if (controller) {
+        controller.hostDisconnected();
+        this.removeController(controller);
       }
     }
     this._clipboardScope = null;

--- a/tests/lit/SolutionChildBlock.e2e.test.tsx
+++ b/tests/lit/SolutionChildBlock.e2e.test.tsx
@@ -105,4 +105,30 @@ describe('SolutionChildBlock', () => {
     // above) — re-adoption must not double-release it.
     expect(unregister).toHaveBeenCalledTimes(1);
   });
+
+  it('releases the a11y scope (unregisterBlock) on disconnect and re-registers on reconnect (re-adoption)', async () => {
+    const ctxName = getCtxName();
+    page.render(<uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>);
+    const container = containerOf(ctxName);
+
+    const registerBlockSpy = vi.spyOn(container.get(A11y), 'registerBlock');
+    const unregisterBlockSpy = vi.spyOn(container.get(A11y), 'unregisterBlock');
+
+    const child = append('uc-test-solution-child', { 'ctx-name': ctxName });
+    await expect.poll(() => child.readyCount).toBe(1);
+    expect(registerBlockSpy).toHaveBeenCalledWith(child);
+    expect(unregisterBlockSpy).not.toHaveBeenCalled();
+
+    // The load-bearing fix: on disconnect the a11y scope is released (previously
+    // it leaked until ctx teardown — there was no unregisterBlock at all).
+    child.remove();
+    expect(unregisterBlockSpy).toHaveBeenCalledWith(child);
+    expect(unregisterBlockSpy).toHaveBeenCalledTimes(1);
+
+    document.body.append(child);
+    await expect.poll(() => child.readyCount).toBe(2);
+    // Re-adoption re-registers rather than stacking; no extra release.
+    expect(registerBlockSpy).toHaveBeenCalledTimes(2);
+    expect(unregisterBlockSpy).toHaveBeenCalledTimes(1);
+  });
 });


### PR DESCRIPTION
## What & why

Converts the two genuine host-lifecycle aggregators — `ClipboardController` (`paste`) and `A11y` (`keydown`/`keyup`) — to register their per-block DOM scopes through a reusable Lit reactive controller, and gives `A11y` the symmetric teardown it was missing.

Internal wiring only — no documented public API change.

## Changes

- **`A11y.unregisterBlock`** (+ `ScopedMinimalWindow.unregisterScope`): drops a block's scope and **disarms** the keyux window listeners when the last scope is removed (they re-arm on the next `registerBlock`). Previously `A11y` had no unregister at all — a disconnected widget's scope leaked until ctx teardown. Scopes are now `Set`-backed (matching `ClipboardController`): idempotent register, single-delete unregister.
- **`HostScopeController`** — a small reusable per-host `ReactiveController` (following the `SourceListController` precedent) that registers a host's scope on `hostConnected` and unregisters on `hostDisconnected` via a `register → unregister` thunk, so it's agnostic of which aggregator it drives.
- **`SolutionChildBlock`** now registers both the clipboard and a11y scopes through `HostScopeController`s, created in `controllerReady` (where the ctx container resolves the aggregators) and torn down in `controllerReleased` — replacing the hand-rolled registration and closing the a11y leak.

## Review

Reviewed with **grok** against an external rule set: no Critical; the one Important (the a11y leak-fix wasn't pinned at the `SolutionChildBlock` boundary) and the Minors (Set vs array, `destroy()` DRY, negative-path tests, a local name) are all fixed. The e2e now asserts `A11y.unregisterBlock` on disconnect + re-register on reconnect, mirroring the clipboard case.

## Test plan — full green gate

- `tsc:app` / `tsc:test` / `tsc:e2e`
- `build` (incl. `size-limit`)
- `test:specs` — **1039 passing** (a11y +6, `HostScopeController` +5)
- `test:locales`
- `test:e2e` — **385 passing** (real Chromium; + the new a11y release/reconnect pin)
- `lint` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic host-scoped accessibility and clipboard scope registration with lifecycle-aware connect/disconnect handling.
  * Implemented per-host scope aggregation to ensure correct behavior across re-adoption (remove/reconnect).
* **Bug Fixes**
  * Improved accessibility scope teardown so keyboard listeners are disarmed only after the final scope is removed.
  * Ensured `unregisterBlock`/scope cleanup is idempotent and does not interfere with other active scopes.
  * Added end-to-end coverage for accessibility scope lifecycle during re-adoption.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->