### PR TITLE
feat(lit): @throttled/@debounced adoption-scoped method decorators

### DIFF
--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -10,6 +10,7 @@ import type { ControllerContainer } from '../../abstract/di/ControllerContainer'
 import { inject, injectOrNull } from '../../abstract/di/inject';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { ChildBlock } from '../../lit/ChildBlock';
+import { throttled } from '../../lit/rate-limited-method';
 import { subscription, type Unsubscribe } from '../../lit/subscription';
 import type { Uid } from '../../lit/Uid';
 import type { SourceButtonConfig } from '../SourceBtn/SourceBtn';
@@ -20,7 +21,6 @@ import './dynamic-btn.css';
 import './dynamic-btn-mode.css';
 
 import type { OutputCollectionState, OutputCollectionStatus } from '../../types/exported';
-import { throttle } from '../../utils/throttle';
 import '../Thumb/Thumb';
 import { classMap } from 'lit/directives/class-map.js';
 
@@ -162,17 +162,19 @@ export class DynamicBtn extends ChildBlock {
     return !this.isIdle && this.hasCollectionEntries;
   }
 
-  private _throttledHandleCollectionUpdate = throttle(() => {
-    if (!this.isConnected) {
-      return;
-    }
+  // `@throttled` makes this adopted-guarded (a trailing tick after release
+  // no-ops) and cancels the pending timer on release — replacing the old
+  // `!this.isConnected` bail and the manual `.cancel()` in `controllerReleased`.
+  // The name is unchanged, so the `@subscription` observers can still hand this
+  // stable bound reference to `observeCollection`.
+  @throttled(300)
+  protected _throttledHandleCollectionUpdate(): void {
     this._updateButtonBasedOnCollectionState();
-  }, 300);
+  }
 
   private _updateButtonBasedOnCollectionState() {
-    // This runs from the throttled tick, which can fire after the block is
-    // released while still connected — `_api` is `@injectOrNull`, so it reads
-    // `null` then (the trailing-tick guard the v1 `bag.apiOrNull` read provided).
+    // Reached only through the adopted-guarded throttled tick, so `_api` is live
+    // here; the `?.` remains only because the field is `@injectOrNull`-typed.
     const collectionState = this._api?.getOutputCollectionState();
 
     if (!collectionState) {
@@ -330,13 +332,9 @@ export class DynamicBtn extends ChildBlock {
 
   protected override controllerReleased(): void {
     this._teardownSourceListController();
-    // The throttled collection-update tick is fed by the `@subscription`
-    // collection observers (auto-disposed on release); cancel any trailing tick
-    // here so it can't fire against a released container. Runs on disconnect too,
-    // via the base `disconnectedCallback` → `_releaseController`.
-    if (typeof this._throttledHandleCollectionUpdate.cancel === 'function') {
-      this._throttledHandleCollectionUpdate.cancel();
-    }
+    // The throttled collection-update tick is cancelled on release automatically
+    // by `@throttled` (registered in `_adoptController`, drained by
+    // `_releaseController`) — no manual `.cancel()` needed here.
   }
 
   private _teardownSourceListController(): void {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -9,8 +9,8 @@ import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { ActivityChildBlock } from '../../lit/ActivityChildBlock';
 import { ACTIVITY_TYPES } from '../../lit/activity-constants';
+import { throttled } from '../../lit/rate-limited-method';
 import { subscription, type Unsubscribe } from '../../lit/subscription';
-import { throttle } from '../../utils/throttle';
 import { EventType, InternalEventType } from '../UploadCtxProvider/EventEmitter';
 import './upload-list.css';
 import { repeat } from 'lit/directives/repeat.js';
@@ -35,9 +35,10 @@ export class UploadList extends ActivityChildBlock {
   // current container on each access, so re-adoption is safe): `ConfigController`,
   // `CollectionStateController`, `TelemetryManager`, plus `UploaderPublicApi`
   // (flow actions) and `UploadCollectionController` (clear-all). `RouterController`
-  // is inherited from `ActivityChildBlock`. The teardown-tolerant reads (the guard
-  // predicate + the throttled tick can fire after release, where an `@inject` read
-  // would throw) stay on `useOrNull`.
+  // is inherited from `ActivityChildBlock`. The throttled collection-update tick
+  // is now adoption-guarded by `@throttled` (it no-ops after release), so it
+  // reads these `@inject` fields directly; only the visibility predicate — which
+  // can also run during a teardown tick — still reads via `useOrNull`.
   @inject(ConfigController) private readonly _config!: ConfigController;
   @inject(CollectionStateController) private readonly _collectionState!: CollectionStateController;
   @inject(TelemetryManager) private readonly _telemetry!: TelemetryManager;
@@ -126,25 +127,23 @@ export class UploadList extends ActivityChildBlock {
     this._uploadCollection.clearAll();
   };
 
-  private _throttledHandleCollectionUpdate = throttle(() => {
-    // A trailing tick can fire after the block is released while still connected
-    // (registry unregistration race) — read null-tolerantly via `useOrNull` and
-    // bail rather than throwing uncaught in the timeout (DynamicBtn precedent).
-    const config = this.useOrNull(ConfigController);
-    if (!this.isConnected || !config) {
-      return;
-    }
+  // `@throttled` makes this adopted-guarded (a trailing tick after release —
+  // e.g. a registry-unregistration race — no-ops) and cancels the pending timer
+  // on release, so the body reads its throwing `@inject` fields directly instead
+  // of the old `useOrNull` bail. Callers keep using `this._throttledHandleCollectionUpdate`
+  // (a stable bound reference, still safe to hand to `observeCollection`).
+  @throttled(300)
+  protected _throttledHandleCollectionUpdate(): void {
     this._updateUploadsState();
 
     // The router guard (registered via `_guardNonEmpty`) decides whether the
     // empty list may stay open; ask it to re-check now that the collection changed.
-    // Null-tolerant (`useOrNull`): this trailing tick can fire after release.
-    this.useOrNull(RouterController)?.revalidate();
+    this.container.get(RouterController).revalidate();
 
-    if (!config.get('confirmUpload')) {
-      this.useOrNull(UploaderPublicApi)?.uploadAll();
+    if (!this._config.get('confirmUpload')) {
+      this._api.uploadAll();
     }
-  }, 300);
+  }
 
   private _updateUploadsState(): void {
     // Imperative derived-state recompute (writes the toolbar/button `@state`

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -20,6 +20,7 @@ import { ensureUploaderCtx } from './ensureUploaderCtx';
 import { LightDomMixin } from './LightDomMixin';
 import { createL10n } from './l10n';
 import { RegisterableElementMixin } from './RegisterableElementMixin';
+import { registerHostRateLimited } from './rate-limited-method';
 import { registerHostSubscriptions } from './subscription';
 
 // `SignalWatcher` sits at the base of the mixin chain so it wraps
@@ -417,13 +418,18 @@ export abstract class ChildBlock extends ChildBlockBase {
     }
     // Wire this block's declarative reactive methods now that the container is
     // adopted (so their `getTracked` / controller reads resolve): `@effect`
-    // (signal reactions; connected-guarded disposers — see `registerHostEffects`)
-    // and `@subscription` (imperative subscribes returning a teardown). Both are
-    // auto-disposed on release, so a block never tracks a disposer by hand.
+    // (signal reactions; connected-guarded disposers — see `registerHostEffects`),
+    // `@subscription` (imperative subscribes returning a teardown), and
+    // `@throttled`/`@debounced` (rate-limited handlers whose pending timer is
+    // cancelled on release). All are auto-disposed on release, so a block never
+    // tracks a disposer by hand.
     for (const dispose of registerHostEffects(this)) {
       this._disposables.add(dispose);
     }
     for (const teardown of registerHostSubscriptions(this)) {
+      this._disposables.add(teardown);
+    }
+    for (const teardown of registerHostRateLimited(this)) {
       this._disposables.add(teardown);
     }
     this.requestUpdate();

--- a/src/lit/rate-limited-method.test.ts
+++ b/src/lit/rate-limited-method.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { debounced, registerHostRateLimited, throttled } from './rate-limited-method';
+
+// A minimal `ChildBlock`-shaped host: the decorator reads only `containerOrNull`
+// (a truthy container means "adopted"). Methods are public here purely so the
+// tests can invoke them without bracket access.
+class Host {
+  public containerOrNull: object | null = {};
+  public calls: string[] = [];
+
+  @throttled(100)
+  public onThrottled(tag: string): void {
+    this.calls.push(`t:${tag}`);
+  }
+
+  @debounced(100)
+  public onDebounced(tag: string): void {
+    this.calls.push(`d:${tag}`);
+  }
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('@throttled / @debounced', () => {
+  it('exposes a stable bound reference per instance (safe to hand to observe())', () => {
+    const host = new Host();
+    const ref1 = host.onThrottled;
+    const ref2 = host.onThrottled;
+    expect(ref1).toBe(ref2); // cached own-property after first getter read
+    // Runtime shape is the limiter (with `cancel`); the declared type stays the
+    // method signature, so read `cancel` through a cast at this test boundary.
+    expect(typeof (ref1 as unknown as { cancel: () => void }).cancel).toBe('function');
+
+    // A second instance gets its own limiter, not the first's.
+    const other = new Host();
+    expect(other.onThrottled).not.toBe(ref1);
+  });
+
+  it('throttles: leading call runs immediately, bursts collapse', () => {
+    const host = new Host();
+    host.onThrottled('a'); // leading edge → runs now
+    host.onThrottled('b');
+    host.onThrottled('c');
+    expect(host.calls).toEqual(['t:a']);
+
+    vi.advanceTimersByTime(100); // trailing edge → one more
+    expect(host.calls).toEqual(['t:a', 't:c']);
+  });
+
+  it('debounces: only the trailing call runs after the wait', () => {
+    const host = new Host();
+    host.onDebounced('a');
+    host.onDebounced('b');
+    expect(host.calls).toEqual([]); // nothing yet
+
+    vi.advanceTimersByTime(100);
+    expect(host.calls).toEqual(['d:b']);
+  });
+
+  it('adopted-guard: a tick that fires after release no-ops (body never runs)', () => {
+    const host = new Host();
+    host.onDebounced('a'); // scheduled while adopted
+    host.containerOrNull = null; // released before the timer fires
+
+    vi.advanceTimersByTime(100);
+    expect(host.calls).toEqual([]); // guard bailed — @inject reads would be unsafe
+
+    // Re-adopting and firing again runs normally (same limiter reused).
+    host.containerOrNull = {};
+    host.onDebounced('b');
+    vi.advanceTimersByTime(100);
+    expect(host.calls).toEqual(['d:b']);
+  });
+});
+
+describe('registerHostRateLimited', () => {
+  it('returns one teardown that cancels every pending limiter on the host', () => {
+    const host = new Host();
+    const [teardown] = registerHostRateLimited(host);
+    expect(teardown).toBeTypeOf('function');
+
+    host.onDebounced('a'); // pending
+    teardown!(); // release → cancel
+    vi.advanceTimersByTime(100);
+    expect(host.calls).toEqual([]); // pending debounce was cancelled
+  });
+
+  it('reuses the same limiter across a release cycle (re-adoption does not re-create)', () => {
+    const host = new Host();
+    const ref = host.onDebounced;
+    const [teardown] = registerHostRateLimited(host);
+
+    host.onDebounced('a');
+    teardown!(); // cancel pending
+    expect(host.onDebounced).toBe(ref); // same cached bound limiter
+
+    host.onDebounced('b'); // works after the cancel
+    vi.advanceTimersByTime(100);
+    expect(host.calls).toEqual(['d:b']);
+  });
+
+  it('returns an empty array for a host with no rate-limited methods', () => {
+    class Plain {
+      public containerOrNull: object | null = {};
+    }
+    expect(registerHostRateLimited(new Plain())).toEqual([]);
+  });
+});

--- a/src/lit/rate-limited-method.ts
+++ b/src/lit/rate-limited-method.ts
@@ -1,0 +1,120 @@
+import type { ControllerContainer } from '../abstract/di/ControllerContainer';
+import { debounce } from '../utils/debounce';
+import { throttle } from '../utils/throttle';
+import { collectDecoratedMethods, makeMethodDecorator } from './reactive-method-registry';
+
+/**
+ * `@throttled(ms)` / `@debounced(ms)` — method decorators for `ChildBlock`
+ * handlers that must be rate-limited AND scoped to the block's controller
+ * adoption. Siblings of `@effect` / `@subscription`, but where those run once at
+ * adoption and return a teardown, a rate-limited handler is called MANY times
+ * over the block's life — so the decorator turns the method into a lazily-built,
+ * per-instance-cached BOUND rate-limiter with three automatic properties:
+ *
+ * 1. **Rate-limited** — wraps `utils/debounce` / `utils/throttle`; one limiter
+ *    per (instance, method), created on first access.
+ * 2. **Adopted-guarded** — a call after release (or before adoption) no-ops, so
+ *    the body reads its throwing `@inject` fields directly (no `useOrNull`
+ *    inside) — the guard lives at the one edge, not scattered through the body.
+ * 3. **Cancelled on release** — `registerHostRateLimited` (run by `ChildBlock`
+ *    at adoption, next to `registerHostEffects` / `registerHostSubscriptions`)
+ *    returns a teardown that cancels every pending limiter on release; the
+ *    limiter itself survives so re-adoption reuses it.
+ *
+ * The decorated property is a bound, stable reference: `this._x` yields the same
+ * limiter every read (safe to hand to `observeCollection(this._x)`), `this._x()`
+ * invokes it, and `this._x.cancel()` cancels it — byte-for-byte with the
+ * `private _x = throttle(this._raw.bind(this), ms)` field it replaces. Use the
+ * `_name` convention (a runtime string key the registry reads), not `#private`.
+ */
+
+/** A rate-limited callable with the utils' `cancel`. */
+type RateLimiter = ((...args: never[]) => void) & { cancel: () => void };
+/** `debounce` / `throttle` share this `(fn, wait) → fn & { cancel }` shape. */
+type RateLimiterFactory = (fn: (...args: never[]) => void, wait: number) => RateLimiter;
+
+/** The `ChildBlock` slice the guard reads — a null container means "not adopted". */
+interface RateLimitedHost {
+  readonly containerOrNull: ControllerContainer | null;
+}
+
+// Per-instance set of created limiters, so release can cancel every pending one.
+const STORE = Symbol('uc.rateLimited.store');
+// Marks a class as having rate-limited methods, so the host only registers the
+// cancel-all teardown when there is something to cancel.
+const RATE_LIMITED = Symbol('uc.rateLimited');
+const record = makeMethodDecorator<void>(RATE_LIMITED);
+
+type StoreHost = RateLimitedHost & { [STORE]?: Set<RateLimiter> };
+
+const makeDecorator =
+  (factory: RateLimiterFactory) =>
+  (wait: number) =>
+  (proto: object, key: string, descriptor?: PropertyDescriptor): PropertyDescriptor => {
+    // The original handler: `descriptor.value` under experimental decorators,
+    // falling back to the prototype property.
+    const original = (descriptor?.value ?? (proto as Record<string, unknown>)[key]) as (...args: never[]) => void;
+    record()(proto, key);
+
+    // RETURN the replacement descriptor (a getter) — the TS legacy-decorator
+    // emit re-applies whatever we return via `Object.defineProperty`, so
+    // mutating the prototype in-body would be clobbered by the original method
+    // descriptor. The getter, on first per-instance read, builds the bound
+    // limiter, caches it as an own (non-enumerable) data property (so later reads
+    // are cheap and return the SAME reference — safe to hand to `observe`), and
+    // registers it for release-cancel.
+    return {
+      configurable: true,
+      enumerable: false,
+      get(this: StoreHost): RateLimiter {
+        const limiter = factory((...args: never[]) => {
+          // Adopted-guard: a tick that fires after release must not run the body
+          // (whose `@inject` reads would throw on a released container).
+          if (this.containerOrNull) {
+            original.apply(this, args);
+          }
+        }, wait);
+        let store = this[STORE];
+        if (!store) {
+          store = new Set<RateLimiter>();
+          this[STORE] = store;
+        }
+        store.add(limiter);
+        Object.defineProperty(this, key, {
+          value: limiter,
+          configurable: true,
+          writable: true,
+          enumerable: false,
+        });
+        return limiter;
+      },
+    };
+  };
+
+/** Method decorator: rate-limit via `throttle`, adopted-guarded + release-cancelled. */
+export const throttled = makeDecorator(throttle as RateLimiterFactory);
+
+/** Method decorator: rate-limit via `debounce`, adopted-guarded + release-cancelled. */
+export const debounced = makeDecorator(debounce as RateLimiterFactory);
+
+/**
+ * Cancel every pending `@throttled` / `@debounced` limiter on `host` when the
+ * returned teardown runs (on controller release). The limiters themselves stay
+ * cached on the instance, so re-adoption reuses them. Returns an empty array for
+ * a host with no rate-limited methods, so the common block registers nothing.
+ */
+export function registerHostRateLimited(host: object): Array<() => void> {
+  if (collectDecoratedMethods<void>(host, RATE_LIMITED).length === 0) {
+    return [];
+  }
+  return [
+    () => {
+      const store = (host as StoreHost)[STORE];
+      if (store) {
+        for (const limiter of store) {
+          limiter.cancel();
+        }
+      }
+    },
+  ];
+}


### PR DESCRIPTION
> Stacked on #1049 (base `feat/v2-drop-upload-host-bridge`).

## What

Adds `@throttled(ms)` / `@debounced(ms)` — method decorators for `ChildBlock` handlers, siblings of `@effect`/`@subscription`. They retire the "rate-limited tick reads state after release" footgun (and the scattered `useOrNull(...)?.` guards inside those ticks).

A decorated method becomes a lazily-built, per-instance-cached **bound** rate-limiter (over `utils/debounce` + `throttle`) with three automatic properties:

1. **Rate-limited** — one limiter per (instance, method), created on first read.
2. **Adopted-guarded** — a tick that fires after controller release no-ops, so the body reads its throwing `@inject` fields directly (no `useOrNull` inside).
3. **Cancelled on release** — `registerHostRateLimited` (run in `_adoptController`, next to the existing two registries) cancels every pending limiter when the block's controller releases — a plain disconnect **or** an in-place `ctx-name` switch. The limiter survives, so re-adoption reuses it.

The decorated property stays a **stable bound reference** (`this._x === this._x`), so it's still safe to hand to `observeCollection(this._x)` — byte-for-byte with the `private _x = throttle(this._raw.bind(this), ms)` field it replaces.

## Migrated sites

- **`UploadList._throttledHandleCollectionUpdate`** — dropped the 3 `useOrNull` bails inside the tick (the guard now guarantees adoption).
- **`DynamicBtn._throttledHandleCollectionUpdate`** — dropped the `!isConnected` bail and the manual `.cancel()` in `controllerReleased` (now automatic).

**Left as-is:** `Thumb`'s debounce cancels on entry-reset / intersection-exit, not just release — it's entry-scoped, not adoption-scoped, so the decorator would be a worse fit. DOM-free controllers keep their `#disposables.add(() => x.cancel())` pattern (no adoption lifecycle).

## Gate

`tsc` · `build` (size-limit, editor bundle 48.5 KB) · **1111** specs (+7 for the decorator) · locales · **384** e2e · lint (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of collection-driven updates and upload button behavior during rapid changes.
  - Prevented throttled work from running after components are released, reducing stale UI updates.
  - Ensured pending throttled executions behave correctly when components are reactivated.

- **Improvements**
  - Added consistent decorator-based throttling/debouncing for smoother handling of bursty interactions.
  - Improved lifecycle rate-limited handler cleanup and re-adoption behavior for child components.

- **Tests**
  - Added coverage for throttled/debounced behavior and release/reattach edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->