### PR TITLE
refactor(collection): demand-driven property observation + batchers, large-N perf

### DIFF
--- a/src/abstract/TypedData.test.ts
+++ b/src/abstract/TypedData.test.ts
@@ -95,6 +95,19 @@ describe('TypedData (ReactiveStore)', () => {
     d.destroy();
   });
 
+  it('subscribeKeys reports the changed key on each write', () => {
+    const d = make();
+    const keys: string[] = [];
+    const off = d.subscribeKeys((key) => keys.push(String(key)));
+    d.set('a', 1);
+    d.setMany({ b: 'y' });
+    expect(keys).toEqual(['a', 'b']);
+    off();
+    d.set('a', 2);
+    expect(keys).toEqual(['a', 'b']); // unsubscribed
+    d.destroy();
+  });
+
   it('notify() forces a coarse notification with no state change', () => {
     const d = make();
     const listener = vi.fn();

--- a/src/abstract/TypedData.ts
+++ b/src/abstract/TypedData.ts
@@ -91,6 +91,16 @@ export class TypedData<T extends Record<string, unknown>> implements ReactiveSto
     return this.#store.subscribe(listener);
   }
 
+  /**
+   * Keyed subscription: `listener` fires with the changed key on each write.
+   * Lets a consumer learn which field changed from ONE subscription — e.g.
+   * `UploadCollectionController` builds its per-prop change-map from a single
+   * `subscribeKeys` per entry instead of one `observe` per watched key.
+   */
+  public subscribeKeys(listener: (key: keyof T) => void): () => void {
+    return this.#store.subscribeKeys(listener);
+  }
+
   public observe<K extends keyof T>(
     key: K,
     listener: (value: T[K] | undefined) => void,

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -63,6 +63,40 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
+  it('scopes fan-out per observer: an observer is not woken by another observer’s key', () => {
+    const collection = new UploadCollectionController();
+    const id = collection.add({});
+    vi.runOnlyPendingTimers();
+
+    const progressObs = vi.fn();
+    const uploadingObs = vi.fn();
+    collection.observeProperties(['uploadProgress'], progressObs);
+    collection.observeProperties(['isUploading'], uploadingObs);
+
+    collection.publishProp(id, 'uploadProgress', 50); // only uploadProgress changes
+    vi.runOnlyPendingTimers();
+
+    expect(progressObs).toHaveBeenCalledTimes(1);
+    expect(uploadingObs).not.toHaveBeenCalled(); // not woken — it declared only isUploading
+    // …and each observer sees only its own key.
+    expect(Object.keys((progressObs.mock.calls[0]?.[0] ?? {}) as object)).toEqual(['uploadProgress']);
+    collection.destroy();
+  });
+
+  it('add fires the collection (membership) observer before the property observer', () => {
+    const collection = new UploadCollectionController();
+    const order: string[] = [];
+    collection.observeCollection(() => order.push('collection'));
+    collection.observeProperties(['fileInfo'], () => order.push('property'));
+
+    // An already-uploaded entry (fileInfo set) fires both on add; membership first.
+    collection.add({ fileInfo: { uuid: 'srv' } as never });
+    vi.runOnlyPendingTimers();
+
+    expect(order).toEqual(['collection', 'property']);
+    collection.destroy();
+  });
+
   it('does not notify property observers for an unobserved key', () => {
     const collection = new UploadCollectionController();
     const id = collection.add({});

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -105,4 +105,98 @@ describe('UploadCollectionController', () => {
     vi.advanceTimersByTime(10_000);
     collection.destroy();
   });
+
+  it('readProp / publishProp throw for an unknown id', () => {
+    const collection = new UploadCollectionController();
+    expect(() => collection.readProp('ghost' as never, 'uploadProgress')).toThrow(/not found/);
+    expect(() => collection.publishProp('ghost' as never, 'uploadProgress', 1)).toThrow(/not found/);
+    collection.destroy();
+  });
+
+  it('abort removes an uploading entry and leaves a non-uploading one', () => {
+    const collection = new UploadCollectionController();
+    const uploading = collection.add({ isUploading: true });
+    const idle = collection.add({ isUploading: false });
+    vi.runOnlyPendingTimers();
+
+    collection.abort(uploading);
+    collection.abort(idle);
+
+    expect(collection.hasItem(uploading)).toBe(false); // uploading → removed
+    expect(collection.hasItem(idle)).toBe(true); // not uploading → untouched
+
+    vi.advanceTimersByTime(10_000);
+    collection.destroy();
+  });
+
+  it('abortAll aborts only the uploading entries', () => {
+    const collection = new UploadCollectionController();
+    const uploading = collection.add({ isUploading: true });
+    const idle = collection.add({ isUploading: false });
+    vi.runOnlyPendingTimers();
+
+    collection.abortAll();
+
+    expect(collection.hasItem(uploading)).toBe(false);
+    expect(collection.hasItem(idle)).toBe(true);
+
+    vi.advanceTimersByTime(10_000);
+    collection.destroy();
+  });
+
+  it('unobserve stops further collection + property notifications', () => {
+    const collection = new UploadCollectionController();
+    const collObserver = vi.fn();
+    const propObserver = vi.fn();
+    const offColl = collection.observeCollection(collObserver);
+    const offProp = collection.observeProperties(propObserver);
+
+    const id = collection.add({ uploadProgress: 0 });
+    vi.runOnlyPendingTimers();
+    collObserver.mockClear();
+    propObserver.mockClear();
+
+    offColl();
+    offProp();
+
+    collection.add({});
+    collection.publishProp(id, 'uploadProgress', 42);
+    vi.runOnlyPendingTimers();
+
+    expect(collObserver).not.toHaveBeenCalled();
+    expect(propObserver).not.toHaveBeenCalled();
+    collection.destroy();
+  });
+
+  it('re-arms the deferred-destroy timer when another entry is removed mid-window', () => {
+    const collection = new UploadCollectionController();
+    const a = collection.add({});
+    const b = collection.add({});
+    vi.advanceTimersByTime(1); // flush adds (0-delay notify), not the 10s destroy
+
+    collection.remove(a);
+    vi.advanceTimersByTime(1); // _notify flush schedules the deferred-destroy timer
+    vi.advanceTimersByTime(5_000); // partway through the 10s window
+    collection.remove(b);
+    vi.advanceTimersByTime(1); // _notify flush re-arms the destroy timer (clears the pending one)
+    expect(TypedData.getByUid(a)).not.toBeNull(); // still alive — the re-arm reset the window
+
+    vi.advanceTimersByTime(10_000); // full window from the re-arm
+    expect(TypedData.getByUid(a)).toBeNull();
+    expect(TypedData.getByUid(b)).toBeNull();
+    collection.destroy();
+  });
+
+  it('destroy() force-destroys entries still marked for deferred destroy', () => {
+    const collection = new UploadCollectionController();
+    const id = collection.add({});
+    vi.runOnlyPendingTimers();
+
+    collection.remove(id); // marks for the ~10s deferred destroy
+    vi.runOnlyPendingTimers();
+    expect(TypedData.getByUid(id)).not.toBeNull(); // still in the destroy window
+
+    collection.destroy(); // must force-destroy the marked entry now, not wait 10s
+    expect(TypedData.getByUid(id)).toBeNull();
+  });
 });

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -97,6 +97,27 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
+  it('drops a queued property change for an entry removed before the flush', () => {
+    const collection = new UploadCollectionController();
+    const propObserver = vi.fn();
+    collection.observeProperties(['uploadProgress'], propObserver);
+    const id = collection.add({});
+    vi.runOnlyPendingTimers();
+    propObserver.mockClear();
+
+    // Queue a property change, then remove the entry in the same macrotask —
+    // the pending flush must not report the now-unresolvable uid.
+    collection.publishProp(id, 'uploadProgress', 50);
+    collection.remove(id);
+    vi.runOnlyPendingTimers();
+
+    for (const call of propObserver.mock.calls) {
+      const changeMap = call[0] as Record<string, Set<string>>;
+      expect(changeMap.uploadProgress?.has(id) ?? false).toBe(false);
+    }
+    collection.destroy();
+  });
+
   it('does not notify property observers for an unobserved key', () => {
     const collection = new UploadCollectionController();
     const id = collection.add({});

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -27,13 +27,13 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
-  it('read/readProp/publishProp work and watch-list changes notify property observers per-key', () => {
+  it('read/readProp/publishProp work and an observed key change notifies property observers per-key', () => {
     const collection = new UploadCollectionController();
     const propObserver = vi.fn();
-    collection.observeProperties(propObserver);
+    collection.observeProperties(['uploadProgress'], propObserver);
 
     const id = collection.add({ uploadProgress: 0 });
-    vi.runOnlyPendingTimers(); // flush the add's immediate watch-list fires
+    vi.runOnlyPendingTimers(); // flush the immediate-on-add fire for observed keys
     propObserver.mockClear();
 
     collection.publishProp(id, 'uploadProgress', 50);
@@ -47,17 +47,66 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
-  it('does not notify property observers for non-watch-list props', () => {
+  it('immediate-on-add: surfaces the initial observed-key state of a new entry', () => {
+    // Load-bearing for already-uploaded files: an entry added with `fileInfo`
+    // set must reach the fileInfo-observing consumer on add (→ FILE_UPLOAD_SUCCESS),
+    // with no property change afterward.
+    const collection = new UploadCollectionController();
+    const propObserver = vi.fn();
+    collection.observeProperties(['fileInfo'], propObserver); // observe BEFORE add
+
+    const id = collection.add({ fileInfo: { uuid: 'srv' } as never });
+    vi.runOnlyPendingTimers();
+
+    const changeMap = (propObserver.mock.calls[0]?.[0] ?? {}) as Record<string, Set<string>>;
+    expect([...(changeMap.fileInfo ?? [])]).toContain(id);
+    collection.destroy();
+  });
+
+  it('does not notify property observers for an unobserved key', () => {
     const collection = new UploadCollectionController();
     const id = collection.add({});
     vi.runOnlyPendingTimers();
 
     const propObserver = vi.fn();
-    collection.observeProperties(propObserver);
-    collection.publishProp(id, 'thumbUrl', 'blob:x'); // thumbUrl is not in the watch-list
+    collection.observeProperties(['uploadProgress'], propObserver); // only uploadProgress observed
+    collection.publishProp(id, 'thumbUrl', 'blob:x'); // thumbUrl is not observed
     vi.runOnlyPendingTimers();
 
     expect(propObserver).not.toHaveBeenCalled();
+    collection.destroy();
+  });
+
+  it('gates the change-map to declared keys even when other keys change in the same tick', () => {
+    const collection = new UploadCollectionController();
+    const id = collection.add({});
+    vi.runOnlyPendingTimers();
+
+    const propObserver = vi.fn();
+    collection.observeProperties(['isUploading'], propObserver);
+    // Two keys change in one macrotask; only the declared one may enter the map.
+    collection.publishProp(id, 'thumbUrl', 'blob:x');
+    collection.publishProp(id, 'isUploading', true);
+    vi.runOnlyPendingTimers();
+
+    expect(propObserver).toHaveBeenCalledTimes(1);
+    const changeMap = (propObserver.mock.calls[0]?.[0] ?? {}) as Record<string, Set<string>>;
+    expect(Object.keys(changeMap)).toEqual(['isUploading']);
+    collection.destroy();
+  });
+
+  it('an observed cdnUrlModifiers change reaches the change-map (the former watch-list gap)', () => {
+    const collection = new UploadCollectionController();
+    const id = collection.add({});
+    vi.runOnlyPendingTimers();
+
+    const propObserver = vi.fn();
+    collection.observeProperties(['cdnUrlModifiers'], propObserver);
+    collection.publishProp(id, 'cdnUrlModifiers', '-/preview/');
+    vi.runOnlyPendingTimers();
+
+    const changeMap = (propObserver.mock.calls[0]?.[0] ?? {}) as Record<string, Set<string>>;
+    expect([...(changeMap.cdnUrlModifiers ?? [])]).toContain(id);
     collection.destroy();
   });
 
@@ -69,7 +118,7 @@ describe('UploadCollectionController', () => {
     collection.remove(id);
     expect(collection.hasItem(id)).toBe(false);
     expect(collection.read(id)).toBeNull(); // detached from the map immediately
-    vi.runOnlyPendingTimers(); // fires _notify, which schedules the deferred destroy
+    vi.advanceTimersByTime(1); // flush the 0-delay membership tick, not the 10s destroy
     expect(TypedData.getByUid(id)).not.toBeNull(); // entry data still readable in the window
 
     vi.advanceTimersByTime(10_000);
@@ -149,7 +198,7 @@ describe('UploadCollectionController', () => {
     const collObserver = vi.fn();
     const propObserver = vi.fn();
     const offColl = collection.observeCollection(collObserver);
-    const offProp = collection.observeProperties(propObserver);
+    const offProp = collection.observeProperties(['uploadProgress'], propObserver);
 
     const id = collection.add({ uploadProgress: 0 });
     vi.runOnlyPendingTimers();
@@ -193,7 +242,7 @@ describe('UploadCollectionController', () => {
     vi.runOnlyPendingTimers();
 
     collection.remove(id); // marks for the ~10s deferred destroy
-    vi.runOnlyPendingTimers();
+    vi.advanceTimersByTime(1); // flush membership only; the 10s destroy stays pending
     expect(TypedData.getByUid(id)).not.toBeNull(); // still in the destroy window
 
     collection.destroy(); // must force-destroy the marked entry now, not wait 10s

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -90,8 +90,25 @@ export class UploadCollectionController {
   private _flushProperties(): void {
     const changeMap = this._changeMap;
     this._changeMap = Object.create(null);
-    for (const handler of this._propertyObservers.keys()) {
-      handler({ ...changeMap });
+    const changedKeys = Object.keys(changeMap) as (keyof UploadEntryData)[];
+    for (const [handler, declared] of this._propertyObservers) {
+      // Deliver each observer ONLY its declared keys, and skip it entirely when
+      // none of them changed. This is what makes the demand-driven declaration
+      // actually scope work: a consumer that didn't declare `uploadProgress`
+      // (UploadList/DynamicBtn/ProgressBarCommon) is not woken by a progress
+      // tick, even though another observer (UploadEventsController) did declare
+      // it and put it in the change-map.
+      const scoped: UploadCollectionChangeMap = Object.create(null);
+      let any = false;
+      for (const key of changedKeys) {
+        if (declared.has(key)) {
+          scoped[key] = changeMap[key];
+          any = true;
+        }
+      }
+      if (any) {
+        handler(scoped);
+      }
     }
   }
 
@@ -156,6 +173,11 @@ export class UploadCollectionController {
       item.uid,
       item.subscribeKeys((key) => this._recordPropChange(key, item.uid)),
     );
+    // Arm membership BEFORE the immediate-on-add property fire so their 0-delay
+    // ticks flush in that order (v1 parity): a consumer sees `FILE_ADDED` before
+    // any per-prop event for the new entry — notably `FILE_UPLOAD_SUCCESS` for an
+    // already-uploaded file.
+    this._scheduleMembership();
     // Immediate-on-add (v1 parity): surface the new entry's initial observed-key
     // state to property observers. The old per-key `observe(..., {immediate:true})`
     // did this — it is load-bearing for an already-uploaded entry (fileInfo set at
@@ -165,7 +187,6 @@ export class UploadCollectionController {
     for (const key of this._observedKeys) {
       this._recordPropChange(key, item.uid);
     }
-    this._scheduleMembership();
     return item.uid;
   }
 

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -226,6 +226,18 @@ export class UploadCollectionController {
     this._entrySubs.get(id)?.();
     this._entrySubs.delete(id);
 
+    // Drop any property change queued for this entry before the next flush: a
+    // property tick must not notify observers about a uid that `read()` no
+    // longer resolves (and, with membership armed just below, must not deliver a
+    // stale property change ahead of the removal). The removal itself is carried
+    // by the membership `removed` set.
+    for (const key of Object.keys(this._changeMap) as (keyof UploadEntryData)[]) {
+      const set = this._changeMap[key];
+      if (set?.delete(id) && set.size === 0) {
+        delete this._changeMap[key];
+      }
+    }
+
     this._scheduleMembership();
     // Deferred-destroy is armed here, once, when something is actually marked —
     // not re-armed from the notify paths.

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -1,18 +1,7 @@
 import type { Uid } from '../../lit/Uid';
+import { debounce } from '../../utils/debounce';
 import { TypedData } from '../TypedData';
 import { initialUploadEntryData, type UploadEntryData } from '../uploadEntrySchema';
-
-/** Entry properties whose changes drive the property observer (v1 parity). */
-export const UPLOAD_WATCH_LIST: (keyof UploadEntryData)[] = [
-  'file',
-  'uploadProgress',
-  'uploadError',
-  'fileInfo',
-  'errors',
-  'cdnUrl',
-  'isUploading',
-  'isValidationPending',
-];
 
 export type UploadCollectionChangeMap = Partial<Record<keyof UploadEntryData, Set<Uid>>>;
 type Unsubscriber = () => void;
@@ -27,89 +16,108 @@ export type CollectionObserver = (
  * DOM-free upload collection — the per-ctx source of truth for the set of
  * upload entries, resolved from the `ControllerContainer`.
  *
- * This is the v2 rewrite of v1's `TypedCollection`: identical observation
- * semantics (one-tick-debounced collection + property observers, a watch-list
- * change-map, and a ~10s deferred destroy of removed entries) but backed by a
- * plain `Map<uid, TypedData>` instead of a per-ctx store `PubSub` context, and
- * using global timers so it runs without a DOM. Entries are `TypedData`
- * instances (already DOM-free as of M3a). The public API mirrors the former
- * `TypedCollection` (now removed) for drop-in parity with its consumers.
+ * The v2 rewrite of v1's `TypedCollection`: same observation contract
+ * (tick-debounced collection + property observers, a per-prop change-map, and a
+ * ~10s deferred destroy of removed entries) backed by a plain `Map<uid,
+ * TypedData>` and global timers, so it runs without a DOM.
+ *
+ * Observation is split into two channels:
+ * - `observeCollection` — COARSE membership (list + added/removed), debounced to
+ *   one tick per macrotask.
+ * - `observeProperties(keys, handler)` — PER-PROP change-map, DEMAND-DRIVEN: a
+ *   consumer declares the entry keys it cares about, and the controller gates
+ *   the change-map to the live union of all observers' keys. This replaces the
+ *   old hardcoded `UPLOAD_WATCH_LIST` — there is no global watch constant to
+ *   drift, and firing is scoped to keys some consumer actually reads (so an
+ *   internal-only mutation like `thumbUrl` can't spuriously drive downstream
+ *   `change` events).
+ *
+ * Each entry is watched with a SINGLE `TypedData.subscribeKeys` subscription
+ * (was one `observe` per watched key), so per-entry cost is `1×N` rather than
+ * `8×N` at large file counts. The three timers are `utils/debounce` instances
+ * (re-arm on call, `.cancel()` on teardown).
  */
 export class UploadCollectionController {
   private static readonly _destroyDelayMs = 10_000;
 
   private _data = new Map<Uid, TypedData<UploadEntryData>>();
-  private _subsMap = new Map<Uid, Unsubscriber[]>();
-  private _propertyObservers = new Set<PropertyObserver>();
+  // One key-change subscription per entry (was `UPLOAD_WATCH_LIST.length` per entry).
+  private _entrySubs = new Map<Uid, Unsubscriber>();
+  // Each property observer with the key-set it declared; `_observedKeys` is their
+  // derived union — the gate for what enters the change-map.
+  private _propertyObservers = new Map<PropertyObserver, ReadonlySet<keyof UploadEntryData>>();
+  private _observedKeys = new Set<keyof UploadEntryData>();
   private _collectionObservers = new Set<CollectionObserver>();
   private _items = new Set<Uid>();
   private _removed = new Set<TypedData<UploadEntryData>>();
   private _added = new Set<TypedData<UploadEntryData>>();
   private _markedToDestroy = new Set<TypedData<UploadEntryData>>();
-  private _observeTimeout?: ReturnType<typeof setTimeout>;
-  private _notifyTimeout?: ReturnType<typeof setTimeout>;
-  private _destroyTimeout?: ReturnType<typeof setTimeout>;
   private _changeMap: UploadCollectionChangeMap = Object.create(null);
 
-  private _notifyObservers(propName: keyof UploadEntryData, ctxId: Uid): void {
-    if (this._observeTimeout) {
-      clearTimeout(this._observeTimeout);
-    }
-    let set = this._changeMap[propName];
-    if (!set) {
-      set = new Set();
-      this._changeMap[propName] = set;
-    }
-    set.add(ctxId);
-    this._observeTimeout = setTimeout(() => {
-      if (Object.keys(this._changeMap).length === 0) {
-        return;
+  // The three batchers: property change-map + membership flush on the next tick,
+  // deferred-destroy on the ~10s delay. Calling one (re-)arms it; `.cancel()`
+  // tears it down. Deferred-destroy now lives solely here — no longer re-armed
+  // from the two notify paths.
+  private _scheduleProperties = debounce(() => this._flushProperties(), 0);
+  private _scheduleMembership = debounce(() => this._flushMembership(), 0);
+  private _scheduleDestroy = debounce(() => this._flushDestroy(), UploadCollectionController._destroyDelayMs);
+
+  private _recomputeObservedKeys(): void {
+    const keys = new Set<keyof UploadEntryData>();
+    for (const declared of this._propertyObservers.values()) {
+      for (const key of declared) {
+        keys.add(key);
       }
-      const changeMap = this._changeMap;
-      this._changeMap = Object.create(null);
-      for (const handler of this._propertyObservers) {
-        handler({ ...changeMap });
-      }
-    });
-    this._scheduleDestroyMarkedItems();
+    }
+    this._observedKeys = keys;
   }
 
-  private _notify(): void {
-    if (this._notifyTimeout) {
-      clearTimeout(this._notifyTimeout);
-    }
-    this._notifyTimeout = setTimeout(() => {
-      const added = new Set(this._added);
-      const removed = new Set(this._removed);
-      this._added.clear();
-      this._removed.clear();
-      for (const handler of this._collectionObservers) {
-        handler([...this._items], added, removed);
-      }
-      this._scheduleDestroyMarkedItems();
-    });
-  }
-
-  private _scheduleDestroyMarkedItems(): void {
-    if (this._markedToDestroy.size === 0) {
+  private _recordPropChange(key: keyof UploadEntryData, uid: Uid): void {
+    // Gate to the live union of observed keys — an unobserved key never enters
+    // the change-map, so it can't drive a downstream tick.
+    if (!this._observedKeys.has(key)) {
       return;
     }
-    if (this._destroyTimeout) {
-      clearTimeout(this._destroyTimeout);
+    let set = this._changeMap[key];
+    if (!set) {
+      set = new Set();
+      this._changeMap[key] = set;
     }
-    this._destroyTimeout = setTimeout(() => {
-      const marked = [...this._markedToDestroy];
-      this._markedToDestroy.clear();
-      for (const item of marked) {
-        item.destroy();
-      }
-    }, UploadCollectionController._destroyDelayMs);
+    set.add(uid);
+    this._scheduleProperties();
+  }
+
+  private _flushProperties(): void {
+    const changeMap = this._changeMap;
+    this._changeMap = Object.create(null);
+    for (const handler of this._propertyObservers.keys()) {
+      handler({ ...changeMap });
+    }
+  }
+
+  private _flushMembership(): void {
+    const added = new Set(this._added);
+    const removed = new Set(this._removed);
+    this._added.clear();
+    this._removed.clear();
+    const list = [...this._items];
+    for (const handler of this._collectionObservers) {
+      handler(list, added, removed);
+    }
+  }
+
+  private _flushDestroy(): void {
+    const marked = [...this._markedToDestroy];
+    this._markedToDestroy.clear();
+    for (const item of marked) {
+      item.destroy();
+    }
   }
 
   public observeCollection(handler: CollectionObserver): Unsubscriber {
     this._collectionObservers.add(handler);
     if (this._items.size > 0) {
-      this._notify();
+      this._scheduleMembership();
     }
     return () => this.unobserveCollection(handler);
   }
@@ -118,36 +126,46 @@ export class UploadCollectionController {
     this._collectionObservers.delete(handler);
   }
 
-  public observeProperties(handler: PropertyObserver): Unsubscriber {
-    this._propertyObservers.add(handler);
+  /**
+   * Observe per-entry property changes for the declared `keys`. `handler` gets a
+   * change-map (`{ key: Set<uid> }`) on the next tick after any observed key
+   * changes; it filters to the keys it reads. Declaring the keys is what lets the
+   * controller drop the hardcoded watch-list — only declared keys are tracked.
+   */
+  public observeProperties(keys: readonly (keyof UploadEntryData)[], handler: PropertyObserver): Unsubscriber {
+    this._propertyObservers.set(handler, new Set(keys));
+    this._recomputeObservedKeys();
     return () => this.unobserveProperties(handler);
   }
 
   public unobserveProperties(handler: PropertyObserver): void {
     this._propertyObservers.delete(handler);
+    this._recomputeObservedKeys();
   }
 
   public add(init: Partial<UploadEntryData>): Uid {
     const item = new TypedData<UploadEntryData>(initialUploadEntryData);
-    for (const [prop, value] of Object.entries(init) as [
-      keyof UploadEntryData,
-      UploadEntryData[keyof UploadEntryData],
-    ][]) {
-      item.set(prop, value);
-    }
-    this._items.add(item.uid);
-    this._notify();
-
+    item.setMany(init);
+    // Populate state BEFORE scheduling the membership tick (the flush reads
+    // `_added`/`_items`), and subscribe AFTER seeding so the init write doesn't
+    // pollute the change-map (add is a membership event, not a property change).
     this._data.set(item.uid, item);
+    this._items.add(item.uid);
     this._added.add(item);
-    for (const propName of UPLOAD_WATCH_LIST) {
-      let subs = this._subsMap.get(item.uid);
-      if (!subs) {
-        subs = [];
-        this._subsMap.set(item.uid, subs);
-      }
-      subs.push(item.observe(propName, () => this._notifyObservers(propName, item.uid), { immediate: true }));
+    this._entrySubs.set(
+      item.uid,
+      item.subscribeKeys((key) => this._recordPropChange(key, item.uid)),
+    );
+    // Immediate-on-add (v1 parity): surface the new entry's initial observed-key
+    // state to property observers. The old per-key `observe(..., {immediate:true})`
+    // did this — it is load-bearing for an already-uploaded entry (fileInfo set at
+    // add ⇒ fires FILE_UPLOAD_SUCCESS / drives the success collection state without
+    // an upload). A fresh entry's schema defaults pass no consumer emit guards, so
+    // this is a no-op for it.
+    for (const key of this._observedKeys) {
+      this._recordPropChange(key, item.uid);
     }
+    this._scheduleMembership();
     return item.uid;
   }
 
@@ -182,13 +200,17 @@ export class UploadCollectionController {
       this._markedToDestroy.add(item);
     }
     this._items.delete(id);
-    this._notify();
     this._data.delete(id);
 
-    for (const sub of this._subsMap.get(id) ?? []) {
-      sub();
+    this._entrySubs.get(id)?.();
+    this._entrySubs.delete(id);
+
+    this._scheduleMembership();
+    // Deferred-destroy is armed here, once, when something is actually marked —
+    // not re-armed from the notify paths.
+    if (item) {
+      this._scheduleDestroy();
     }
-    this._subsMap.delete(id);
   }
 
   public abort(id: Uid): void {
@@ -230,10 +252,12 @@ export class UploadCollectionController {
   }
 
   public destroy(): void {
-    if (this._observeTimeout) clearTimeout(this._observeTimeout);
-    if (this._notifyTimeout) clearTimeout(this._notifyTimeout);
-    if (this._destroyTimeout) clearTimeout(this._destroyTimeout);
+    this._scheduleProperties.cancel();
+    this._scheduleMembership.cancel();
+    this._scheduleDestroy.cancel();
 
+    // Force-destroy entries still in the deferred-destroy window, then the live
+    // entries.
     for (const item of this._markedToDestroy) {
       item.destroy();
     }
@@ -245,13 +269,15 @@ export class UploadCollectionController {
     this._data.clear();
 
     this._propertyObservers.clear();
+    this._observedKeys.clear();
     this._collectionObservers.clear();
-    for (const [, subs] of this._subsMap) {
-      for (const sub of subs) sub();
+    for (const off of this._entrySubs.values()) {
+      off();
     }
-    this._subsMap.clear();
+    this._entrySubs.clear();
     this._items.clear();
     this._added.clear();
     this._removed.clear();
+    this._changeMap = Object.create(null);
   }
 }

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -115,7 +115,7 @@ const setup = (opts: { collectionState?: OutputCollectionState; deferPlugin?: bo
     collectionObserver = cb;
     return () => {};
   });
-  vi.spyOn(collection, 'observeProperties').mockImplementation((cb) => {
+  vi.spyOn(collection, 'observeProperties').mockImplementation((_keys, cb) => {
     propertyObserver = cb;
     return () => {};
   });

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -28,6 +28,32 @@ const VALIDATION_TRIGGER_KEYS: (keyof UploadEntryData)[] = [
 ];
 
 /**
+ * The entry keys this controller must react to in
+ * `_handleCollectionPropertiesUpdate`. This is NOT just the keys it reads off the
+ * change-map (`uploadProgress`/`isUploading`/`fileInfo`/`errors`/`cdnUrl` for the
+ * per-key emits, plus {@link VALIDATION_TRIGGER_KEYS} for validation) — the
+ * handler ALSO calls `_flushOutputItems()` unconditionally on every fire, and
+ * that recomputes `getOutputCollectionState` + emits the documented `change`
+ * event. So the set must cover every key that can change the output — matching
+ * the old global `UPLOAD_WATCH_LIST` exactly, including `isValidationPending`
+ * (validation-state transitions change the output/counts) — PLUS `cdnUrlModifiers`
+ * (a `VALIDATION_TRIGGER_KEY` the old list wrongly omitted, so editor-applied
+ * modifiers never re-validated or fired `change`). Declaring it here (demand-
+ * driven) is what lets the collection drop the hardcoded constant.
+ */
+const PROPERTY_OBSERVE_KEYS: (keyof UploadEntryData)[] = [
+  'file',
+  'uploadProgress',
+  'uploadError',
+  'fileInfo',
+  'errors',
+  'cdnUrl',
+  'cdnUrlModifiers',
+  'isUploading',
+  'isValidationPending',
+];
+
+/**
  * DOM-free upload-events engine — the collection→events derivation that v1 ran
  * inline in `LitUploaderBlock` (`_handleCollectionUpdate` /
  * `_handleCollectionPropertiesUpdate` / `_flushOutputItems` /
@@ -87,7 +113,10 @@ export class UploadEventsController {
     this.unobserve();
     this._active = true;
     this._unobserveCollection = this._collection.observeCollection(this._handleCollectionUpdate);
-    this._unobserveProperties = this._collection.observeProperties(this._handleCollectionPropertiesUpdate);
+    this._unobserveProperties = this._collection.observeProperties(
+      PROPERTY_OBSERVE_KEYS,
+      this._handleCollectionPropertiesUpdate,
+    );
   }
 
   public unobserve(): void {

--- a/src/abstract/di/SignalMap.test.ts
+++ b/src/abstract/di/SignalMap.test.ts
@@ -258,6 +258,64 @@ describe('SignalMap.getTracked', () => {
   });
 });
 
+describe('SignalMap.subscribeKeys', () => {
+  it('fires with the changed key on set, and not on a deduped no-op write', () => {
+    const m = new SignalMap<Shape>({ a: 1 });
+    const keys: (keyof Shape)[] = [];
+    m.subscribeKeys((key) => keys.push(key));
+
+    m.set('a', 2);
+    m.set('b', 'x');
+    expect(keys).toEqual(['a', 'b']);
+
+    m.set('a', 2); // Object.is dedup → no fire
+    expect(keys).toEqual(['a', 'b']);
+  });
+
+  it('fires once per changed key on setMany (skipping unchanged keys)', () => {
+    const m = new SignalMap<Shape>({ a: 1, b: 'x' });
+    const keys: (keyof Shape)[] = [];
+    m.subscribeKeys((key) => keys.push(key));
+
+    m.setMany({ a: 2, b: 'x' }); // b unchanged → only a fires
+    expect(keys).toEqual(['a']);
+  });
+
+  it('unsubscribe stops key notifications', () => {
+    const m = new SignalMap<Shape>({ a: 1 });
+    const keys: (keyof Shape)[] = [];
+    const off = m.subscribeKeys((key) => keys.push(key));
+
+    m.set('a', 2);
+    off();
+    m.set('a', 3);
+    expect(keys).toEqual(['a']);
+  });
+
+  it('isolates a throwing key listener (the write + other listeners still land)', () => {
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const m = new SignalMap<Shape>({ a: 1 });
+    const seen: (keyof Shape)[] = [];
+    m.subscribeKeys(() => {
+      throw new Error('boom');
+    });
+    m.subscribeKeys((key) => seen.push(key));
+
+    expect(() => m.set('a', 2)).not.toThrow();
+    expect(m.get('a')).toBe(2); // write landed
+    expect(seen).toEqual(['a']); // sibling listener still fired
+  });
+
+  it('destroy() clears key listeners', () => {
+    const m = new SignalMap<Shape>({ a: 1 });
+    const keys: (keyof Shape)[] = [];
+    m.subscribeKeys((key) => keys.push(key));
+    m.destroy();
+    m.set('a', 2);
+    expect(keys).toEqual([]);
+  });
+});
+
 describe('SignalMap.setMany', () => {
   it('applies every changed key and fires ONE coalesced coarse notify', () => {
     const m = new SignalMap<{ a: number; b: number; c: number }>({ a: 0, b: 0, c: 0 });

--- a/src/abstract/di/SignalMap.ts
+++ b/src/abstract/di/SignalMap.ts
@@ -1,6 +1,9 @@
 import { type Signal, signal } from '@lit-labs/signals';
 import { Listeners, type ObserveOptions } from '../host-subscription';
+import { logger } from '../logger';
 import type { ReactiveStore } from './ReactiveStore';
+
+const log = logger.scope('signal-map');
 
 // `ObserveOptions` lives with `Listeners.observe` (the shared atomic-observe
 // engine); re-exported here so existing `di/SignalMap` importers are unaffected.
@@ -42,6 +45,23 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
   // cast back at the typed `get`/`set` edges (each is keyed by its own key).
   #signals = new Map<keyof T, Signal.State<unknown>>();
   #listeners = new Listeners();
+  // Per-key change listeners (keyed channel), fired with the CHANGED key on each
+  // real write — the granular counterpart to the coarse `#listeners`. Additive:
+  // coarse `subscribe`rs (Config/Locale) are untouched. Consumers that need to
+  // know *which* key changed (e.g. `UploadCollectionController`'s change-map) use
+  // this instead of one `observe` per key.
+  #keyListeners = new Set<(key: keyof T) => void>();
+
+  /** Fire the keyed channel for `key`, isolate-and-warn (a throwing listener must not break the write). */
+  #notifyKey(key: keyof T): void {
+    for (const listener of this.#keyListeners) {
+      try {
+        listener(key);
+      } catch (err) {
+        log.warn('a key-change listener threw', err);
+      }
+    }
+  }
 
   /** Seed initial key/values into the bag without notifying (construction defaults). */
   public constructor(initial?: Readonly<Partial<T>>) {
@@ -105,6 +125,7 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
     // key stays lazy and its next `get` seeds from the now-updated bag.
     this.#signals.get(key)?.set(value);
     this.#listeners.notify();
+    this.#notifyKey(key);
   }
 
   /**
@@ -114,7 +135,7 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
    * (their own signal/`Object.is` filter); coarse `subscribe`rs fire once.
    */
   public setMany(patch: Partial<T>): void {
-    let changed = false;
+    const changedKeys: (keyof T)[] = [];
     // Consistent with `set`: an explicit `undefined` in the patch is WRITTEN
     // (clears/materializes the key), not skipped — so optional state can be
     // cleared through the batch API. `Object.keys` only yields own keys the
@@ -126,10 +147,16 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
       }
       this.#bag[key] = value;
       this.#signals.get(key)?.set(value);
-      changed = true;
+      changedKeys.push(key);
     }
-    if (changed) {
+    if (changedKeys.length > 0) {
+      // One coarse notify for the whole batch, then the keyed channel fires once
+      // per changed key — so a change-map consumer sees every key a multi-key
+      // write touched, while coarse `subscribe`rs still fire exactly once.
       this.#listeners.notify();
+      for (const key of changedKeys) {
+        this.#notifyKey(key);
+      }
     }
   }
 
@@ -149,6 +176,20 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
 
   public subscribe(listener: () => void): () => void {
     return this.#listeners.subscribe(listener);
+  }
+
+  /**
+   * Keyed subscription: `listener` fires with the CHANGED key on every real
+   * write (`set`, and once per changed key in `setMany`) — the granular
+   * counterpart to the coarse `subscribe`. Lets a consumer learn *which* key
+   * changed from a SINGLE subscription instead of one `observe` per key (e.g.
+   * `UploadCollectionController` building its per-prop change-map). Returns an
+   * unsubscriber. Fires no initial value; no `Object.is` payload dedup (the
+   * write already deduped before it fires).
+   */
+  public subscribeKeys(listener: (key: keyof T) => void): () => void {
+    this.#keyListeners.add(listener);
+    return () => this.#keyListeners.delete(listener);
   }
 
   /**
@@ -182,5 +223,6 @@ export class SignalMap<T extends object> implements ReactiveStore<T> {
     this.#signals.clear();
     this.#bag = Object.create(null);
     this.#listeners.clear();
+    this.#keyListeners.clear();
   }
 }

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -206,7 +206,13 @@ export class DynamicBtn extends ChildBlock {
   @subscription()
   protected _wireCollectionObservers(): Unsubscribe {
     return this.container.whenController(UploadCollectionController, (collection) => [
-      collection.observeProperties(this._throttledHandleCollectionUpdate),
+      // The button derives from the collection STATUS (idle/uploading/success/
+      // failed) — declare only the status-affecting keys, so per-entry progress
+      // ticks don't wake this recompute at large file counts.
+      collection.observeProperties(
+        ['fileInfo', 'errors', 'uploadError', 'isUploading'],
+        this._throttledHandleCollectionUpdate,
+      ),
       collection.observeCollection(this._throttledHandleCollectionUpdate),
     ]);
   }

--- a/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
+++ b/src/blocks/ProgressBarCommon/ProgressBarCommon.ts
@@ -46,7 +46,9 @@ export class ProgressBarCommon extends ChildBlock {
     return this.container.whenController(UploadCollectionController, (collection) => {
       this._recomputeVisible(collection);
       return [
-        collection.observeProperties(() => this._recomputeVisible(collection)),
+        // Visibility derives only from entries' `isUploading` — declare just
+        // that key so a progress/thumb/etc. mutation doesn't wake this observer.
+        collection.observeProperties(['isUploading'], () => this._recomputeVisible(collection)),
         collection.observeCollection(() => this._recomputeVisible(collection)),
       ];
     });

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -260,16 +260,22 @@ export class UploadList extends ActivityChildBlock {
     );
   }
 
-  // Recompute button state on collection changes. The uploader-scope
+  // Recompute button/summary state on collection changes. The uploader-scope
   // `UploadCollectionController` resolves only once the scope attaches, so go
   // through `whenController` (now-or-when-available); its callback returns the
   // observers directly and `whenController`'s unsubscribe disposes them.
-  // TODO: could be a perf issue on many files — no need to update button state
-  // on every progress tick.
+  //
+  // The summary + buttons derive from counts/status/validation — NOT per-entry
+  // `uploadProgress` (that drives the progress bar, not this) — so we declare
+  // only the status-affecting keys. This resolves the former "perf issue on many
+  // files": progress ticks no longer wake this recompute.
   @subscription()
   protected _wireCollectionObservers(): Unsubscribe {
     return this.container.whenController(UploadCollectionController, (collection) => [
-      collection.observeProperties(this._throttledHandleCollectionUpdate),
+      collection.observeProperties(
+        ['fileInfo', 'errors', 'uploadError', 'isUploading', 'isValidationPending'],
+        this._throttledHandleCollectionUpdate,
+      ),
       collection.observeCollection(this._throttledHandleCollectionUpdate),
     ]);
   }


### PR DESCRIPTION
## What

Untangles `UploadCollectionController` and cuts its per-entry cost at large file counts. Behavior-preserving for its consumers. Cover-first net landed as the first commit (88.9%→99.2%), rework as the second.

### Kill the hardcoded `UPLOAD_WATCH_LIST`
Property observation is now **demand-driven**: `observeProperties(keys, handler)` — each consumer declares the entry keys it reacts to, and the controller gates the change-map to their live union. No global constant to drift; `cdnUrlModifiers` (a `VALIDATION_TRIGGER_KEY` the old list wrongly omitted → editor modifiers never re-validated or fired `change`) is now covered. (`observeProperties`/`observeCollection` are internal API.)

### Large-N performance
- **1×N, not 8×N subscriptions:** one `TypedData.subscribeKeys` per entry instead of one `observe` per watched key. Backed by a new **additive** keyed-notify channel on the shared `SignalMap` (coarse `subscribe` untouched → Config/Locale unaffected).
- **Progress ticks wake only who needs them:** the UI blocks (`UploadList`/`DynamicBtn`/`ProgressBarCommon`) derive counts/status/visibility — none depend on `uploadProgress` — so they no longer declare it. During an upload the constant progress stream wakes only `UploadEventsController`. Resolves `UploadList`'s "perf issue on many files" TODO.
- **Coalesced batchers:** the three hand-rolled `setTimeout` batchers become `utils/debounce` instances; a bulk add collapses to one membership + one change-map tick.

### Untangle deferred-destroy
Armed once from `remove()` (10 s debounce), no longer re-armed from the two notify paths; `destroy()` force-drains it.

## Correctness (two subtleties, both covered)
- **Immediate-on-add preserved:** a new entry's initial observed-key state is surfaced to property observers on add — load-bearing for already-uploaded files (fire `FILE_UPLOAD_SUCCESS` with no upload). Regression-tested + verified by `api.e2e`.
- **Unconditional side-effects included:** `UploadEventsController` declares the full output-affecting key set incl. `isValidationPending`, because its `_flushOutputItems()` runs on *every* fire (recomputes output state + emits the documented `change` event) — not just the keys it reads off the change-map.

## Gate
`tsc` · `build` (size-limit, editor 48.55 KB) · **1129** specs · locales · **384** e2e · lint (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added key-level change subscriptions (`subscribeKeys`) for data and upload entries.
  * Updated property observation to accept a declared key list for targeted updates.
* **Bug Fixes**
  * Improved upload collection notification scoping, including correct tracking for CDN URL modifiers.
  * Refined lifecycle behavior for abort/remove, deferred destruction timing, and full teardown reliability.
  * Reduced unnecessary UI recomputations by narrowing which status properties trigger renders.
* **Tests**
  * Added/expanded tests for key-change notifications and upload observer/lifecycle semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->