### PR TITLE
perf(output-state): single-pass buildOutputCollectionState (+cover-first net)

### DIFF
--- a/src/abstract/buildOutputCollectionState.test.ts
+++ b/src/abstract/buildOutputCollectionState.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildOutputCollectionState } from './buildOutputCollectionState';
+import { CollectionStateController } from './controllers/CollectionStateController';
+import { UploadCollectionController } from './controllers/UploadCollectionController';
+import { ControllerContainer } from './di/ControllerContainer';
+import { UploaderPublicApi } from './UploaderPublicApi';
+
+// Cover-first parity net for `buildOutputCollectionState` (no dedicated test
+// existed) ahead of a single-pass perf refactor. Pins the derived counts /
+// status / entry partitions / flags so the refactor is provably behavior-
+// preserving on the documented `getOutputCollectionState` surface.
+describe('buildOutputCollectionState', () => {
+  let container: ControllerContainer;
+  let collection: UploadCollectionController;
+  let collectionState: CollectionStateController;
+
+  beforeEach(() => {
+    container = new ControllerContainer();
+    collection = container.get(UploadCollectionController);
+    collectionState = container.get(CollectionStateController);
+    // getOutputData resolves through the public API; force it into existence.
+    container.get(UploaderPublicApi);
+  });
+  afterEach(() => {
+    container.dispose();
+    vi.restoreAllMocks();
+  });
+
+  // status derivation (getOutputItem): removed → failed(errors) → success(fileInfo)
+  // → uploading(isUploading) → idle.
+  const addIdle = () => collection.add({});
+  const addUploading = () => collection.add({ isUploading: true });
+  const addSuccess = () => collection.add({ fileInfo: { uuid: 'srv' } as never });
+  const addFailed = () => collection.add({ errors: [{ type: 'X', message: 'e' } as never] });
+
+  it('counts and partitions entries by derived status', () => {
+    const idle = addIdle();
+    const uploading = addUploading();
+    const success = addSuccess();
+    const failed = addFailed();
+
+    const state = buildOutputCollectionState(container);
+
+    expect(state.totalCount).toBe(4);
+    expect(state.successCount).toBe(1);
+    expect(state.uploadingCount).toBe(1);
+    expect(state.failedCount).toBe(1);
+    expect(state.allEntries).toHaveLength(4);
+    expect(state.successEntries.map((e) => e.internalId)).toEqual([success]);
+    expect(state.uploadingEntries.map((e) => e.internalId)).toEqual([uploading]);
+    expect(state.failedEntries.map((e) => e.internalId)).toEqual([failed]);
+    expect(state.idleEntries.map((e) => e.internalId)).toEqual([idle]);
+  });
+
+  it('status is failed when any entry has errors, uploading > success > idle otherwise', () => {
+    // failed dominates.
+    addSuccess();
+    addUploading();
+    const withFailed = addFailed();
+    expect(buildOutputCollectionState(container).status).toBe('failed');
+    collection.remove(withFailed);
+
+    // uploading dominates success/idle.
+    expect(buildOutputCollectionState(container).status).toBe('uploading');
+  });
+
+  it('idle when empty; isSuccess only when all entries succeeded and no collection errors', () => {
+    expect(buildOutputCollectionState(container).status).toBe('idle');
+    expect(buildOutputCollectionState(container).isSuccess).toBe(false); // empty → not success
+
+    addSuccess();
+    addSuccess();
+    const all = buildOutputCollectionState(container);
+    expect(all.isSuccess).toBe(true);
+    expect(all.status).toBe('success');
+  });
+
+  it('isFailed via a collection-level error even with no failed entries', () => {
+    addSuccess();
+    collectionState.set('collectionErrors', [{ type: 'TOO_MANY_FILES', message: 'too many' } as never]);
+
+    const state = buildOutputCollectionState(container);
+    expect(state.errors).toHaveLength(1);
+    expect(state.isFailed).toBe(true);
+    expect(state.status).toBe('failed');
+    expect(state.isSuccess).toBe(false); // collection error blocks success
+  });
+
+  it('surfaces progress and group straight from CollectionStateController', () => {
+    collectionState.set('commonProgress', 42);
+    collectionState.set('groupInfo', { uuid: 'group~1' } as never);
+
+    const state = buildOutputCollectionState(container);
+    expect(state.progress).toBe(42);
+    expect(state.group).toEqual({ uuid: 'group~1' });
+  });
+});

--- a/src/abstract/buildOutputCollectionState.ts
+++ b/src/abstract/buildOutputCollectionState.ts
@@ -44,6 +44,35 @@ export function buildOutputCollectionState<
   const collectionState = container.get(CollectionStateController);
   const uploadCollection = container.get(UploadCollectionController);
 
+  // Partition all entries by derived status in ONE pass (memoized), so counts,
+  // the four per-status arrays, and the status flags don't each re-filter the
+  // whole list. Was O(N × ~5) filters/scans per state; now O(N) once. The result
+  // is identical to the per-getter `.filter(status === …)` it replaces (a
+  // `removed` entry lands in no bucket, exactly as the old filters excluded it).
+  const partitionByStatus = memoize(() => {
+    const success: OutputFileEntry<'success'>[] = [];
+    const failed: OutputFileEntry<'failed'>[] = [];
+    const uploading: OutputFileEntry<'uploading'>[] = [];
+    const idle: OutputFileEntry<'idle'>[] = [];
+    for (const entry of state.allEntries) {
+      switch (entry.status) {
+        case 'success':
+          success.push(entry as OutputFileEntry<'success'>);
+          break;
+        case 'failed':
+          failed.push(entry as OutputFileEntry<'failed'>);
+          break;
+        case 'uploading':
+          uploading.push(entry as OutputFileEntry<'uploading'>);
+          break;
+        case 'idle':
+          idle.push(entry as OutputFileEntry<'idle'>);
+          break;
+      }
+    }
+    return { success, failed, uploading, idle };
+  });
+
   const getters = {
     progress: (): number => {
       return collectionState.get('commonProgress');
@@ -61,15 +90,15 @@ export function buildOutputCollectionState<
     },
 
     failedCount: (): number => {
-      return state.failedEntries.length;
+      return partitionByStatus().failed.length;
     },
 
     successCount: (): number => {
-      return state.successEntries.length;
+      return partitionByStatus().success.length;
     },
 
     uploadingCount: (): number => {
-      return state.uploadingEntries.length;
+      return partitionByStatus().uploading.length;
     },
 
     status: (): TCollectionStatus => {
@@ -81,16 +110,16 @@ export function buildOutputCollectionState<
       return (
         state.allEntries.length > 0 &&
         state.errors.length === 0 &&
-        state.successEntries.length === state.allEntries.length
+        partitionByStatus().success.length === state.allEntries.length
       );
     },
 
     isUploading: (): boolean => {
-      return state.allEntries.some((entry: OutputFileEntry) => entry.status === 'uploading');
+      return partitionByStatus().uploading.length > 0;
     },
 
     isFailed: (): boolean => {
-      return state.errors.length > 0 || state.failedEntries.length > 0;
+      return state.errors.length > 0 || partitionByStatus().failed.length > 0;
     },
 
     allEntries: (): OutputFileEntry[] => {
@@ -98,25 +127,19 @@ export function buildOutputCollectionState<
     },
 
     successEntries: (): OutputFileEntry<'success'>[] => {
-      return state.allEntries.filter(
-        (entry: OutputFileEntry) => entry.status === 'success',
-      ) as OutputFileEntry<'success'>[];
+      return partitionByStatus().success;
     },
 
     failedEntries: (): OutputFileEntry<'failed'>[] => {
-      return state.allEntries.filter(
-        (entry: OutputFileEntry) => entry.status === 'failed',
-      ) as OutputFileEntry<'failed'>[];
+      return partitionByStatus().failed;
     },
 
     uploadingEntries: (): OutputFileEntry<'uploading'>[] => {
-      return state.allEntries.filter(
-        (entry: OutputFileEntry) => entry.status === 'uploading',
-      ) as OutputFileEntry<'uploading'>[];
+      return partitionByStatus().uploading;
     },
 
     idleEntries: (): OutputFileEntry<'idle'>[] => {
-      return state.allEntries.filter((entry: OutputFileEntry) => entry.status === 'idle') as OutputFileEntry<'idle'>[];
+      return partitionByStatus().idle;
     },
   };
 


### PR DESCRIPTION
First increment of the output-layer perf work (grok + codex both ranked this layer the #1 remaining large-N cost after the collection rework).

## What
- **Cover-first:** `buildOutputCollectionState` had **no dedicated test**. Added a parity net pinning counts, status precedence (failed→uploading→success→idle), the four entry partitions, `isSuccess`/`isFailed` (incl. collection-level errors), and progress/group passthrough — the documented `getOutputCollectionState` surface.
- **Single-pass refactor:** the four per-status entry arrays, their counts, and the status flags each re-filtered/scanned `allEntries` independently (~5 O(N) passes per state access). Now one memoized `partitionByStatus()` buckets entries once; every getter reads from it. **Byte-identical** results (a `removed` entry lands in no bucket, as before) — the parity net passes unchanged. O(N×K) → O(N) on a path hit by progress, CHANGE, common-progress, validation, and the UI summary.

## Not included (next increments, tracked)
Incremental collection **counters** (so counts/status are O(1) and UploadList/DynamicBtn/ProgressBarCommon stop rebuilding N entries) and an incremental per-uid output cache — the deeper wins — will follow as separate parity-preserving PRs. This PR is the safe, self-contained first step.

## Gate
`tsc` · `build` (size-limit, editor 48.66 KB) · **1137** specs · locales · **384** e2e · lint (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved collection status reporting for success, failure, uploading, and idle states.
  * Ensured collection-level errors correctly affect failure status.
  * Preserved accurate progress, grouping, entry counts, and status precedence.
* **Tests**
  * Added coverage for collection state counts, status handling, entry categorization, empty collections, and error scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->