### PR TITLE
perf(file-item): O(1) focus, one-shot observer, unsubscribe on disconnect

### DIFF
--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -35,6 +35,7 @@ import { LocaleController } from './controllers/LocaleController';
 import { RouterController } from './controllers/RouterController';
 import { UploadCollectionController } from './controllers/UploadCollectionController';
 import { UploadController } from './controllers/UploadController';
+import { deriveEntryStatus } from './deriveEntryStatus';
 import { CONTAINER, type ControllerContainer } from './di/ControllerContainer';
 import { inject } from './di/inject';
 import { PluginController } from './managers/plugin';
@@ -331,15 +332,8 @@ export class UploaderPublicApi {
     const uploadEntryData = entry.values;
     const fileInfo = uploadEntryData.fileInfo as UploadcareFile | null;
 
-    const status: OutputFileEntry['status'] = uploadEntryData.isRemoved
-      ? 'removed'
-      : uploadEntryData.errors.length > 0
-        ? 'failed'
-        : uploadEntryData.fileInfo
-          ? 'success'
-          : uploadEntryData.isUploading
-            ? 'uploading'
-            : 'idle';
+    // Shared status ladder (single source with UploadList's toolbar counts).
+    const status = deriveEntryStatus(uploadEntryData);
 
     const outputItem = {
       uuid: fileInfo?.uuid ?? uploadEntryData.uuid ?? null,

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -233,6 +233,19 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
+  it('remove() aborts the entry in-flight upload (abortController)', () => {
+    const collection = new UploadCollectionController();
+    const abort = vi.fn();
+    const id = collection.add({ abortController: { abort, signal: {} } as unknown as AbortController });
+    vi.runOnlyPendingTimers();
+
+    collection.remove(id);
+    expect(abort).toHaveBeenCalledOnce();
+
+    vi.advanceTimersByTime(10_000);
+    collection.destroy();
+  });
+
   it('abortAll aborts only the uploading entries', () => {
     const collection = new UploadCollectionController();
     const uploading = collection.add({ isUploading: true });

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -217,6 +217,10 @@ export class UploadCollectionController {
   public remove(id: Uid): void {
     const item = this.read(id);
     if (item) {
+      // Removing an entry aborts its in-flight upload — this file/upload
+      // side-effect lives here at the collection level, not in the UI. A no-op
+      // when there is no controller or the request already settled.
+      item.get('abortController')?.abort();
       this._removed.add(item);
       this._markedToDestroy.add(item);
     }

--- a/src/abstract/controllers/UploadCollectionEventsController.ts
+++ b/src/abstract/controllers/UploadCollectionEventsController.ts
@@ -1,0 +1,134 @@
+import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import type { Uid } from '../../lit/Uid';
+import type { OutputCollectionState } from '../../types';
+import { inject, injectOrNull } from '../di/inject';
+import { UploaderEventType } from '../EventBus';
+import type { TypedData } from '../TypedData';
+import { UploaderPublicApi } from '../UploaderPublicApi';
+import type { UploadEntryData } from '../uploadEntrySchema';
+import { CollectionStateController } from './CollectionStateController';
+import { UploadCollectionController } from './UploadCollectionController';
+import { UploadController } from './UploadController';
+
+type Entry = TypedData<UploadEntryData>;
+
+/**
+ * COLLECTION-level derived state + events — the collection-scoped half of the
+ * derivation split out of {@link UploadEventsController}: it maintains the
+ * derived collection keys (`uploadList`/`collectionState`/`commonProgress`/
+ * `groupInfo` on {@link CollectionStateController}) and emits the collection-wide
+ * events (`CHANGE`, `COMMON_UPLOAD_PROGRESS`/`SUCCESS`/`FAILED`). No observers or
+ * lifecycle — the coordinator drives it in order; group creation is delegated to
+ * `UploadGroupController`.
+ */
+export class UploadCollectionEventsController {
+  @injectOrNull(EventEmitter) private readonly _eventEmitter!: EventEmitter | null;
+  @inject(UploaderPublicApi) private readonly _api!: UploaderPublicApi;
+  @inject(CollectionStateController) private readonly _collectionState!: CollectionStateController;
+  @inject(UploadCollectionController) private readonly _collection!: UploadCollectionController;
+  @inject(UploadController) private readonly _upload!: UploadController;
+
+  private _emit = (...args: Parameters<EventEmitter['emit']>): void => {
+    this._eventEmitter?.emit(...args);
+  };
+
+  /** Membership changed → the current group no longer describes the collection. */
+  public resetGroupIfMembershipChanged(added: Set<Entry>, removed: Set<Entry>): void {
+    if (added.size || removed.size) {
+      this._collectionState.set('groupInfo', null);
+    }
+  }
+
+  public resetGroup(): void {
+    this._collectionState.set('groupInfo', null);
+  }
+
+  public setUploadList(entries: Uid[]): void {
+    this._collectionState.set(
+      'uploadList',
+      entries.map((uid) => ({ uid })),
+    );
+  }
+
+  /**
+   * Rebuild + publish the output collection state and emit the debounced `CHANGE`.
+   * Returns the freshly built state (for the group-output decision), or `null`
+   * when the item set is inconsistent (defensive early-return).
+   */
+  public flushOutput(): OutputCollectionState | null {
+    const collection = this._collection;
+    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
+    // Defensive: bail on an inconsistent item set. Compare the uid-list length to
+    // `size` directly (no per-item `OutputFileEntry` build).
+    if (collection.items().length !== collection.size) {
+      return null;
+    }
+    const collectionState = getOutputCollectionState();
+    this._collectionState.set('collectionState', collectionState);
+    this._emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+    return collectionState;
+  }
+
+  public flushCommonProgress(): void {
+    const collection = this._collection;
+    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
+    let commonProgress = 0;
+    const items = this._upload.uploadBatch;
+    items.forEach((id) => {
+      const uploadProgress = collection.readProp(id, 'uploadProgress');
+      if (typeof uploadProgress === 'number') {
+        commonProgress += uploadProgress;
+      }
+    });
+    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
+
+    if (this._collectionState.get('commonProgress') === progress) {
+      return;
+    }
+
+    this._collectionState.set('commonProgress', progress);
+    this._emit(
+      UploaderEventType.COMMON_UPLOAD_PROGRESS,
+      getOutputCollectionState() as OutputCollectionState<'uploading'>,
+    );
+  }
+
+  /** `COMMON_UPLOAD_FAILED` (debounced) — paired per errored entry by the coordinator. */
+  public emitCommonFailed(): void {
+    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
+    this._emit(
+      UploaderEventType.COMMON_UPLOAD_FAILED,
+      () => getOutputCollectionState() as OutputCollectionState<'failed'>,
+      { debounce: true },
+    );
+  }
+
+  /** `COMMON_UPLOAD_SUCCESS` when every entry is loaded, none errored, and there are no collection errors. */
+  public emitCommonSuccessIfComplete(): void {
+    const collection = this._collection;
+    // One pass: "all loaded, none errored".
+    let loadedCount = 0;
+    let hasErrored = false;
+    for (const uid of collection.items()) {
+      const entry = collection.read(uid);
+      if (!entry) continue;
+      if (entry.get('errors').length > 0) {
+        hasErrored = true;
+      }
+      if (entry.get('fileInfo')) {
+        loadedCount++;
+      }
+    }
+    if (
+      collection.size > 0 &&
+      !hasErrored &&
+      collection.size === loadedCount &&
+      this._collectionState.get('collectionErrors').length === 0
+    ) {
+      this._emit(
+        UploaderEventType.COMMON_UPLOAD_SUCCESS,
+        this._api.getOutputCollectionState() as OutputCollectionState<'success'>,
+      );
+    }
+  }
+}

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -477,6 +477,19 @@ describe('UploadEventsController', () => {
 
       expect(t.emit).not.toHaveBeenCalled();
     });
+
+    it('common-success scan tolerates a listed id whose entry cannot be read (defensive)', () => {
+      const t = setup();
+      const id = t.collection.add({ fileName: 'a.txt' });
+      // Force the defensive `!entry` branch in the common-success scan (a uid in
+      // `items()` that `read()` can't resolve — can't happen in practice).
+      vi.spyOn(t.collection, 'read').mockReturnValue(null);
+      t.emit.mockClear();
+
+      t.fireProperties({ errors: new Set([id]) });
+
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.COMMON_UPLOAD_SUCCESS, expect.anything());
+    });
   });
 
   describe('output flush + group', () => {

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -209,19 +209,19 @@ describe('UploadEventsController', () => {
       expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
     });
 
-    it('on remove: aborts, marks removed, revokes thumbUrl, cleans validation, emits FILE_REMOVED', () => {
+    it('on remove: marks removed, clears abortController, revokes thumbUrl, cleans validation, emits FILE_REMOVED', () => {
       const t = setup();
       const id = t.collection.add({ fileName: 'a.txt', thumbUrl: 'blob:xyz' });
       const entry = t.collection.read(id) as Entry;
-      const ac = new AbortController();
-      const abortSpy = vi.spyOn(ac, 'abort');
-      entry.set('abortController', ac);
+      entry.set('abortController', new AbortController());
       const revokeSpy = vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
 
       t.fireCollection([], new Set(), new Set([entry]));
 
       expect(t.deps.validation.cleanupValidationForEntry).toHaveBeenCalledWith(entry);
-      expect(abortSpy).toHaveBeenCalled();
+      // Aborting the in-flight upload is owned by `UploadCollectionController.remove`
+      // now; this handler only clears state (and nulls the abortController).
+      expect(entry.get('abortController')).toBeNull();
       expect(entry.get('isRemoved')).toBe(true);
       expect(revokeSpy).toHaveBeenCalledWith('blob:xyz');
       expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_REMOVED, expect.objectContaining({ internalId: id }));

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -340,6 +340,30 @@ describe('UploadEventsController', () => {
       });
     });
 
+    it('pairs FILE_UPLOAD_FAILED + COMMON_UPLOAD_FAILED per errored entry, in order (locks the interleave)', () => {
+      const t = setup();
+      const a = t.collection.add({ fileName: 'a.txt' });
+      const b = t.collection.add({ fileName: 'b.txt' });
+      t.collection.publishProp(a, 'errors', [{ type: 'X', message: 'm' }] as never);
+      t.collection.publishProp(b, 'errors', [{ type: 'Y', message: 'n' }] as never);
+
+      t.fireProperties({ errors: new Set([a, b]) });
+
+      // The documented pairing must stay per-entry (FILE then COMMON), not
+      // "all FILE_* then one COMMON_*" — a future reorder would break consumers.
+      const failedTypes = t.emit.mock.calls
+        .map((c) => c[0])
+        .filter(
+          (type) => type === UploaderEventType.FILE_UPLOAD_FAILED || type === UploaderEventType.COMMON_UPLOAD_FAILED,
+        );
+      expect(failedTypes).toEqual([
+        UploaderEventType.FILE_UPLOAD_FAILED,
+        UploaderEventType.COMMON_UPLOAD_FAILED,
+        UploaderEventType.FILE_UPLOAD_FAILED,
+        UploaderEventType.COMMON_UPLOAD_FAILED,
+      ]);
+    });
+
     it('emits COMMON_UPLOAD_SUCCESS when all entries are loaded with no errors', () => {
       const t = setup();
       const id = t.collection.add({ fileName: 'a.txt' });
@@ -557,6 +581,47 @@ describe('UploadEventsController', () => {
 
       expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith({ uuid: 'group~1' });
       expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
+    it('swallows an uploadFileGroup rejection (no unhandled rejection, no GROUP_CREATED)', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state });
+      t.config.set('groupOutput', true);
+      mockUploadFileGroup.mockRejectedValue(new Error('group upload failed'));
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      // groupInfo is legitimately reset to null on the membership add; the point is
+      // it was never finalized to a real group after the failed request.
+      expect(t.deps.setGroupInfo).not.toHaveBeenCalledWith(expect.objectContaining({ uuid: expect.anything() }));
+      expect(t.emit).not.toHaveBeenCalledWith(UploaderEventType.GROUP_CREATED, expect.anything());
+    });
+
+    it('does not send the group request if unobserved while building options', async () => {
+      const state = makeState({
+        totalCount: 1,
+        status: 'success',
+        allEntries: [{ uuid: 'u1', cdnUrlModifiers: '' }] as never,
+      });
+      const t = setup({ collectionState: state });
+      t.config.set('groupOutput', true);
+      const upload = t.container.get(UploadController);
+      vi.spyOn(upload, 'buildUploadOptions').mockImplementation(async () => {
+        t.controller.unobserve(); // torn down before the network call
+        return {} as never;
+      });
+      const id = t.collection.add({ fileName: 'a.txt' });
+
+      t.fireCollection([id], entriesByUid(t.collection, [id]), new Set());
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(mockUploadFileGroup).not.toHaveBeenCalled();
     });
 
     it('aborts group creation if the collection state changed mid-flight', async () => {

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -276,12 +276,23 @@ export class UploadEventsController {
           );
         }
       }
-      const loadedItems = collection.findItems((entry) => !!entry.get('fileInfo'));
-      const errorItems = collection.findItems((entry) => entry.get('errors').length > 0);
+      // One pass instead of two `findItems` scans: "all loaded, none errored".
+      let loadedCount = 0;
+      let hasErrored = false;
+      for (const uid of collection.items()) {
+        const entry = collection.read(uid);
+        if (!entry) continue;
+        if (entry.get('errors').length > 0) {
+          hasErrored = true;
+        }
+        if (entry.get('fileInfo')) {
+          loadedCount++;
+        }
+      }
       if (
         collection.size > 0 &&
-        errorItems.length === 0 &&
-        collection.size === loadedItems.length &&
+        !hasErrored &&
+        collection.size === loadedCount &&
         this._collectionState.get('collectionErrors').length === 0
       ) {
         emit(UploaderEventType.COMMON_UPLOAD_SUCCESS, getOutputCollectionState() as OutputCollectionState<'success'>);
@@ -302,10 +313,12 @@ export class UploadEventsController {
     const config = this._config;
     const emit = this._emit;
     const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
-    // Inlined from the removed bridge's `getOutputData(container)`: the flat
-    // output list is the collection's items resolved through the public api.
-    const data = collection.items().map((uid) => this._api.getOutputItem(uid));
-    if (data.length !== collection.size) {
+    // Defensive early-return on an inconsistent item set. Compare the uid-list
+    // length to `size` directly — the old code built an `OutputFileEntry` for
+    // every item via `getOutputItem` just to read `data.length` (a wasted O(N)
+    // allocation on every flush); `items().length === data.length`, so this is
+    // equivalent without the build.
+    if (collection.items().length !== collection.size) {
       return;
     }
     const collectionState = getOutputCollectionState();

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -1,23 +1,20 @@
-import { uploadFileGroup } from '@uploadcare/upload-client';
-import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
-import type { OutputCollectionState } from '../../types';
 import { debounce } from '../../utils/debounce';
 import { applyInitialCrop } from '../applyInitialCrop';
 import { containerOf } from '../di/ControllerContainer';
-import { inject, injectOrNull } from '../di/inject';
-import { UploaderEventType } from '../EventBus';
+import { inject } from '../di/inject';
 import { PluginController } from '../managers/plugin';
 import { TypedData } from '../TypedData';
-import { UploaderPublicApi } from '../UploaderPublicApi';
 import type { UploadEntryData } from '../uploadEntrySchema';
-import { CollectionStateController } from './CollectionStateController';
 import { ConfigController } from './ConfigController';
 import type { CollectionObserver, UploadCollectionChangeMap } from './UploadCollectionController';
 import { UploadCollectionController } from './UploadCollectionController';
-import { UploadController } from './UploadController';
+import { UploadCollectionEventsController } from './UploadCollectionEventsController';
+import { UploadFileEventsController } from './UploadFileEventsController';
+import { UploadGroupController } from './UploadGroupController';
 import { ValidationController } from './ValidationController';
 
 type Unsubscribe = () => void;
+type Entry = TypedData<UploadEntryData>;
 
 const VALIDATION_TRIGGER_KEYS: (keyof UploadEntryData)[] = [
   'file',
@@ -55,50 +52,35 @@ const PROPERTY_OBSERVE_KEYS: (keyof UploadEntryData)[] = [
 
 /**
  * DOM-free upload-events engine — the collection→events derivation that v1 ran
- * inline in `LitUploaderBlock` (`_handleCollectionUpdate` /
- * `_handleCollectionPropertiesUpdate` / `_flushOutputItems` /
- * `_flushCommonUploadProgress` / `_createGroup`).
+ * inline in `LitUploaderBlock`.
  *
- * It observes the upload collection and, as entries are added/removed and their
- * properties change, drives validation, emits the documented events (via the
- * host `emit`, a pure event dispatch that reaches the EventBus; telemetry
- * observes that bus independently, not this call), maintains the derived
- * `uploadList`/`collectionState`/`commonProgress`/`groupInfo` collection state
- * (owned by `CollectionStateController`), and creates the output group.
+ * This is a thin COORDINATOR: it owns the collection observers + the active/
+ * teardown lifecycle and dispatches, in the exact order the observers dictate, to
+ * focused collaborators that own the actual side-effects:
+ * - {@link UploadFileEventsController} — per-file events (added/removed/progress/
+ *   start/success/failed/url-changed) + per-entry finalization.
+ * - {@link UploadCollectionEventsController} — collection-level derived state
+ *   (`uploadList`/`collectionState`/`commonProgress`/`groupInfo`) + collection
+ *   events (`CHANGE`/`COMMON_UPLOAD_*`).
+ * - {@link UploadGroupController} — output-group creation (`GROUP_CREATED`).
  *
- * Container-resolved (M-god step 5): controller peers (collection, config,
- * validation, upload, collection-state), the public API (output-state readers)
- * and the per-ctx `EventEmitter` are `@inject`-ed; plugin `onAdd` hooks fire
- * through the conditionally-bound `PluginController` via the container
- * (`containerOf` + `whenController`, now-or-when-available). So it runs zero-arg
- * without a DOM and is unit-testable. `observe()` is called explicitly by
+ * Validation orchestration stays with {@link ValidationController}; plugin `onAdd`
+ * hooks fire through the conditionally-bound {@link PluginController} via the
+ * container (`containerOf` + `whenController`, now-or-when-available). Everything
+ * is container-resolved and runs without a DOM. `observe()` is called by
  * `registerUploadStack` once the whole stack is resolved.
  */
 export class UploadEventsController {
   @inject(UploadCollectionController) private readonly _collection!: UploadCollectionController;
   @inject(ConfigController) private readonly _config!: ConfigController;
   @inject(ValidationController) private readonly _validation!: ValidationController;
-  @inject(UploadController) private readonly _upload!: UploadController;
-  @inject(CollectionStateController) private readonly _collectionState!: CollectionStateController;
-  @inject(UploaderPublicApi) private readonly _api!: UploaderPublicApi;
-  // `@injectOrNull`: a teardown-time emit (released container) resolves `null` →
-  // no-op, matching the guard the removed host `emit` closure carried.
-  @injectOrNull(EventEmitter) private readonly _eventEmitter!: EventEmitter | null;
-
-  // Guarded event dispatch — the direct successor to the host `emit` closure
-  // (`ChildBlock.emit`): pure per-ctx `EventEmitter` dispatch that reaches the
-  // bus (telemetry observes the bus independently; the DOM `CustomEvent` re-
-  // dispatch is the provider's `_bridgeBusToDom` bus subscription, unaffected).
-  // A bound arrow field so the handlers can keep destructuring `emit`;
-  // rest-forwarded so the call arity (2- vs 3-arg) reaches `EventEmitter.emit`
-  // unchanged rather than padding a trailing `undefined`.
-  private _emit = (...args: Parameters<EventEmitter['emit']>): void => {
-    this._eventEmitter?.emit(...args);
-  };
+  @inject(UploadFileEventsController) private readonly _fileEvents!: UploadFileEventsController;
+  @inject(UploadCollectionEventsController) private readonly _collectionEvents!: UploadCollectionEventsController;
+  @inject(UploadGroupController) private readonly _group!: UploadGroupController;
 
   // Active while observing (the v1 `isConnected` guard) — survives disconnect/
-  // reconnect cycles; gates the debounced flush + deferred validation that may
-  // fire after the host disconnects.
+  // reconnect cycles; gates the debounced flush + deferred validation/group that
+  // may fire after the host disconnects.
   private _active = false;
   private _unobserveCollection?: Unsubscribe;
   private _unobserveProperties?: Unsubscribe;
@@ -133,14 +115,23 @@ export class UploadEventsController {
     this.unobserve();
   }
 
+  // Plugin `onAdd` hooks live on the conditionally-bound `PluginController` (bound
+  // by `ensurePluginManager`); fire now-or-when-available via the container. It is
+  // bound at scope-attach (before any file is added), so this normally fires
+  // synchronously; the `_active` re-check guards the rare deferred case where the
+  // manager resolves only after `unobserve()`, so a stale waiter can't run hooks
+  // against a released scope.
+  private _runPluginOnAdd(entry: Entry): void {
+    containerOf(this)?.whenController(PluginController, (pluginManager) => {
+      if (!this._active) return;
+      pluginManager.runOnAddHooks(entry);
+    });
+  }
+
   private _handleCollectionUpdate: CollectionObserver = (entries, added, removed) => {
     if (!this._active) return;
-    const emit = this._emit;
-    const getOutputItem = this._api.getOutputItem.bind(this._api);
 
-    if (added.size || removed.size) {
-      this._collectionState.set('groupInfo', null);
-    }
+    this._collectionEvents.resetGroupIfMembershipChanged(added, removed);
 
     this._validation.runFileValidators(
       'add',
@@ -148,61 +139,65 @@ export class UploadEventsController {
     );
 
     for (const entry of added) {
-      if (!entry.get('silent')) {
-        emit(UploaderEventType.FILE_ADDED, getOutputItem(entry.uid));
-      }
-      // Plugin `onAdd` hooks live on the conditionally-bound `PluginController`
-      // (bound by `ensurePluginManager`); fire now-or-when-available via the
-      // container, matching the removed bridge's `whenController` port of v1's
-      // `bag.wait('pluginManager').then(…)`. `PluginController` is bound at
-      // scope-attach (before any file is added), so this normally fires
-      // synchronously; the `_active` re-check guards the rare deferred case where
-      // the manager resolves only after `unobserve()`/`destroy()`, so a stale
-      // waiter can't run `onAdd` hooks against a released scope.
-      containerOf(this)?.whenController(PluginController, (pluginManager) => {
-        if (!this._active) return;
-        pluginManager.runOnAddHooks(entry);
-      });
+      this._fileEvents.added(entry);
+      this._runPluginOnAdd(entry);
     }
 
     this._validation.runCollectionValidators();
 
     for (const entry of removed) {
-      // (`UploadController` drops removed uids from its own active batch.) The
-      // in-flight upload is already aborted by `UploadCollectionController.remove`
-      // (the single owner of that side-effect), so this handler only clears state.
+      // The in-flight upload is already aborted by `UploadCollectionController.remove`
+      // (the single owner of that side-effect); here we only clear validation +
+      // entry state and emit `FILE_REMOVED`.
       this._validation.cleanupValidationForEntry(entry);
-      entry.setMany({
-        isRemoved: true,
-        abortController: null,
-        isUploading: false,
-        uploadProgress: 0,
-      });
-      const thumbUrl = entry.get('thumbUrl');
-      thumbUrl && URL.revokeObjectURL(thumbUrl);
-      emit(UploaderEventType.FILE_REMOVED, getOutputItem(entry.uid));
+      this._fileEvents.finalizeRemoved(entry);
     }
 
-    this._collectionState.set(
-      'uploadList',
-      entries.map((uid) => ({ uid })),
-    );
-
-    this._flushCommonUploadProgress();
+    this._collectionEvents.setUploadList(entries);
+    this._collectionEvents.flushCommonProgress();
     this._flushOutputItems();
   };
 
   private _handleCollectionPropertiesUpdate = (changeMap: UploadCollectionChangeMap): void => {
     if (!this._active) return;
-    const collection = this._collection;
-    const config = this._config;
-    const validation = this._validation;
-    const emit = this._emit;
-    const getOutputItem = this._api.getOutputItem.bind(this._api);
-    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
 
     this._flushOutputItems();
+    this._scheduleValidation(changeMap);
 
+    if (changeMap.uploadProgress) {
+      this._fileEvents.progress(changeMap.uploadProgress);
+      this._collectionEvents.flushCommonProgress();
+    }
+    if (changeMap.isUploading) {
+      this._fileEvents.start(changeMap.isUploading);
+    }
+    if (changeMap.fileInfo) {
+      this._fileEvents.success(changeMap.fileInfo);
+      if (this._config.get('cropPreset')) {
+        this._applyInitialCrop();
+      }
+    }
+    if (changeMap.errors) {
+      this._validation.runCollectionValidators();
+      for (const entryId of changeMap.errors) {
+        // Pair each per-file failure with a (debounced) common-failed emit, matching
+        // the original per-entry interleave.
+        if (this._fileEvents.failed(entryId)) {
+          this._collectionEvents.emitCommonFailed();
+        }
+      }
+      this._collectionEvents.emitCommonSuccessIfComplete();
+    }
+    if (changeMap.cdnUrl) {
+      this._fileEvents.urlChanged(changeMap.cdnUrl);
+      this._collectionEvents.resetGroup();
+    }
+  };
+
+  // Deferred file validation for the keys that trigger it — a tick later, since we
+  // can't mutate entry properties in the same tick. Guards `_active` (a released
+  // scope must not run validators).
+  private _scheduleValidation(changeMap: UploadCollectionChangeMap): void {
     const entriesToRunValidation = [
       ...new Set(
         Object.entries(changeMap)
@@ -210,171 +205,31 @@ export class UploadEventsController {
           .flatMap(([, ids]) => [...(ids ?? [])]),
       ),
     ];
-
-    entriesToRunValidation.length > 0 &&
-      setTimeout(() => {
-        if (!this._active) return;
-        // We can't modify entry properties in the same tick, so we need to wait a bit
-        const entriesToRunOnUpload = entriesToRunValidation.filter(
-          (entryId) =>
-            changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.values.fileInfo,
-        );
-        if (entriesToRunOnUpload.length > 0) {
-          validation.runFileValidators('upload', entriesToRunOnUpload);
-        }
-        validation.runFileValidators('change', entriesToRunValidation);
-      });
-
-    if (changeMap.uploadProgress) {
-      for (const entryId of changeMap.uploadProgress) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.values;
-        if (isUploading && !silent) {
-          emit(UploaderEventType.FILE_UPLOAD_PROGRESS, getOutputItem(entryId));
-        }
+    if (entriesToRunValidation.length === 0) return;
+    setTimeout(() => {
+      if (!this._active) return;
+      const entriesToRunOnUpload = entriesToRunValidation.filter(
+        (entryId) =>
+          changeMap.fileInfo?.has(entryId) && !!TypedData.getByUid<UploadEntryData>(entryId)?.values.fileInfo,
+      );
+      if (entriesToRunOnUpload.length > 0) {
+        this._validation.runFileValidators('upload', entriesToRunOnUpload);
       }
-
-      this._flushCommonUploadProgress();
-    }
-    if (changeMap.isUploading) {
-      for (const entryId of changeMap.isUploading) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { isUploading, silent } = entry.values;
-        if (isUploading && !silent) {
-          emit(UploaderEventType.FILE_UPLOAD_START, getOutputItem(entryId));
-        }
-      }
-    }
-    if (changeMap.fileInfo) {
-      for (const entryId of changeMap.fileInfo) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { fileInfo, silent } = entry.values;
-        if (fileInfo && !silent) {
-          emit(UploaderEventType.FILE_UPLOAD_SUCCESS, getOutputItem(entryId));
-        }
-      }
-      if (config.get('cropPreset')) {
-        this._applyInitialCrop();
-      }
-    }
-    if (changeMap.errors) {
-      validation.runCollectionValidators();
-
-      for (const entryId of changeMap.errors) {
-        const entry = TypedData.getByUid<UploadEntryData>(entryId);
-        if (!entry) continue;
-        const { errors } = entry.values;
-        if (errors.length > 0) {
-          emit(UploaderEventType.FILE_UPLOAD_FAILED, getOutputItem(entryId));
-          emit(
-            UploaderEventType.COMMON_UPLOAD_FAILED,
-            () => getOutputCollectionState() as OutputCollectionState<'failed'>,
-            { debounce: true },
-          );
-        }
-      }
-      // One pass instead of two `findItems` scans: "all loaded, none errored".
-      let loadedCount = 0;
-      let hasErrored = false;
-      for (const uid of collection.items()) {
-        const entry = collection.read(uid);
-        if (!entry) continue;
-        if (entry.get('errors').length > 0) {
-          hasErrored = true;
-        }
-        if (entry.get('fileInfo')) {
-          loadedCount++;
-        }
-      }
-      if (
-        collection.size > 0 &&
-        !hasErrored &&
-        collection.size === loadedCount &&
-        this._collectionState.get('collectionErrors').length === 0
-      ) {
-        emit(UploaderEventType.COMMON_UPLOAD_SUCCESS, getOutputCollectionState() as OutputCollectionState<'success'>);
-      }
-    }
-    if (changeMap.cdnUrl) {
-      const uids = [...changeMap.cdnUrl].filter((uid) => !!collection.read(uid)?.get('cdnUrl'));
-      uids.forEach((uid) => {
-        emit(UploaderEventType.FILE_URL_CHANGED, getOutputItem(uid));
-      });
-
-      this._collectionState.set('groupInfo', null);
-    }
-  };
-
-  private _flushOutputItems = debounce(async () => {
-    const collection = this._collection;
-    const config = this._config;
-    const emit = this._emit;
-    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
-    // Defensive early-return on an inconsistent item set. Compare the uid-list
-    // length to `size` directly — the old code built an `OutputFileEntry` for
-    // every item via `getOutputItem` just to read `data.length` (a wasted O(N)
-    // allocation on every flush); `items().length === data.length`, so this is
-    // equivalent without the build.
-    if (collection.items().length !== collection.size) {
-      return;
-    }
-    const collectionState = getOutputCollectionState();
-    this._collectionState.set('collectionState', collectionState);
-    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
-
-    if (config.get('groupOutput') && collectionState.totalCount > 0 && collectionState.status === 'success') {
-      this._createGroup(collectionState);
-    }
-  }, 300);
-
-  private async _createGroup(collectionState: OutputCollectionState): Promise<void> {
-    const emit = this._emit;
-    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
-    const uploadClientOptions = await this._upload.buildUploadOptions();
-    const uuidList = collectionState.allEntries.map((entry) => {
-      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
+      this._validation.runFileValidators('change', entriesToRunValidation);
     });
-    const abortController = new AbortController();
-    const resp = await uploadFileGroup(uuidList, {
-      ...uploadClientOptions,
-      signal: abortController.signal,
-    });
-    // Bail if the controller was unobserved mid-flight (the `_active` check is
-    // new with the controller lifecycle) or the collection state moved on
-    // (mirrors v1).
-    if (!this._active || this._collectionState.get('collectionState') !== collectionState) {
-      abortController.abort();
-      return;
-    }
-    this._collectionState.set('groupInfo', resp);
-    const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
-    emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
-    emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
-    this._collectionState.set('collectionState', collectionStateWithGroup);
   }
 
-  private _flushCommonUploadProgress = (): void => {
-    const collection = this._collection;
-    const emit = this._emit;
-    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
-    let commonProgress = 0;
-    const items = this._upload.uploadBatch;
-    items.forEach((id) => {
-      const uploadProgress = collection.readProp(id, 'uploadProgress');
-      if (typeof uploadProgress === 'number') {
-        commonProgress += uploadProgress;
-      }
-    });
-    const progress = items.length ? Math.round(commonProgress / items.length) : 0;
-
-    if (this._collectionState.get('commonProgress') === progress) {
-      return;
+  // Debounced: publish the derived collection state + `CHANGE`, then create the
+  // output group when configured and fully successful. Cancelled on `unobserve()`.
+  private _flushOutputItems = debounce(() => {
+    const collectionState = this._collectionEvents.flushOutput();
+    if (
+      collectionState &&
+      this._config.get('groupOutput') &&
+      collectionState.totalCount > 0 &&
+      collectionState.status === 'success'
+    ) {
+      void this._group.create(collectionState, () => this._active);
     }
-
-    this._collectionState.set('commonProgress', progress);
-    emit(UploaderEventType.COMMON_UPLOAD_PROGRESS, getOutputCollectionState() as OutputCollectionState<'uploading'>);
-  };
+  }, 300);
 }

--- a/src/abstract/controllers/UploadEventsController.ts
+++ b/src/abstract/controllers/UploadEventsController.ts
@@ -168,9 +168,10 @@ export class UploadEventsController {
     this._validation.runCollectionValidators();
 
     for (const entry of removed) {
-      // (`UploadController` drops removed uids from its own active batch.)
+      // (`UploadController` drops removed uids from its own active batch.) The
+      // in-flight upload is already aborted by `UploadCollectionController.remove`
+      // (the single owner of that side-effect), so this handler only clears state.
       this._validation.cleanupValidationForEntry(entry);
-      entry.get('abortController')?.abort();
       entry.setMany({
         isRemoved: true,
         abortController: null,

--- a/src/abstract/controllers/UploadFileEventsController.ts
+++ b/src/abstract/controllers/UploadFileEventsController.ts
@@ -1,0 +1,103 @@
+import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import type { Uid } from '../../lit/Uid';
+import { inject, injectOrNull } from '../di/inject';
+import { UploaderEventType } from '../EventBus';
+import { TypedData } from '../TypedData';
+import { UploaderPublicApi } from '../UploaderPublicApi';
+import type { UploadEntryData } from '../uploadEntrySchema';
+
+type Entry = TypedData<UploadEntryData>;
+
+/**
+ * Per-FILE event emission — the file-scoped half of the collection→events
+ * derivation, split out of {@link UploadEventsController}. Pure event dispatch +
+ * per-entry finalization; it owns no observers or lifecycle. The coordinator
+ * calls these in the exact order the single collection observer dictates, so the
+ * documented event ordering is unchanged.
+ */
+export class UploadFileEventsController {
+  @injectOrNull(EventEmitter) private readonly _eventEmitter!: EventEmitter | null;
+  @inject(UploaderPublicApi) private readonly _api!: UploaderPublicApi;
+
+  // Guarded dispatch — matches the coordinator's `_emit` (a released container
+  // resolves `null` → no-op). Rest-forwarded so the 2-/3-arg call arity reaches
+  // `EventEmitter.emit` unchanged.
+  private _emit = (...args: Parameters<EventEmitter['emit']>): void => {
+    this._eventEmitter?.emit(...args);
+  };
+
+  /** `FILE_ADDED` for a newly added entry (unless it was added silently). */
+  public added(entry: Entry): void {
+    if (!entry.get('silent')) {
+      this._emit(UploaderEventType.FILE_ADDED, this._api.getOutputItem(entry.uid));
+    }
+  }
+
+  /** Finalize a removed entry's state (abort already done by the collection) and emit `FILE_REMOVED`. */
+  public finalizeRemoved(entry: Entry): void {
+    entry.setMany({
+      isRemoved: true,
+      abortController: null,
+      isUploading: false,
+      uploadProgress: 0,
+    });
+    const thumbUrl = entry.get('thumbUrl');
+    thumbUrl && URL.revokeObjectURL(thumbUrl);
+    this._emit(UploaderEventType.FILE_REMOVED, this._api.getOutputItem(entry.uid));
+  }
+
+  /** `FILE_UPLOAD_PROGRESS` for each entry that is actively (non-silently) uploading. */
+  public progress(ids: Iterable<Uid>): void {
+    for (const id of ids) {
+      const entry = TypedData.getByUid<UploadEntryData>(id);
+      if (!entry) continue;
+      const { isUploading, silent } = entry.values;
+      if (isUploading && !silent) {
+        this._emit(UploaderEventType.FILE_UPLOAD_PROGRESS, this._api.getOutputItem(id));
+      }
+    }
+  }
+
+  /** `FILE_UPLOAD_START` for each entry that just started (non-silently) uploading. */
+  public start(ids: Iterable<Uid>): void {
+    for (const id of ids) {
+      const entry = TypedData.getByUid<UploadEntryData>(id);
+      if (!entry) continue;
+      const { isUploading, silent } = entry.values;
+      if (isUploading && !silent) {
+        this._emit(UploaderEventType.FILE_UPLOAD_START, this._api.getOutputItem(id));
+      }
+    }
+  }
+
+  /** `FILE_UPLOAD_SUCCESS` for each entry that just got `fileInfo` (non-silently). */
+  public success(ids: Iterable<Uid>): void {
+    for (const id of ids) {
+      const entry = TypedData.getByUid<UploadEntryData>(id);
+      if (!entry) continue;
+      const { fileInfo, silent } = entry.values;
+      if (fileInfo && !silent) {
+        this._emit(UploaderEventType.FILE_UPLOAD_SUCCESS, this._api.getOutputItem(id));
+      }
+    }
+  }
+
+  /** `FILE_UPLOAD_FAILED` for `id` if it has errors. Returns whether it emitted (the caller pairs a common-failed emit). */
+  public failed(id: Uid): boolean {
+    const entry = TypedData.getByUid<UploadEntryData>(id);
+    if (!entry || entry.values.errors.length === 0) {
+      return false;
+    }
+    this._emit(UploaderEventType.FILE_UPLOAD_FAILED, this._api.getOutputItem(id));
+    return true;
+  }
+
+  /** `FILE_URL_CHANGED` for each id whose `cdnUrl` is now set. */
+  public urlChanged(ids: Iterable<Uid>): void {
+    for (const id of ids) {
+      const entry = TypedData.getByUid<UploadEntryData>(id);
+      if (!entry?.values.cdnUrl) continue;
+      this._emit(UploaderEventType.FILE_URL_CHANGED, this._api.getOutputItem(id));
+    }
+  }
+}

--- a/src/abstract/controllers/UploadGroupController.ts
+++ b/src/abstract/controllers/UploadGroupController.ts
@@ -1,0 +1,49 @@
+import { uploadFileGroup } from '@uploadcare/upload-client';
+import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
+import type { OutputCollectionState } from '../../types';
+import { inject, injectOrNull } from '../di/inject';
+import { UploaderEventType } from '../EventBus';
+import { UploaderPublicApi } from '../UploaderPublicApi';
+import { CollectionStateController } from './CollectionStateController';
+import { UploadController } from './UploadController';
+
+/**
+ * Output-group creation — split out of {@link UploadEventsController}. Given a
+ * fully-successful collection state it builds the CDN group, publishes
+ * `groupInfo`, and emits `GROUP_CREATED` + a follow-up `CHANGE`. Async and
+ * lifecycle-aware: `isActive` is re-checked after the network round-trip (and the
+ * collection state must not have moved on) before committing the result.
+ */
+export class UploadGroupController {
+  @injectOrNull(EventEmitter) private readonly _eventEmitter!: EventEmitter | null;
+  @inject(UploaderPublicApi) private readonly _api!: UploaderPublicApi;
+  @inject(CollectionStateController) private readonly _collectionState!: CollectionStateController;
+  @inject(UploadController) private readonly _upload!: UploadController;
+
+  private _emit = (...args: Parameters<EventEmitter['emit']>): void => {
+    this._eventEmitter?.emit(...args);
+  };
+
+  public async create(collectionState: OutputCollectionState, isActive: () => boolean): Promise<void> {
+    const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
+    const uploadClientOptions = await this._upload.buildUploadOptions();
+    const uuidList = collectionState.allEntries.map((entry) => {
+      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
+    });
+    const abortController = new AbortController();
+    const resp = await uploadFileGroup(uuidList, {
+      ...uploadClientOptions,
+      signal: abortController.signal,
+    });
+    // Bail if the stack was unobserved mid-flight or the collection state moved on.
+    if (!isActive() || this._collectionState.get('collectionState') !== collectionState) {
+      abortController.abort();
+      return;
+    }
+    this._collectionState.set('groupInfo', resp);
+    const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
+    this._emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
+    this._emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+    this._collectionState.set('collectionState', collectionStateWithGroup);
+  }
+}

--- a/src/abstract/controllers/UploadGroupController.ts
+++ b/src/abstract/controllers/UploadGroupController.ts
@@ -1,6 +1,7 @@
 import { uploadFileGroup } from '@uploadcare/upload-client';
 import { EventEmitter } from '../../blocks/UploadCtxProvider/EventEmitter';
 import type { OutputCollectionState } from '../../types';
+import { controllerLogger } from '../controllerLogger';
 import { inject, injectOrNull } from '../di/inject';
 import { UploaderEventType } from '../EventBus';
 import { UploaderPublicApi } from '../UploaderPublicApi';
@@ -19,6 +20,7 @@ export class UploadGroupController {
   @inject(UploaderPublicApi) private readonly _api!: UploaderPublicApi;
   @inject(CollectionStateController) private readonly _collectionState!: CollectionStateController;
   @inject(UploadController) private readonly _upload!: UploadController;
+  private readonly _log = controllerLogger(this, 'upload-group');
 
   private _emit = (...args: Parameters<EventEmitter['emit']>): void => {
     this._eventEmitter?.emit(...args);
@@ -26,24 +28,37 @@ export class UploadGroupController {
 
   public async create(collectionState: OutputCollectionState, isActive: () => boolean): Promise<void> {
     const getOutputCollectionState = this._api.getOutputCollectionState.bind(this._api);
-    const uploadClientOptions = await this._upload.buildUploadOptions();
-    const uuidList = collectionState.allEntries.map((entry) => {
-      return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
-    });
-    const abortController = new AbortController();
-    const resp = await uploadFileGroup(uuidList, {
-      ...uploadClientOptions,
-      signal: abortController.signal,
-    });
-    // Bail if the stack was unobserved mid-flight or the collection state moved on.
-    if (!isActive() || this._collectionState.get('collectionState') !== collectionState) {
-      abortController.abort();
-      return;
+    // Callers invoke this fire-and-forget (`void create(...)`) and `uploadFileGroup`
+    // REJECTS on network/server failure, so swallow-and-log here rather than leak an
+    // unhandled rejection; a failed group leaves `groupInfo` unset (documented).
+    try {
+      const uploadClientOptions = await this._upload.buildUploadOptions();
+      // Building options awaits (secure signature etc.); bail before the network
+      // call if the stack was torn down or the collection state moved on meanwhile,
+      // so a dead scope never fires a stale group-create request.
+      if (!isActive() || this._collectionState.get('collectionState') !== collectionState) {
+        return;
+      }
+      const uuidList = collectionState.allEntries.map((entry) => {
+        return entry.uuid + (entry.cdnUrlModifiers ? `/${entry.cdnUrlModifiers}` : '');
+      });
+      const abortController = new AbortController();
+      const resp = await uploadFileGroup(uuidList, {
+        ...uploadClientOptions,
+        signal: abortController.signal,
+      });
+      // Bail if the stack was unobserved mid-flight or the collection state moved on.
+      if (!isActive() || this._collectionState.get('collectionState') !== collectionState) {
+        abortController.abort();
+        return;
+      }
+      this._collectionState.set('groupInfo', resp);
+      const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
+      this._emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
+      this._emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
+      this._collectionState.set('collectionState', collectionStateWithGroup);
+    } catch (err) {
+      this._log.error('Failed to create the output file group', err);
     }
-    this._collectionState.set('groupInfo', resp);
-    const collectionStateWithGroup = getOutputCollectionState() as OutputCollectionState<'success', 'has-group'>;
-    this._emit(UploaderEventType.GROUP_CREATED, collectionStateWithGroup);
-    this._emit(UploaderEventType.CHANGE, () => getOutputCollectionState(), { debounce: true });
-    this._collectionState.set('collectionState', collectionStateWithGroup);
   }
 }

--- a/src/abstract/deriveEntryStatus.test.ts
+++ b/src/abstract/deriveEntryStatus.test.ts
@@ -1,0 +1,36 @@
+import type { UploadcareFile } from '@uploadcare/upload-client';
+import { describe, expect, it } from 'vitest';
+import { deriveEntryStatus, type EntryStatusFields } from './deriveEntryStatus';
+
+const fields = (over: Partial<EntryStatusFields> = {}): EntryStatusFields => ({
+  isRemoved: false,
+  errors: [],
+  fileInfo: null,
+  isUploading: false,
+  ...over,
+});
+
+const fileInfo = {} as UploadcareFile;
+const err = { type: 'x', message: 'm' } as never;
+
+describe('deriveEntryStatus (precedence: removed > failed > success > uploading > idle)', () => {
+  it('idle by default', () => {
+    expect(deriveEntryStatus(fields())).toBe('idle');
+  });
+
+  it('removed wins over everything', () => {
+    expect(deriveEntryStatus(fields({ isRemoved: true, errors: [err], fileInfo, isUploading: true }))).toBe('removed');
+  });
+
+  it('failed wins over success/uploading', () => {
+    expect(deriveEntryStatus(fields({ errors: [err], fileInfo, isUploading: true }))).toBe('failed');
+  });
+
+  it('success wins over uploading', () => {
+    expect(deriveEntryStatus(fields({ fileInfo, isUploading: true }))).toBe('success');
+  });
+
+  it('uploading when only uploading', () => {
+    expect(deriveEntryStatus(fields({ isUploading: true }))).toBe('uploading');
+  });
+});

--- a/src/abstract/deriveEntryStatus.ts
+++ b/src/abstract/deriveEntryStatus.ts
@@ -1,0 +1,28 @@
+import type { OutputFileStatus } from '../types/exported';
+import type { UploadEntryData } from './uploadEntrySchema';
+
+/** The subset of entry fields the status ladder reads. */
+export type EntryStatusFields = Pick<UploadEntryData, 'isRemoved' | 'errors' | 'fileInfo' | 'isUploading'>;
+
+/**
+ * Single source of the output-entry status ladder — used by
+ * `UploaderPublicApi.getOutputItem` (which builds the full `OutputFileEntry`) AND
+ * by UploadList's cheap toolbar-count pass, so the two can never drift.
+ *
+ * Precedence: removed > failed > success > uploading > idle.
+ */
+export function deriveEntryStatus(fields: EntryStatusFields): OutputFileStatus {
+  if (fields.isRemoved) {
+    return 'removed';
+  }
+  if (fields.errors.length > 0) {
+    return 'failed';
+  }
+  if (fields.fileInfo) {
+    return 'success';
+  }
+  if (fields.isUploading) {
+    return 'uploading';
+  }
+  return 'idle';
+}

--- a/src/blocks/FileItem/FileActionButton.ts
+++ b/src/blocks/FileItem/FileActionButton.ts
@@ -16,6 +16,11 @@ export class FileActionButton extends ChildBlock {
   @property({ type: Boolean })
   public uploading = false;
 
+  // Queued to upload (accepted, not yet started). Rendered as an indeterminate
+  // (continuously spinning) preloader so it's clear the file is waiting in queue.
+  @property({ type: Boolean })
+  public queued = false;
+
   @property({ type: Boolean })
   public failed = false;
 
@@ -50,11 +55,14 @@ export class FileActionButton extends ChildBlock {
       'uc-mini-btn': true,
       'uc-idle': this.idle,
       'uc-uploading': this.uploading,
+      'uc-queued': this.queued,
       'uc-hide-remove': this.hideRemove,
       'uc-failed': this.failed,
       'uc-success': this.success,
     });
-    const progressOffset = 100 - this._normalizedProgress;
+    // Queued → a fixed partial arc that the CSS spins (indeterminate); otherwise
+    // the determinate upload progress.
+    const progressOffset = this.queued ? 65 : 100 - this._normalizedProgress;
     const actionLabel = this.l10n(L10N_REMOVE_KEY);
 
     return html`

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -1,9 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
+import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import { PluginController } from '../../abstract/managers/plugin';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderRegistry } from '../../abstract/UploaderRegistry';
+import type { UploadEntryData } from '../../abstract/uploadEntrySchema';
 import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
+import type { Uid } from '../../lit/Uid';
 import { delay } from '../../utils/delay';
 import { FileItem } from './FileItem';
 
@@ -52,6 +55,41 @@ const mount = async (ctxName: string): Promise<{ el: FileItem; config: ConfigCon
 
 const fileNameHidden = (el: FileItem): boolean =>
   (el.querySelector('.uc-file-name') as HTMLElement | null)?.hasAttribute('hidden') ?? true;
+
+// --- rendered-output readers (the S2 parity net keys off the DOM/props render
+// commits, not the private @state/getters, so it holds across the refactor) ---
+const inner = (el: FileItem): HTMLElement => el.querySelector('.uc-inner') as HTMLElement;
+const thumb = (el: FileItem): HTMLElement & { badgeIcon: string } =>
+  el.querySelector('uc-thumb') as HTMLElement & { badgeIcon: string };
+type ActionButton = HTMLElement & {
+  uploading: boolean;
+  hideRemove: boolean;
+  progress: number;
+  failed: boolean;
+  success: boolean;
+};
+const actionButton = (el: FileItem): ActionButton => el.querySelector('uc-file-action-button') as ActionButton;
+const fileNameText = (el: FileItem): string => el.querySelector('.uc-file-name')?.textContent ?? '';
+const errorSpan = (el: FileItem): HTMLElement => el.querySelector('.uc-file-error') as HTMLElement;
+const hintSpan = (el: FileItem): HTMLElement => el.querySelector('.uc-file-hint') as HTMLElement;
+
+const getCollection = (ctxName: string): UploadCollectionController => {
+  const collection = UploaderRegistry.get(ctxName)?.get(UploadCollectionController);
+  if (!collection) throw new Error('collection controller not resolved');
+  return collection;
+};
+
+// Add an entry, bind it to the item, and open the render gate so render() commits.
+const bindEntry = async (
+  el: FileItem,
+  collection: UploadCollectionController,
+  init: Partial<UploadEntryData>,
+): Promise<Uid> => {
+  const uid = collection.add(init);
+  el.uid = uid;
+  await openRenderGate(el);
+  return uid;
+};
 
 describe('FileItem (M-god step 6b-6 migration)', () => {
   it('resolves its always-bound dependencies via @inject fields on the element', async () => {
@@ -168,5 +206,148 @@ describe('FileItem (M-god step 6b-6 migration)', () => {
     // Disconnect tears the tracked subscription down.
     el.remove();
     expect(unsub).toHaveBeenCalledOnce();
+  });
+});
+
+// Parity net for the entry-state → rendered-output mapping (`_calculateState`/
+// `_handleState`/`_updateHintAndProgress` today; derived `getTracked` reads after
+// S2). Asserts the DOM/child-props render commits, so it survives the refactor.
+describe('FileItem entry-state rendering', () => {
+  it('IDLE entry: no status flags, empty badge, zero progress, name shown', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), { fileName: 'photo.png' });
+
+    expect(inner(el).hasAttribute('data-finished')).toBe(false);
+    expect(inner(el).hasAttribute('data-failed')).toBe(false);
+    expect(inner(el).hasAttribute('data-uploading')).toBe(false);
+    expect(thumb(el).badgeIcon).toBe('');
+    expect(fileNameText(el)).toBe('photo.png');
+    expect(errorSpan(el).hasAttribute('hidden')).toBe(true);
+    expect(hintSpan(el).hasAttribute('hidden')).toBe(true);
+
+    const btn = actionButton(el);
+    expect(btn.uploading).toBe(false);
+    expect(btn.hideRemove).toBe(false);
+    expect(btn.failed).toBe(false);
+    expect(btn.success).toBe(false);
+    expect(btn.progress).toBe(0);
+  });
+
+  it('FINISHED entry (fileInfo set): success flag + success badge', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), { fileName: 'photo.png', fileInfo: { uuid: 'srv' } as never });
+
+    expect(inner(el).hasAttribute('data-finished')).toBe(true);
+    expect(thumb(el).badgeIcon).toBe('badge-success');
+    expect(actionButton(el).success).toBe(true);
+  });
+
+  it('FAILED entry (errors set): failed flag, error badge, error text shown', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {
+      fileName: 'photo.png',
+      errors: [{ type: 'boom', message: 'It broke' } as never],
+    });
+
+    expect(inner(el).hasAttribute('data-failed')).toBe(true);
+    expect(thumb(el).badgeIcon).toBe('badge-error');
+    expect(actionButton(el).failed).toBe(true);
+    expect(errorSpan(el).hasAttribute('hidden')).toBe(false);
+    expect(errorSpan(el).textContent).toBe('It broke');
+    expect(hintSpan(el).hasAttribute('hidden')).toBe(true);
+  });
+
+  it('UPLOADING entry: uploading flag, hidden remove, live progress, no badge', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {
+      fileName: 'photo.png',
+      isUploading: true,
+      uploadProgress: 0.42,
+    });
+
+    expect(inner(el).hasAttribute('data-uploading')).toBe(true);
+    expect(thumb(el).badgeIcon).toBe('');
+    const btn = actionButton(el);
+    expect(btn.uploading).toBe(true);
+    expect(btn.hideRemove).toBe(true);
+    expect(btn.progress).toBe(0.42);
+  });
+
+  it('QUEUED-UPLOADING entry: remove hidden, progress NOT zeroed', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {
+      fileName: 'photo.png',
+      isQueuedForUploading: true,
+      uploadProgress: 0.3,
+    });
+
+    const btn = actionButton(el);
+    expect(btn.hideRemove).toBe(true);
+    expect(btn.uploading).toBe(false);
+    expect(btn.progress).toBe(0.3);
+  });
+
+  it('VALIDATION-pending entry: progress zeroed even with uploadProgress set', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {
+      fileName: 'photo.png',
+      isValidationPending: true,
+      uploadProgress: 0.5,
+    });
+
+    expect(actionButton(el).progress).toBe(0);
+  });
+
+  it('name falls back to the l10n placeholder when no fileName/externalUrl', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {});
+
+    expect(fileNameText(el)).toBe('No name...');
+  });
+
+  it('shows the "waiting-for" source hint for a pending external-source entry', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), {
+      externalUrl: 'https://example.com/x',
+      source: 'dropbox',
+    });
+
+    expect(hintSpan(el).hasAttribute('hidden')).toBe(false);
+    expect(hintSpan(el).textContent).toBe('Waiting for Dropbox');
+  });
+
+  it('reacts to a fileName change on the bound entry', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uid = await bindEntry(el, collection, { fileName: 'old.png' });
+    expect(fileNameText(el)).toBe('old.png');
+
+    collection.publishProp(uid, 'fileName', 'new.png');
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameText(el)).toBe('new.png');
+  });
+
+  it('clears focus when the bound entry transitions to uploading', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uid = await bindEntry(el, collection, { fileName: 'photo.png' });
+
+    el.click();
+    expect(el.hasAttribute('focused')).toBe(true);
+
+    collection.publishProp(uid, 'isUploading', true);
+    await delay(120);
+    expect(el.hasAttribute('focused')).toBe(false);
   });
 });

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -372,6 +372,46 @@ describe('FileItem entry-state rendering', () => {
     expect(remove).toHaveBeenCalledWith(uid);
   });
 
+  it('does not send remove-file telemetry for a no-op removal (entry already gone)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uid = await bindEntry(el, collection, { fileName: 'photo.png' });
+    collection.remove(uid); // entry already removed — the button click is now a no-op
+    await delay(0);
+    const telemetry = UploaderRegistry.get(ctxName)?.get(TelemetryManager);
+    const sendEvent = vi.spyOn(telemetry as TelemetryManager, 'sendEvent');
+
+    el.querySelector('uc-file-action-button')?.dispatchEvent(
+      new CustomEvent('uc:remove', { bubbles: true, composed: true }),
+    );
+    expect(sendEvent).not.toHaveBeenCalled();
+  });
+
+  it('does not re-focus a row that is uploading (drop-focus-on-upload holds on re-click)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uid = await bindEntry(el, collection, { fileName: 'photo.png' });
+
+    el.click();
+    await el.updateComplete;
+    expect(inner(el).hasAttribute('data-focused')).toBe(true);
+
+    // Row starts uploading → focus dropped (host attr + inner data-focused + static ref).
+    collection.publishProp(uid, 'isUploading', true);
+    await delay(120);
+    await el.updateComplete;
+    expect(el.hasAttribute('focused')).toBe(false);
+    expect(inner(el).hasAttribute('data-focused')).toBe(false);
+
+    // Re-clicking while uploading must NOT re-apply the highlight.
+    el.click();
+    await el.updateComplete;
+    expect(el.hasAttribute('focused')).toBe(false);
+    expect(inner(el).hasAttribute('data-focused')).toBe(false);
+  });
+
   it('clears focus when the bound entry transitions to uploading', async () => {
     const ctxName = freshCtxName();
     const { el } = await mount(ctxName);

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -63,6 +63,7 @@ const thumb = (el: FileItem): HTMLElement & { badgeIcon: string } =>
   el.querySelector('uc-thumb') as HTMLElement & { badgeIcon: string };
 type ActionButton = HTMLElement & {
   uploading: boolean;
+  queued: boolean;
   hideRemove: boolean;
   progress: number;
   failed: boolean;
@@ -289,7 +290,15 @@ describe('FileItem entry-state rendering', () => {
     const btn = actionButton(el);
     expect(btn.hideRemove).toBe(true);
     expect(btn.uploading).toBe(false);
+    expect(btn.queued).toBe(true); // surfaced as the indeterminate queued indicator
     expect(btn.progress).toBe(0.3);
+  });
+
+  it('is not marked queued while actively uploading', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    await bindEntry(el, getCollection(ctxName), { fileName: 'photo.png', isUploading: true });
+    expect(actionButton(el).queued).toBe(false);
   });
 
   it('VALIDATION-pending entry: progress zeroed even with uploadProgress set', async () => {
@@ -347,6 +356,81 @@ describe('FileItem entry-state rendering', () => {
     expect(el.hasAttribute('focused')).toBe(true);
 
     collection.publishProp(uid, 'isUploading', true);
+    await delay(120);
+    expect(el.hasAttribute('focused')).toBe(false);
+  });
+});
+
+// The uid-change path must fully rebind: the render getters + side-effects read
+// `this.entry`/`this.uid`, and `reset()` tears down the previous entry's keyed
+// subscription — so no state or subscription from a previous uid leaks in.
+describe('FileItem uid rebinding', () => {
+  it('rebinds to the new entry on uid change; the previous entry no longer drives it', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uidA = await bindEntry(el, collection, { fileName: 'a.png' });
+    expect(fileNameText(el)).toBe('a.png');
+
+    const uidB = collection.add({ fileName: 'b.png' });
+    el.uid = uidB;
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameText(el)).toBe('b.png');
+
+    // A write to the PREVIOUS entry must not leak into this item (subscription
+    // torn down by reset(); its signals no longer tracked by render).
+    collection.publishProp(uidA, 'fileName', 'a-changed.png');
+    await el.updateComplete;
+    await delay(120);
+    expect(fileNameText(el)).toBe('b.png');
+
+    // A write to the CURRENT entry still updates it.
+    collection.publishProp(uidB, 'fileName', 'b-changed.png');
+    await el.updateComplete;
+    await delay(0);
+    expect(fileNameText(el)).toBe('b-changed.png');
+  });
+
+  it('clears its bound entry when uid changes to an unknown id', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    await bindEntry(el, collection, { fileName: 'a.png', fileInfo: { uuid: 'srv' } as never });
+    expect(fileNameText(el)).toBe('a.png');
+    expect(inner(el).hasAttribute('data-finished')).toBe(true);
+
+    el.uid = 'nonexistent-uid' as Uid;
+    await el.updateComplete;
+    await delay(0);
+    // entry === null → the name clears to '' (NOT the stale previous name, which
+    // the pre-S2 @state mirror retained) and status flags reset.
+    expect(fileNameText(el)).toBe('');
+    expect(inner(el).hasAttribute('data-finished')).toBe(false);
+  });
+
+  it('does not let the previous entry drive side-effects after a uid change', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uidA = await bindEntry(el, collection, { fileName: 'a.png' });
+
+    const uidB = collection.add({ fileName: 'b.png' });
+    el.uid = uidB;
+    await el.updateComplete;
+    await delay(0);
+
+    el.click();
+    expect(el.hasAttribute('focused')).toBe(true);
+
+    // The PREVIOUS entry starting to upload must NOT clear this item's focus —
+    // its keyed subscription (which drives focus-clear-on-uploading) is gone.
+    collection.publishProp(uidA, 'isUploading', true);
+    await delay(120);
+    expect(el.hasAttribute('focused')).toBe(true);
+
+    // The CURRENT entry uploading still clears focus.
+    collection.publishProp(uidB, 'isUploading', true);
     await delay(120);
     expect(el.hasAttribute('focused')).toBe(false);
   });

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -346,6 +346,24 @@ describe('FileItem entry-state rendering', () => {
     expect(fileNameText(el)).toBe('new.png');
   });
 
+  it('remove action sends remove-file telemetry and delegates to collection.remove (which owns abort)', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const collection = getCollection(ctxName);
+    const uid = await bindEntry(el, collection, { fileName: 'photo.png' });
+    const remove = vi.spyOn(collection, 'remove');
+    const telemetry = UploaderRegistry.get(ctxName)?.get(TelemetryManager);
+    const sendEvent = vi.spyOn(telemetry as TelemetryManager, 'sendEvent');
+
+    el.querySelector('uc-file-action-button')?.dispatchEvent(
+      new CustomEvent('uc:remove', { bubbles: true, composed: true }),
+    );
+    expect(sendEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ payload: { metadata: { event: 'remove-file', node: 'UC-FILE-ITEM' } } }),
+    );
+    expect(remove).toHaveBeenCalledWith(uid);
+  });
+
   it('clears focus when the bound entry transitions to uploading', async () => {
     const ctxName = freshCtxName();
     const { el } = await mount(ctxName);

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -166,14 +166,22 @@ describe('FileItem (M-god step 6b-6 migration)', () => {
     ensureUploaderCtx(ctxName);
     const a = await mount(ctxName);
     const b = await mount(ctxName);
+    await openRenderGate(a.el);
+    await openRenderGate(b.el);
 
     a.el.click();
+    await a.el.updateComplete;
     expect(a.el.hasAttribute('focused')).toBe(true);
+    expect(inner(a.el).hasAttribute('data-focused')).toBe(true); // the visible highlight
     expect(b.el.hasAttribute('focused')).toBe(false);
 
     b.el.click();
+    await a.el.updateComplete;
+    await b.el.updateComplete;
     expect(b.el.hasAttribute('focused')).toBe(true);
+    expect(inner(b.el).hasAttribute('data-focused')).toBe(true);
     expect(a.el.hasAttribute('focused')).toBe(false); // previous focus dropped — O(1), no full sweep
+    expect(inner(a.el).hasAttribute('data-focused')).toBe(false);
   });
 
   it('wires the plugin manager via whenController once the PluginController resolves, and unsubscribes on disconnect', async () => {

--- a/src/blocks/FileItem/FileItem.test.ts
+++ b/src/blocks/FileItem/FileItem.test.ts
@@ -122,6 +122,21 @@ describe('FileItem (M-god step 6b-6 migration)', () => {
   // `UploadController.uploadEntries` directly. See UploaderPublicApi /
   // UploadController specs.)
 
+  it('single-focus: clicking an item focuses it and unfocuses the previously-focused one', async () => {
+    const ctxName = freshCtxName();
+    ensureUploaderCtx(ctxName);
+    const a = await mount(ctxName);
+    const b = await mount(ctxName);
+
+    a.el.click();
+    expect(a.el.hasAttribute('focused')).toBe(true);
+    expect(b.el.hasAttribute('focused')).toBe(false);
+
+    b.el.click();
+    expect(b.el.hasAttribute('focused')).toBe(true);
+    expect(a.el.hasAttribute('focused')).toBe(false); // previous focus dropped — O(1), no full sweep
+  });
+
   it('wires the plugin manager via whenController once the PluginController resolves, and unsubscribes on disconnect', async () => {
     const ctxName = freshCtxName();
     ensureUploaderCtx(ctxName);

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -8,7 +8,7 @@ import { PluginController, type PluginFileActionRegistration } from '../../abstr
 import type { Owned } from '../../abstract/managers/plugin/PluginTypes';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
-import type { UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
+import type { UploadEntryKeys, UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
 import { debounce } from '../../utils/debounce';
 import { throttle } from '../../utils/throttle';
 import { canonicalSourceName, ExternalUploadSource } from '../../utils/UploadSource';
@@ -34,6 +34,30 @@ const FileItemState = Object.freeze({
 } as const);
 
 type FileItemStateValue = (typeof FileItemState)[keyof typeof FileItemState];
+
+// Entry keys whose change re-derives the item state machine (`_calculateState`).
+// `externalUrl` is intentionally absent — it only affects the display name.
+const STATE_RECOMPUTE_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
+  'isQueuedForValidation',
+  'isValidationPending',
+  'uploadProgress',
+  'isQueuedForUploading',
+  'fileName',
+  'fileInfo',
+  'errors',
+  'isUploading',
+  'fileSize',
+  'mimeType',
+  'isImage',
+]);
+// Entry keys whose change re-evaluates plugin file actions.
+const PLUGIN_ACTION_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
+  'fileInfo',
+  'isUploading',
+  'errors',
+]);
+// Entry keys that feed the displayed item name.
+const NAME_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>(['fileName', 'externalUrl']);
 
 export class FileItem extends FileItemConfig {
   // `ConfigController`/`TelemetryManager` are always-bound `@inject` fields.
@@ -231,45 +255,25 @@ export class FileItem extends FileItemConfig {
       return;
     }
 
-    this.subEntry('isQueuedForValidation', () => {
-      this._debouncedCalculateState();
+    // Seed the display name (was the immediate fire of the fileName/externalUrl
+    // observers, which `subscribeKeys` doesn't replay).
+    this._itemName = entry.get('fileName') || entry.get('externalUrl') || this.l10n('file-no-name');
+
+    // ONE keyed subscription replaces the ~15 per-key `subEntry` observes (which
+    // included duplicate `fileInfo`/`isUploading`/`errors` watches). Dispatch by
+    // the changed key to the same effects: recompute the display name, re-derive
+    // the state machine (debounced), and re-evaluate plugin actions.
+    this.subEntryKeys((key) => {
+      if (NAME_KEYS.has(key)) {
+        this._itemName = entry.get('fileName') || entry.get('externalUrl') || this.l10n('file-no-name');
+      }
+      if (STATE_RECOMPUTE_KEYS.has(key)) {
+        this._debouncedCalculateState();
+      }
+      if (PLUGIN_ACTION_KEYS.has(key)) {
+        this._updatePluginFileActions();
+      }
     });
-
-    this.subEntry('isValidationPending', () => {
-      this._debouncedCalculateState();
-    });
-
-    this.subEntry('uploadProgress', () => {
-      this._debouncedCalculateState();
-    });
-
-    this.subEntry('isQueuedForUploading', () => {
-      this._debouncedCalculateState();
-    });
-
-    this.subEntry('fileName', (name) => {
-      this._itemName = name || entry.get('externalUrl') || this.l10n('file-no-name');
-      this._debouncedCalculateState();
-    });
-
-    this.subEntry('externalUrl', (externalUrl) => {
-      this._itemName = entry.get('fileName') || externalUrl || this.l10n('file-no-name');
-    });
-
-    this.subEntry('fileInfo', () => {
-      this._debouncedCalculateState();
-    });
-
-    this.subEntry('errors', () => this._debouncedCalculateState());
-    this.subEntry('isUploading', () => this._debouncedCalculateState());
-    this.subEntry('fileSize', () => this._debouncedCalculateState());
-    this.subEntry('mimeType', () => this._debouncedCalculateState());
-    this.subEntry('isImage', () => this._debouncedCalculateState());
-
-    // Update plugin file actions when file status changes
-    this.subEntry('fileInfo', () => this._updatePluginFileActions());
-    this.subEntry('isUploading', () => this._updatePluginFileActions());
-    this.subEntry('errors', () => this._updatePluginFileActions());
 
     this._calculateState();
     this._updatePluginFileActions();

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -95,10 +95,18 @@ export class FileItem extends FileItemConfig {
   private _observer?: IntersectionObserver;
   private _pluginManager: PluginController | null = null;
 
-  // Thin UI handler: the file/upload side-effects live at the collection level —
-  // `UploadCollectionController.remove` aborts the in-flight upload and emits the
-  // removal telemetry. The element just requests the removal for its entry.
   private _handleRemove = (): void => {
+    this._telemetry.sendEvent({
+      payload: {
+        metadata: {
+          event: 'remove-file',
+          node: this.tagName,
+        },
+      },
+    });
+
+    // Aborting the in-flight upload is file/upload logic and lives in
+    // `UploadCollectionController.remove` — the UI just requests the removal.
     const collection = this._collection;
     if (this.uid && collection?.hasItem(this.uid)) {
       collection.remove(this.uid);

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -20,6 +20,10 @@ import '../Icon/Icon';
 import '../ProgressBar/ProgressBar';
 import './FileActionButton';
 
+// The file-item display state machine. This — and everything derived from it
+// (badge, flags, hint, progress, name, aria) — is UI/presentation logic and
+// lives in the element; only file/upload/collection *side-effects* (aborting an
+// upload, removing an entry, telemetry) belong in the controller layer.
 const FileItemState = Object.freeze({
   FINISHED: Symbol('FINISHED'),
   FAILED: Symbol('FAILED'),
@@ -35,7 +39,7 @@ type FileItemStateValue = (typeof FileItemState)[keyof typeof FileItemState];
 // Entry keys the state-machine verdict (`_deriveState`) reads. A change to one of
 // these is the only trigger for the imperative focus-clear side-effect
 // (`_syncUploadingFocus`); everything else the state feeds — badge, flags, hint,
-// progress, aria, name — is a pure `getTracked` read in `render()` (S2), so Lit
+// progress, aria, name — is a pure `getTracked` read in `render()`, so Lit
 // re-renders those on the exact keys read with no imperative mirror.
 const STATE_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
   'errors',
@@ -63,6 +67,14 @@ export class FileItem extends FileItemConfig {
   @injectOrNull(UploadCollectionController) private readonly _collection!: UploadCollectionController | null;
   @injectOrNull(UploaderPublicApi) private readonly _api!: UploaderPublicApi | null;
 
+  // Off-screen render gate. Complements list virtualization rather than being
+  // superseded by it: virtualization caps mounted rows in the bounded/steady
+  // case, but when the list can't be windowed yet — the first render of a large
+  // bulk-populate (row geometry not measured) and unbounded/page-scroll
+  // containers — the row still mounts, and this keeps that render CHEAP (empty)
+  // until it scrolls into view. Without it, a bulk add renders every FileItem
+  // template synchronously in one frame (Thumb's own lazy observer only defers
+  // the thumbnail image, not the template), blocking the summary update.
   @state()
   private _pauseRender = true;
 
@@ -83,22 +95,12 @@ export class FileItem extends FileItemConfig {
   private _observer?: IntersectionObserver;
   private _pluginManager: PluginController | null = null;
 
+  // Thin UI handler: the file/upload side-effects live at the collection level —
+  // `UploadCollectionController.remove` aborts the in-flight upload and emits the
+  // removal telemetry. The element just requests the removal for its entry.
   private _handleRemove = (): void => {
-    this._telemetry.sendEvent({
-      payload: {
-        metadata: {
-          event: 'remove-file',
-          node: this.tagName,
-        },
-      },
-    });
-
-    // `uploadCollection` is container-owned (M-god step 4). Read it
-    // null-tolerantly via `useOrNull`: this handler can run outside an adopted
-    // scope (teardown race), where the throwing `use()` would be unsafe.
     const collection = this._collection;
     if (this.uid && collection?.hasItem(this.uid)) {
-      this.entry?.get('abortController')?.abort();
       collection.remove(this.uid);
     }
   };
@@ -153,8 +155,7 @@ export class FileItem extends FileItemConfig {
       this._renderedOnce = true;
       // One-shot: the observer's only job is to un-pause on first view. Disconnect
       // so it stops firing on every subsequent scroll for this row's whole life
-      // (matches Thumb). Without this, N rows keep N live callbacks running on
-      // every scroll frame at large N.
+      // (matches Thumb).
       this._observer?.disconnect();
     }
   }
@@ -174,9 +175,8 @@ export class FileItem extends FileItemConfig {
     // ONE keyed subscription drives only the genuine side-effects that are NOT
     // pure render: the focus-clear-on-uploading transition and the plugin
     // file-action recompute. Everything the row *displays* (name, badge, flags,
-    // hint, progress, aria) is a `getTracked` read in `render()` (S2), so Lit
-    // re-renders on the exact entry keys it reads — no imperative mirror, no
-    // debounce.
+    // hint, progress, aria) is a `getTracked` read in `render()`, so Lit
+    // re-renders on the exact entry keys it reads — no imperative mirror.
     this.subEntryKeys((key) => {
       if (STATE_KEYS.has(key)) {
         this._syncUploadingFocus();
@@ -276,12 +276,11 @@ export class FileItem extends FileItemConfig {
     }
   }
 
-  // Host `[mode]` attribute: the `uc-file-item[mode="grid"]` CSS selectors key
-  // off it, driving the grid/list box sizing, so it must be set eagerly before
-  // first paint. `beforeUpdate` fires this synchronously on adoption AND keeps
-  // firing on `filesViewMode` change even while this block's `_pauseRender`
-  // lazy-render gate holds `shouldUpdate` off (verified in effect.integration.test)
-  // — which a plain `willUpdate`+`getTracked` host-attr write could not do.
+  // Host `[mode]` attribute: the `uc-file-item[mode="grid"]` CSS selectors key off
+  // it, driving the grid/list box sizing, so it must be set eagerly before first
+  // paint. `beforeUpdate` fires this synchronously on adoption AND keeps firing on
+  // `filesViewMode` change even while `_pauseRender` holds `shouldUpdate` off —
+  // which a plain `willUpdate`+`getTracked` host-attr write could not do.
   @effect({ beforeUpdate: true })
   protected _applyMode(): void {
     this.setAttribute('mode', this._config.getTracked('filesViewMode'));
@@ -329,6 +328,8 @@ export class FileItem extends FileItemConfig {
   public override connectedCallback(): void {
     super.connectedCallback();
 
+    // One-shot render gate: un-pause on first view (see `_pauseRender`). The
+    // observer watches this element's own node.
     this._observer = new window.IntersectionObserver(this._observerCallback.bind(this), {
       threshold: [0, 1],
     });
@@ -336,21 +337,17 @@ export class FileItem extends FileItemConfig {
   }
 
   public override disconnectedCallback(): void {
+    // `super.disconnectedCallback()` (via `_releaseController` / FileItemConfig)
+    // drops membership and calls `reset()`; also tear down this element's own
+    // IntersectionObserver.
     super.disconnectedCallback();
-
-    // `activeInstances` membership is dropped by `controllerReleased` (invoked
-    // via `super.disconnectedCallback()` → `_releaseController`). The
-    // `IntersectionObserver` observes this element's own node (created in
-    // `connectedCallback`), so it stays on the DOM disconnect; `reset()` cancels
-    // in-flight per-entry work.
     this._observer?.disconnect();
-    this.reset();
   }
 
   // The upload mechanics (queue, beforeUpload chain, progress/abort, error
-  // handling) now live in the DOM-free UploadController. This block stays the
-  // trigger; it reflects the resulting entry mutations through `getTracked` reads
-  // in `render()` (state/badge/progress/…) plus the keyed side-effect subscription.
+  // handling) live in the DOM-free UploadController. This block reflects the
+  // resulting entry mutations through `getTracked` reads in `render()`
+  // (state/badge/progress/…) plus the keyed side-effect subscription.
   // The currently-focused item (single-focus model — see the click handler).
   private static _focusedInstance: FileItem | null = null;
 
@@ -361,55 +358,105 @@ export class FileItem extends FileItemConfig {
     return super.shouldUpdate(changedProperties);
   }
 
-  public override render() {
-    // Signals-native derivation (S2): read the entry through `getTracked`, so
-    // `SignalWatcher` re-renders the row on exactly the keys read — a progress
-    // tick repaints only the progress binding, not a full imperative recompute.
+  private get _state(): FileItemStateValue {
     const { entry } = this;
-    const state = entry ? this._deriveState((key) => entry.getTracked(key)) : FileItemState.IDLE;
+    return entry ? this._deriveState((key) => entry.getTracked(key)) : FileItemState.IDLE;
+  }
 
-    const isFinished = state === FileItemState.FINISHED;
-    const isFailed = state === FileItemState.FAILED;
-    const isUploading = state === FileItemState.UPLOADING;
+  private get _isFinished(): boolean {
+    return this._state === FileItemState.FINISHED;
+  }
+
+  private get _isFailed(): boolean {
+    return this._state === FileItemState.FAILED;
+  }
+
+  private get _isUploading(): boolean {
+    return this._state === FileItemState.UPLOADING;
+  }
+
+  // Waiting in the upload queue (accepted, not yet uploading) — surfaced in the UI
+  // as an indeterminate progress indicator so it's clear the file is queued.
+  private get _isQueued(): boolean {
+    return this._state === FileItemState.QUEUED_UPLOADING;
+  }
+
+  private get _hideRemoveAction(): boolean {
+    const state = this._state;
+    return state === FileItemState.QUEUED_UPLOADING || state === FileItemState.UPLOADING;
+  }
+
+  private get _badgeIcon(): string {
+    const state = this._state;
+    return state === FileItemState.FAILED ? 'badge-error' : state === FileItemState.FINISHED ? 'badge-success' : '';
+  }
+
+  private get _errorText(): string {
+    return this.entry?.getTracked('errors')?.[0]?.message ?? '';
+  }
+
+  private get _progressValue(): number {
+    const { entry } = this;
+    if (!entry) {
+      return 0;
+    }
+    const state = this._state;
     const isValidating = state === FileItemState.QUEUED_VALIDATION || state === FileItemState.VALIDATION;
-    const hideRemoveAction = state === FileItemState.QUEUED_UPLOADING || isUploading;
-    const badgeIcon = isFailed ? 'badge-error' : isFinished ? 'badge-success' : '';
+    return isValidating ? 0 : entry.getTracked('uploadProgress');
+  }
 
-    const errorText = entry?.getTracked('errors')?.[0]?.message ?? '';
-    const progressValue = entry && !isValidating ? entry.getTracked('uploadProgress') : 0;
-    const itemName = entry
-      ? entry.getTracked('fileName') || entry.getTracked('externalUrl') || this.l10n('file-no-name')
-      : '';
+  private get _itemName(): string {
+    const { entry } = this;
+    if (!entry) {
+      return '';
+    }
+    return entry.getTracked('fileName') || entry.getTracked('externalUrl') || this.l10n('file-no-name');
+  }
 
-    const source = entry?.getTracked('source') ?? null;
-    const externalUrl = entry?.getTracked('externalUrl') ?? null;
-    const hint =
-      !errorText && !isFinished && externalUrl && source && Object.values(ExternalUploadSource).includes(source)
-        ? this.l10n('waiting-for', { source: this.l10n(`src-type-${canonicalSourceName(source)}`) })
-        : '';
+  private get _hint(): string {
+    const { entry } = this;
+    if (!entry || this._errorText || this._isFinished) {
+      return '';
+    }
+    const source = entry.getTracked('source');
+    const externalUrl = entry.getTracked('externalUrl');
+    if (externalUrl && source && Object.values(ExternalUploadSource).includes(source)) {
+      return this.l10n('waiting-for', { source: this.l10n(`src-type-${canonicalSourceName(source)}`) });
+    }
+    return '';
+  }
 
-    const fileName = entry?.getTracked('fileName') ?? null;
-    const ariaLabelStatusFile = fileName
-      ? this.l10n('a11y-file-item-status', {
-          fileName,
-          status: this.l10n(state.description?.toLocaleLowerCase() ?? '').toLocaleLowerCase(),
-        })
-      : '';
+  private get _ariaLabelStatusFile(): string {
+    const fileName = this.entry?.getTracked('fileName') ?? null;
+    if (!fileName) {
+      return '';
+    }
+    return this.l10n('a11y-file-item-status', {
+      fileName,
+      status: this.l10n(this._state.description?.toLocaleLowerCase() ?? '').toLocaleLowerCase(),
+    });
+  }
 
+  public override render() {
     return html`
       <div
         class="uc-inner"
-        ?data-finished=${isFinished}
-        ?data-uploading=${isUploading}
-        ?data-failed=${isFailed}
+        ?data-finished=${this._isFinished}
+        ?data-uploading=${this._isUploading}
+        ?data-failed=${this._isFailed}
         ?data-focused=${this._isFocused}
       >
-        <uc-thumb .uid=${this.uid} .badgeIcon=${badgeIcon}></uc-thumb>
+        <uc-thumb .uid=${this.uid} .badgeIcon=${this._badgeIcon}></uc-thumb>
 
-        <div aria-atomic="true" aria-live="polite" class="uc-file-name-wrapper" aria-label=${ariaLabelStatusFile}>
-          <span class="uc-file-name" ?hidden=${!this._showFileNames}>${itemName}</span>
-          <span class="uc-file-error" ?hidden=${!errorText}>${errorText}</span>
-          <span class="uc-file-hint" ?hidden=${!hint}>${hint}</span>
+        <div
+          aria-atomic="true"
+          aria-live="polite"
+          class="uc-file-name-wrapper"
+          aria-label=${this._ariaLabelStatusFile}
+        >
+          <span class="uc-file-name" ?hidden=${!this._showFileNames}>${this._itemName}</span>
+          <span class="uc-file-error" ?hidden=${!this._errorText}>${this._errorText}</span>
+          <span class="uc-file-hint" ?hidden=${!this._hint}>${this._hint}</span>
         </div>
         <div class="uc-file-actions">
           ${this._pluginFileActions.map(
@@ -428,11 +475,12 @@ export class FileItem extends FileItemConfig {
           )}
           <uc-file-action-button
             @uc:remove=${this._handleRemove}
-            .uploading=${isUploading}
-            .hideRemove=${hideRemoveAction}
-            .progress=${progressValue}
-            .failed=${isFailed}
-            .success=${isFinished}
+            .uploading=${this._isUploading}
+            .queued=${this._isQueued}
+            .hideRemove=${this._hideRemoveAction}
+            .progress=${this._progressValue}
+            .failed=${this._isFailed}
+            .success=${this._isFinished}
           ></uc-file-action-button>
         </div>
       </div>

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -96,6 +96,12 @@ export class FileItem extends FileItemConfig {
   private _pluginManager: PluginController | null = null;
 
   private _handleRemove = (): void => {
+    const collection = this._collection;
+    if (!this.uid || !collection?.hasItem(this.uid)) {
+      return;
+    }
+    // Telemetry only for a real removal — guard first, so a stale/double
+    // `uc:remove` (or an unset uid) doesn't record a phantom `remove-file`.
     this._telemetry.sendEvent({
       payload: {
         metadata: {
@@ -104,13 +110,9 @@ export class FileItem extends FileItemConfig {
         },
       },
     });
-
     // Aborting the in-flight upload is file/upload logic and lives in
     // `UploadCollectionController.remove` — the UI just requests the removal.
-    const collection = this._collection;
-    if (this.uid && collection?.hasItem(this.uid)) {
-      collection.remove(this.uid);
-    }
+    collection.remove(this.uid);
   };
 
   // Single source of truth for the state-machine verdict. `read` is `getTracked`
@@ -149,6 +151,12 @@ export class FileItem extends FileItemConfig {
     if (this._deriveState((key) => entry.get(key)) === FileItemState.UPLOADING) {
       this._isFocused = false;
       this.removeAttribute('focused');
+      // Also drop the static single-focus ref, otherwise re-clicking this row
+      // while it uploads hits the `previous === this` short-circuit and re-focuses
+      // it — undoing the drop-focus-on-upload rule.
+      if (FileItem._focusedInstance === this) {
+        FileItem._focusedInstance = null;
+      }
     }
   }
 
@@ -302,6 +310,13 @@ export class FileItem extends FileItemConfig {
     // mutated `[focused]` on all rows, dirtying style for the whole list at large
     // N) and the static `Set` of all instances (which pinned every row from GC).
     this.onclick = () => {
+      // An uploading row does not take focus (consistent with the
+      // drop-focus-on-upload rule in `_syncUploadingFocus`) — otherwise clicking
+      // it would re-apply the highlight mid-upload.
+      const entry = this.entry;
+      if (entry && this._deriveState((key) => entry.get(key)) === FileItemState.UPLOADING) {
+        return;
+      }
       const previous = FileItem._focusedInstance;
       if (previous && previous !== this) {
         previous._isFocused = false;

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -211,6 +211,11 @@ export class FileItem extends FileItemConfig {
     if (entry.isIntersecting && !this._renderedOnce) {
       this._pauseRender = false;
       this._renderedOnce = true;
+      // One-shot: the observer's only job is to un-pause on first view. Disconnect
+      // so it stops firing on every subsequent scroll for this row's whole life
+      // (matches Thumb). Without this, N rows keep N live callbacks running on
+      // every scroll frame at large N.
+      this._observer?.disconnect();
     }
   }
 
@@ -369,17 +374,18 @@ export class FileItem extends FileItemConfig {
   protected override controllerReady(): void {
     this._handleEntryId(this.uid);
 
+    // Single-focus: unfocus the previously-focused item and focus this one — O(1)
+    // per click. Replaces an O(N) sweep over every connected FileItem (which
+    // mutated `[focused]` on all rows, dirtying style for the whole list at large
+    // N) and the static `Set` of all instances (which pinned every row from GC).
     this.onclick = () => {
-      FileItem.activeInstances.forEach((inst) => {
-        if (inst === this) {
-          inst.setAttribute('focused', '');
-        } else {
-          inst.removeAttribute('focused');
-        }
-      });
+      const previous = FileItem._focusedInstance;
+      if (previous && previous !== this) {
+        previous.removeAttribute('focused');
+      }
+      this.setAttribute('focused', '');
+      FileItem._focusedInstance = this;
     };
-
-    FileItem.activeInstances.add(this);
   }
 
   // The uploader-scope `PluginController` is bound + resolved only once an
@@ -397,9 +403,11 @@ export class FileItem extends FileItemConfig {
 
   protected override controllerReleased(): void {
     this._pluginManager = null;
-    // Adoption-scoped: `activeInstances.add(this)` runs in `controllerReady`, so
-    // drop it on release/re-adoption (and disconnect, via `_releaseController`).
-    FileItem.activeInstances.delete(this);
+    // Release the static focus reference if it points at this row, so a removed/
+    // re-adopted item isn't retained (and a later click doesn't touch a stale one).
+    if (FileItem._focusedInstance === this) {
+      FileItem._focusedInstance = null;
+    }
   }
 
   public override connectedCallback(): void {
@@ -427,7 +435,8 @@ export class FileItem extends FileItemConfig {
   // handling) now live in the DOM-free UploadController. This block stays the
   // trigger; it reacts to the resulting entry mutations through its existing
   // per-entry subscriptions (`isUploading`/`errors`/… → `_debouncedCalculateState`).
-  public static activeInstances: Set<FileItem> = new Set<FileItem>();
+  // The currently-focused item (single-focus model — see the click handler).
+  private static _focusedInstance: FileItem | null = null;
 
   protected override shouldUpdate(changedProperties: PropertyValues<this>): boolean {
     if (this._pauseRender) {

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -304,8 +304,13 @@ export class FileItem extends FileItemConfig {
     this.onclick = () => {
       const previous = FileItem._focusedInstance;
       if (previous && previous !== this) {
+        previous._isFocused = false;
         previous.removeAttribute('focused');
       }
+      // `_isFocused` drives `.uc-inner[data-focused]` (the actual focus style);
+      // the host `[focused]` attribute is kept for compat. Both must be set —
+      // setting only the attribute left the visible highlight dead.
+      this._isFocused = true;
       this.setAttribute('focused', '');
       FileItem._focusedInstance = this;
     };

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -1,16 +1,13 @@
 import { html, type PropertyValues } from 'lit';
 import { property, state } from 'lit/decorators.js';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
-import { LocaleController } from '../../abstract/controllers/LocaleController';
 import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
 import { inject, injectOrNull } from '../../abstract/di/inject';
 import { PluginController, type PluginFileActionRegistration } from '../../abstract/managers/plugin';
 import type { Owned } from '../../abstract/managers/plugin/PluginTypes';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
-import type { UploadEntryKeys, UploadEntryTypedData } from '../../abstract/uploadEntrySchema';
-import { debounce } from '../../utils/debounce';
-import { throttle } from '../../utils/throttle';
+import type { UploadEntryData, UploadEntryKeys } from '../../abstract/uploadEntrySchema';
 import { canonicalSourceName, ExternalUploadSource } from '../../utils/UploadSource';
 import './file-item.css';
 import { effect } from '../../lit/effect';
@@ -35,20 +32,18 @@ const FileItemState = Object.freeze({
 
 type FileItemStateValue = (typeof FileItemState)[keyof typeof FileItemState];
 
-// Entry keys whose change re-derives the item state machine (`_calculateState`).
-// `externalUrl` is intentionally absent — it only affects the display name.
-const STATE_RECOMPUTE_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
+// Entry keys the state-machine verdict (`_deriveState`) reads. A change to one of
+// these is the only trigger for the imperative focus-clear side-effect
+// (`_syncUploadingFocus`); everything else the state feeds — badge, flags, hint,
+// progress, aria, name — is a pure `getTracked` read in `render()` (S2), so Lit
+// re-renders those on the exact keys read with no imperative mirror.
+const STATE_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
+  'errors',
+  'isQueuedForUploading',
   'isQueuedForValidation',
   'isValidationPending',
-  'uploadProgress',
-  'isQueuedForUploading',
-  'fileName',
-  'fileInfo',
-  'errors',
   'isUploading',
-  'fileSize',
-  'mimeType',
-  'isImage',
+  'fileInfo',
 ]);
 // Entry keys whose change re-evaluates plugin file actions.
 const PLUGIN_ACTION_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>([
@@ -56,8 +51,6 @@ const PLUGIN_ACTION_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys
   'isUploading',
   'errors',
 ]);
-// Entry keys that feed the displayed item name.
-const NAME_KEYS: ReadonlySet<UploadEntryKeys> = new Set<UploadEntryKeys>(['fileName', 'externalUrl']);
 
 export class FileItem extends FileItemConfig {
   // `ConfigController`/`TelemetryManager` are always-bound `@inject` fields.
@@ -78,38 +71,10 @@ export class FileItem extends FileItemConfig {
   })
   public uid: Uid = '' as Uid;
 
-  @state()
-  private _itemName = '';
-
-  @state()
-  private _errorText = '';
-
-  @state()
-  private _hint = '';
-
-  @state()
-  private _progressValue = 0;
-
-  @state()
-  private _badgeIcon = '';
-
-  @state()
-  private _isFinished = false;
-
-  @state()
-  private _isFailed = false;
-
-  @state()
-  private _isUploading = false;
-
-  @state()
-  private _hideRemoveAction = false;
-
+  // UI focus flag (drives `[data-focused]`). Not entry-derived — set by the click
+  // handler and cleared imperatively when the entry starts uploading.
   @state()
   private _isFocused = false;
-
-  @state()
-  private _ariaLabelStatusFile = '';
 
   @state()
   private _pluginFileActions: Owned<PluginFileActionRegistration>[] = [];
@@ -138,92 +103,43 @@ export class FileItem extends FileItemConfig {
     }
   };
 
-  private _calculateState(): void {
+  // Single source of truth for the state-machine verdict. `read` is `getTracked`
+  // in `render()` (so `SignalWatcher` re-renders on the exact keys read) and the
+  // plain `get` in the imperative focus-sync path (no tracking off the render).
+  private _deriveState(read: <K extends UploadEntryKeys>(key: K) => UploadEntryData[K]): FileItemStateValue {
+    if (read('errors').length > 0) {
+      return FileItemState.FAILED;
+    }
+    if (read('isQueuedForUploading')) {
+      return FileItemState.QUEUED_UPLOADING;
+    }
+    if (read('isQueuedForValidation')) {
+      return FileItemState.QUEUED_VALIDATION;
+    }
+    if (read('isValidationPending')) {
+      return FileItemState.VALIDATION;
+    }
+    if (read('isUploading')) {
+      return FileItemState.UPLOADING;
+    }
+    if (read('fileInfo')) {
+      return FileItemState.FINISHED;
+    }
+    return FileItemState.IDLE;
+  }
+
+  // The one genuine side-effect the entry state drives that is NOT pure render:
+  // an item that starts uploading drops its focus. Reads imperatively (`get`), so
+  // it never tracks off a render pass.
+  private _syncUploadingFocus(): void {
     const entry = this.entry;
     if (!entry) {
       return;
     }
-
-    let state: FileItemStateValue = FileItemState.IDLE;
-
-    if (entry.get('errors').length > 0) {
-      state = FileItemState.FAILED;
-    } else if (entry.get('isQueuedForUploading')) {
-      state = FileItemState.QUEUED_UPLOADING;
-    } else if (entry.get('isQueuedForValidation')) {
-      state = FileItemState.QUEUED_VALIDATION;
-    } else if (entry.get('isValidationPending')) {
-      state = FileItemState.VALIDATION;
-    } else if (entry.get('isUploading')) {
-      state = FileItemState.UPLOADING;
-    } else if (entry.get('fileInfo')) {
-      state = FileItemState.FINISHED;
-    }
-
-    this._handleState(entry, state);
-  }
-
-  private _debouncedCalculateState = debounce(() => this._calculateState(), 100);
-
-  private _updateHintAndProgress = this.withEntry(
-    throttle((entry: UploadEntryTypedData, state?: FileItemStateValue) => {
-      // A trailing throttle tick can fire after the item unmounts / its container
-      // is released (an entry update that raced teardown). The `l10n` reads below
-      // resolve `LocaleController` off the container, which is gone by then —
-      // bail first via the null-tolerant `useOrNull`.
-      if (!this.useOrNull(LocaleController)) {
-        return;
-      }
-      const errorText = entry.get('errors')?.[0]?.message ?? '';
-      const source = entry.get('source');
-      const externalUrl = entry.get('externalUrl');
-      const isFinished = state === FileItemState.FINISHED;
-      const isQueuedForValidation = state === FileItemState.QUEUED_VALIDATION;
-      const isValidationPending = state === FileItemState.VALIDATION;
-      const fileName = entry.get('fileName');
-      let hint = '';
-
-      if (errorText) {
-        hint = '';
-      } else if (!isFinished && externalUrl && source && Object.values(ExternalUploadSource).includes(source)) {
-        hint = this.l10n('waiting-for', { source: this.l10n(`src-type-${canonicalSourceName(source)}`) });
-      }
-
-      this._hint = hint;
-      this._errorText = errorText;
-      this._progressValue = isQueuedForValidation || isValidationPending ? 0 : entry.get('uploadProgress');
-      this._ariaLabelStatusFile = fileName
-        ? this.l10n('a11y-file-item-status', {
-            fileName,
-            status: this.l10n(state?.description?.toLocaleLowerCase() ?? '').toLocaleLowerCase(),
-          })
-        : '';
-    }, 100),
-  );
-
-  private _handleState(_entry: UploadEntryTypedData, state: FileItemStateValue): void {
-    if (state === FileItemState.FAILED) {
-      this._badgeIcon = 'badge-error';
-    } else if (state === FileItemState.FINISHED) {
-      this._badgeIcon = 'badge-success';
-    }
-
-    if (state === FileItemState.UPLOADING) {
+    if (this._deriveState((key) => entry.get(key)) === FileItemState.UPLOADING) {
       this._isFocused = false;
       this.removeAttribute('focused');
     }
-
-    this._isFailed = state === FileItemState.FAILED;
-    this._isUploading = state === FileItemState.UPLOADING;
-    this._hideRemoveAction = state === FileItemState.QUEUED_UPLOADING || state === FileItemState.UPLOADING;
-    this._isFinished = state === FileItemState.FINISHED;
-
-    this._updateHintAndProgress(state);
-  }
-
-  protected override reset(): void {
-    super.reset();
-    this._debouncedCalculateState.cancel();
   }
 
   private _observerCallback(entries: IntersectionObserverEntry[]): void {
@@ -255,27 +171,23 @@ export class FileItem extends FileItemConfig {
       return;
     }
 
-    // Seed the display name (was the immediate fire of the fileName/externalUrl
-    // observers, which `subscribeKeys` doesn't replay).
-    this._itemName = entry.get('fileName') || entry.get('externalUrl') || this.l10n('file-no-name');
-
-    // ONE keyed subscription replaces the ~15 per-key `subEntry` observes (which
-    // included duplicate `fileInfo`/`isUploading`/`errors` watches). Dispatch by
-    // the changed key to the same effects: recompute the display name, re-derive
-    // the state machine (debounced), and re-evaluate plugin actions.
+    // ONE keyed subscription drives only the genuine side-effects that are NOT
+    // pure render: the focus-clear-on-uploading transition and the plugin
+    // file-action recompute. Everything the row *displays* (name, badge, flags,
+    // hint, progress, aria) is a `getTracked` read in `render()` (S2), so Lit
+    // re-renders on the exact entry keys it reads — no imperative mirror, no
+    // debounce.
     this.subEntryKeys((key) => {
-      if (NAME_KEYS.has(key)) {
-        this._itemName = entry.get('fileName') || entry.get('externalUrl') || this.l10n('file-no-name');
-      }
-      if (STATE_RECOMPUTE_KEYS.has(key)) {
-        this._debouncedCalculateState();
+      if (STATE_KEYS.has(key)) {
+        this._syncUploadingFocus();
       }
       if (PLUGIN_ACTION_KEYS.has(key)) {
         this._updatePluginFileActions();
       }
     });
 
-    this._calculateState();
+    // Seed the initial side-effects (subscribeKeys does not replay current state).
+    this._syncUploadingFocus();
     this._updatePluginFileActions();
   }
 
@@ -437,8 +349,8 @@ export class FileItem extends FileItemConfig {
 
   // The upload mechanics (queue, beforeUpload chain, progress/abort, error
   // handling) now live in the DOM-free UploadController. This block stays the
-  // trigger; it reacts to the resulting entry mutations through its existing
-  // per-entry subscriptions (`isUploading`/`errors`/… → `_debouncedCalculateState`).
+  // trigger; it reflects the resulting entry mutations through `getTracked` reads
+  // in `render()` (state/badge/progress/…) plus the keyed side-effect subscription.
   // The currently-focused item (single-focus model — see the click handler).
   private static _focusedInstance: FileItem | null = null;
 
@@ -450,20 +362,54 @@ export class FileItem extends FileItemConfig {
   }
 
   public override render() {
+    // Signals-native derivation (S2): read the entry through `getTracked`, so
+    // `SignalWatcher` re-renders the row on exactly the keys read — a progress
+    // tick repaints only the progress binding, not a full imperative recompute.
+    const { entry } = this;
+    const state = entry ? this._deriveState((key) => entry.getTracked(key)) : FileItemState.IDLE;
+
+    const isFinished = state === FileItemState.FINISHED;
+    const isFailed = state === FileItemState.FAILED;
+    const isUploading = state === FileItemState.UPLOADING;
+    const isValidating = state === FileItemState.QUEUED_VALIDATION || state === FileItemState.VALIDATION;
+    const hideRemoveAction = state === FileItemState.QUEUED_UPLOADING || isUploading;
+    const badgeIcon = isFailed ? 'badge-error' : isFinished ? 'badge-success' : '';
+
+    const errorText = entry?.getTracked('errors')?.[0]?.message ?? '';
+    const progressValue = entry && !isValidating ? entry.getTracked('uploadProgress') : 0;
+    const itemName = entry
+      ? entry.getTracked('fileName') || entry.getTracked('externalUrl') || this.l10n('file-no-name')
+      : '';
+
+    const source = entry?.getTracked('source') ?? null;
+    const externalUrl = entry?.getTracked('externalUrl') ?? null;
+    const hint =
+      !errorText && !isFinished && externalUrl && source && Object.values(ExternalUploadSource).includes(source)
+        ? this.l10n('waiting-for', { source: this.l10n(`src-type-${canonicalSourceName(source)}`) })
+        : '';
+
+    const fileName = entry?.getTracked('fileName') ?? null;
+    const ariaLabelStatusFile = fileName
+      ? this.l10n('a11y-file-item-status', {
+          fileName,
+          status: this.l10n(state.description?.toLocaleLowerCase() ?? '').toLocaleLowerCase(),
+        })
+      : '';
+
     return html`
       <div
         class="uc-inner"
-        ?data-finished=${this._isFinished}
-        ?data-uploading=${this._isUploading}
-        ?data-failed=${this._isFailed}
+        ?data-finished=${isFinished}
+        ?data-uploading=${isUploading}
+        ?data-failed=${isFailed}
         ?data-focused=${this._isFocused}
       >
-        <uc-thumb .uid=${this.uid} .badgeIcon=${this._badgeIcon}></uc-thumb>
+        <uc-thumb .uid=${this.uid} .badgeIcon=${badgeIcon}></uc-thumb>
 
-        <div aria-atomic="true" aria-live="polite" class="uc-file-name-wrapper" aria-label=${this._ariaLabelStatusFile}>
-          <span class="uc-file-name" ?hidden=${!this._showFileNames}>${this._itemName}</span>
-          <span class="uc-file-error" ?hidden=${!this._errorText}>${this._errorText}</span>
-          <span class="uc-file-hint" ?hidden=${!this._hint}>${this._hint}</span>
+        <div aria-atomic="true" aria-live="polite" class="uc-file-name-wrapper" aria-label=${ariaLabelStatusFile}>
+          <span class="uc-file-name" ?hidden=${!this._showFileNames}>${itemName}</span>
+          <span class="uc-file-error" ?hidden=${!errorText}>${errorText}</span>
+          <span class="uc-file-hint" ?hidden=${!hint}>${hint}</span>
         </div>
         <div class="uc-file-actions">
           ${this._pluginFileActions.map(
@@ -482,11 +428,11 @@ export class FileItem extends FileItemConfig {
           )}
           <uc-file-action-button
             @uc:remove=${this._handleRemove}
-            .uploading=${this._isUploading}
-            .hideRemove=${this._hideRemoveAction}
-            .progress=${this._progressValue}
-            .failed=${this._isFailed}
-            .success=${this._isFinished}
+            .uploading=${isUploading}
+            .hideRemove=${hideRemoveAction}
+            .progress=${progressValue}
+            .failed=${isFailed}
+            .success=${isFinished}
           ></uc-file-action-button>
         </div>
       </div>

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -42,6 +42,24 @@ export class FileItemConfig extends ChildBlock {
     })(prop, handler);
   }
 
+  /**
+   * Observe ALL of the entry's key changes through a SINGLE subscription (the
+   * entry's keyed-notify channel), dispatching by the changed key — instead of
+   * one `subEntry`/`observe` per key. `handler` runs on any changed key while
+   * connected; it reads current values off `entry` as needed. No initial fire
+   * (unlike `subEntry`'s `{immediate}`): the caller seeds initial state itself.
+   * This is the large-N win — 1 subscription per row instead of ~15.
+   */
+  protected subEntryKeys(handler: (key: UploadEntryKeys) => void): void {
+    this.withEntry((entry) => {
+      const sub = entry.subscribeKeys((key) => {
+        if (!this.isConnected) return;
+        handler(key);
+      });
+      this._entrySubs.add(sub);
+    })();
+  }
+
   protected reset(): void {
     for (const sub of this._entrySubs) {
       sub();

--- a/src/blocks/FileItem/FileItemConfig.ts
+++ b/src/blocks/FileItem/FileItemConfig.ts
@@ -53,6 +53,10 @@ export class FileItemConfig extends ChildBlock {
 
   public override disconnectedCallback(): void {
     super.disconnectedCallback();
-    this._entrySubs = new Set<EntrySubscription>();
+    // Unsubscribe on disconnect — the previous `= new Set()` dropped the
+    // subscription refs WITHOUT calling them, leaking `Listeners` callbacks that
+    // kept running `select()` on every later entry write until the entry's
+    // deferred destroy (~10s). `reset()` invokes each unsubscribe first.
+    this.reset();
   }
 }

--- a/src/blocks/FileItem/file-action-button.css
+++ b/src/blocks/FileItem/file-action-button.css
@@ -62,7 +62,19 @@
     height: 24px;
   }
 
-  :where([uc-file-action-button]) button.uc-uploading .uc-preloader {
+  :where([uc-file-action-button]) button:is(.uc-uploading, .uc-queued) .uc-preloader {
     opacity: 1;
+  }
+
+  /* Queued: indeterminate spinner — a fixed partial arc (set via
+     `--l-progress-offset` in the render) rotated continuously. */
+  :where([uc-file-action-button]) button.uc-queued .uc-preloader {
+    animation: uc-file-action-queued-spin 0.9s linear infinite;
+  }
+
+  @keyframes uc-file-action-queued-spin {
+    to {
+      transform: rotate(360deg);
+    }
   }
 }

--- a/src/blocks/FileItem/file-item.css
+++ b/src/blocks/FileItem/file-item.css
@@ -8,9 +8,9 @@
     min-height: var(--uc-file-item-height);
   }
 
-  uc-file-item:last-of-type {
-    --uc-file-item-gap: 0;
-  }
+  /* Every row keeps the same gap so the virtualizer's fixed rowHeight holds: the
+     last MOUNTED row is not the true last one under windowing, so a
+     `:last-of-type { gap: 0 }` would shrink a mid-list row and nudge alignment. */
 
   uc-file-item > .uc-inner {
     position: relative;

--- a/src/blocks/UploadList/UploadList.test.ts
+++ b/src/blocks/UploadList/UploadList.test.ts
@@ -7,6 +7,7 @@ import { UploadCollectionController } from '../../abstract/controllers/UploadCol
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
 import { UploaderRegistry } from '../../abstract/UploaderRegistry';
+import type { UploadEntryData } from '../../abstract/uploadEntrySchema';
 import { ensureUploaderCtx } from '../../lit/ensureUploaderCtx';
 import type { Uid } from '../../lit/Uid';
 import type { ConfigType, OutputCollectionState } from '../../types';
@@ -67,30 +68,22 @@ const makeFakeApi = (state: OutputCollectionState): { api: UploaderPublicApi; sp
   return { api: spies as unknown as UploaderPublicApi, spies };
 };
 
-const makeFakeCollection = (): { collection: UploadCollectionController; clearAll: ReturnType<typeof vi.fn> } => {
-  const clearAll = vi.fn();
-  const noop = () => () => {};
-  const collection = {
-    clearAll,
-    size: 0,
-    observeProperties: noop,
-    observeCollection: noop,
-    hasItem: () => false,
-  } as unknown as UploadCollectionController;
-  return { collection, clearAll };
-};
-
 const mount = async (
   ctxName: string,
-  opts: { state?: Partial<OutputCollectionState>; config?: Partial<ConfigType> } = {},
+  opts: {
+    entries?: Partial<UploadEntryData>[];
+    collectionErrors?: { type: string; message: string }[];
+    config?: Partial<ConfigType>;
+  } = {},
 ): Promise<{
   el: UploadList;
   config: ConfigController;
   collectionState: CollectionStateController;
+  collection: UploadCollectionController;
   router: RouterController;
   telemetry: TelemetryManager;
   spies: ApiSpies;
-  clearAll: ReturnType<typeof vi.fn>;
+  clearAll: ReturnType<typeof vi.spyOn>;
 }> => {
   ensureUploaderCtx(ctxName);
   const container = UploaderRegistry.get(ctxName);
@@ -98,24 +91,35 @@ const mount = async (
   const collectionState = container?.get(CollectionStateController);
   const router = container?.get(RouterController);
   const telemetry = container?.get(TelemetryManager);
-  if (!container || !config || !collectionState || !router || !telemetry) throw new Error('controllers not resolved');
+  // The toolbar summary is a raw single-pass count over the REAL collection now,
+  // so use the real controller + real entries (not a fake) to drive it.
+  const collection = container?.get(UploadCollectionController);
+  if (!container || !config || !collectionState || !router || !telemetry || !collection) {
+    throw new Error('controllers not resolved');
+  }
   // Config must be applied before the element adopts (the leading throttled tick
   // in `controllerReady` reads it), so set it up front.
   for (const [k, v] of Object.entries(opts.config ?? {})) {
     config.set(k as keyof ConfigType, v as ConfigType[keyof ConfigType]);
   }
-  const { api, spies } = makeFakeApi(zeroCollectionState(opts.state));
-  const { collection, clearAll } = makeFakeCollection();
-  // Bind the fakes on the container (the block reads them via `use()`).
+  for (const init of opts.entries ?? []) {
+    collection.add(init);
+  }
+  if (opts.collectionErrors) {
+    collectionState.set('collectionErrors', opts.collectionErrors as never);
+  }
+  // Fake api only for the action methods (`uploadAll`/`initFlow`/`doneFlow`) and
+  // the `_handleDone` DONE_CLICK payload — `_updateUploadsState` no longer reads it.
+  const { api, spies } = makeFakeApi(zeroCollectionState());
   container.bind(UploaderPublicApi, () => api);
-  container.bind(UploadCollectionController, () => collection);
+  const clearAll = vi.spyOn(collection, 'clearAll');
   const el = document.createElement('uc-upload-list') as UploadList;
   el.setAttribute('ctx-name', ctxName);
   document.body.append(el);
   mounted.push(el);
   await el.updateComplete;
   await delay(0);
-  return { el, config, collectionState, router, telemetry, spies, clearAll };
+  return { el, config, collectionState, collection, router, telemetry, spies, clearAll };
 };
 
 afterEach(() => {
@@ -243,7 +247,7 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
     const ctxName = freshCtxName();
     const { el, spies } = await mount(ctxName, {
       config: { confirmUpload: true },
-      state: { totalCount: 2 },
+      entries: [{}, {}], // two idle entries, ready to upload
     });
 
     const uploadBtn = el.querySelector<HTMLButtonElement>('button.uc-upload-btn');
@@ -262,7 +266,7 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
   it('enables the done button for a fully-succeeded collection and calls doneFlow on click', async () => {
     const ctxName = freshCtxName();
     const { el, spies } = await mount(ctxName, {
-      state: { totalCount: 1, successCount: 1 },
+      entries: [{ fileInfo: { uuid: 'srv' } as never }], // one succeeded entry
     });
 
     const doneBtn = el.querySelector<HTMLButtonElement>('button.uc-done-btn');
@@ -274,14 +278,33 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
     expect(spies.doneFlow).toHaveBeenCalledOnce();
   });
 
-  it.each([
-    ['uploading', { totalCount: 1, uploadingCount: 1 }],
-    ['failed', { totalCount: 1, failedCount: 1 }],
-    ['succeed', { totalCount: 1, successCount: 1 }],
-    ['total', { totalCount: 1 }],
-  ] as const)('derives a non-empty localized header for the %s state', async (_label, state) => {
+  it('an idle entry pending validation blocks upload/done and reads as "uploading" in the header', async () => {
     const ctxName = freshCtxName();
-    const { el } = await mount(ctxName, { state });
+    const { el } = await mount(ctxName, {
+      config: { confirmUpload: true },
+      entries: [{ isValidationPending: true }], // idle + validation pending
+    });
+
+    // validatingBeforeUploading=1 (idle+validation) and anyValidationPending=true,
+    // so validationOk is false → no upload button, done disabled.
+    expect(el.querySelector<HTMLButtonElement>('button.uc-upload-btn')?.hasAttribute('hidden')).toBe(true);
+    const doneBtn = el.querySelector<HTMLButtonElement>('button.uc-done-btn');
+    expect(doneBtn?.hasAttribute('disabled')).toBe(true);
+    // The header folds validating-before-uploading into the "uploading" line.
+    expect(el.querySelector('.uc-header-text')?.textContent?.trim()).not.toBe('');
+  });
+
+  it.each([
+    ['uploading', [{ isUploading: true }]],
+    ['failed', [{ errors: [{ type: 'x', message: 'boom' } as never] }]],
+    ['succeed', [{ fileInfo: { uuid: 'srv' } as never }]],
+    ['total', [{}]],
+  ] as [
+    string,
+    Partial<UploadEntryData>[],
+  ][])('derives a non-empty localized header for the %s state', async (_label, entries) => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName, { entries });
     expect(el.querySelector('.uc-header-text')?.textContent?.trim()).not.toBe('');
   });
 
@@ -289,7 +312,7 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
     const ctxName = freshCtxName();
     const { el, router, collectionState } = await mount(ctxName);
 
-    // Guard predicate: empty collection (fake size 0) + default showEmptyList=false
+    // Guard predicate: empty collection (real size 0) + default showEmptyList=false
     // -> the router refuses to make upload-list the active activity.
     router.setActivity('upload-list');
     expect(router.activity).not.toBe('upload-list');

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -14,6 +14,7 @@ import { subscription, type Unsubscribe } from '../../lit/subscription';
 import { EventType, InternalEventType } from '../UploadCtxProvider/EventEmitter';
 import './upload-list.css';
 import { repeat } from 'lit/directives/repeat.js';
+import { VirtualListController } from '../../lit/VirtualListController';
 
 import '../ActivityHeader/ActivityHeader';
 import '../Icon/Icon';
@@ -67,6 +68,30 @@ export class UploadList extends ActivityChildBlock {
 
   @state()
   private _latestSummary: Summary | null = null;
+
+  // List virtualization: only ~viewport±overscan `<uc-file-item>` render at large
+  // file counts. The shared controller measures the `.uc-files` scroll container
+  // and turns `uploadList` into the visible slice + spacer heights; row metrics
+  // are app-specific (list = 1 col, grid = `--uc-grid-col` cols + inter-row gap),
+  // so this block supplies them. It degrades to rendering the full list whenever
+  // the container isn't laid out (happy-dom, hidden panel, pre-measurement paint).
+  private readonly _virtualList = new VirtualListController(this, {
+    scrollContainer: () => this.querySelector<HTMLElement>('.uc-files'),
+    itemSelector: 'uc-file-item',
+    rowMetrics: (scrollEl, firstItem) => {
+      if (this._config.get('filesViewMode') !== 'grid') {
+        return { columns: 1, rowHeight: firstItem.offsetHeight };
+      }
+      const gridCol = Number.parseInt(getComputedStyle(this).getPropertyValue('--uc-grid-col'), 10);
+      // Flex `gap` sits BETWEEN grid cells (not in offsetHeight), so one grid row
+      // is a cell plus one inter-row gap; list rows fold the gap into their box.
+      const rowGap = Number.parseFloat(getComputedStyle(scrollEl).rowGap) || 0;
+      return {
+        columns: Number.isFinite(gridCol) && gridCol >= 1 ? gridCol : 1,
+        rowHeight: firstItem.offsetHeight + rowGap,
+      };
+    },
+  });
 
   private get _headerText() {
     if (!this._latestSummary) {
@@ -296,6 +321,16 @@ export class UploadList extends ActivityChildBlock {
     this.setAttribute('mode', this._config.getTracked('filesViewMode'));
   }
 
+  // A list⇆grid view-mode switch changes row height + column count but need not
+  // resize the scroll container (so the ResizeObserver may not fire), so drop the
+  // virtualizer's latched row metrics on the change to force a re-measure.
+  // `observe` dedups per key and fires only on an actual change — no prev-value
+  // bookkeeping.
+  @subscription()
+  protected _invalidateVirtualListOnViewMode(): Unsubscribe {
+    return this._config.observe('filesViewMode', () => this._virtualList.invalidate());
+  }
+
   public override render() {
     // Tracked render reads: `uploadList` drives the `<uc-file-item>` list and
     // `collectionErrors` (via `_commonErrorMessage`) drives the common-error row —
@@ -303,6 +338,11 @@ export class UploadList extends ActivityChildBlock {
     // `SignalWatcher`, so a collection change re-renders with no `ctx.sub`.
     const uploadList = this._collectionState.getTracked('uploadList');
     const commonErrorMessage = this._commonErrorMessage;
+
+    // Render only the visible window (+ overscan) with top/bottom spacers holding
+    // the scroll height. Unmeasured geometry → full list, no spacers (unchanged).
+    const view = this._virtualList.window(uploadList);
+    const windowItems = view.items;
     return html`
   <uc-activity-header>
     <span aria-live="polite" class="uc-header-text">${this._headerText}</span>
@@ -323,11 +363,13 @@ export class UploadList extends ActivityChildBlock {
 
   <div class="uc-files">
     <div class="uc-files-wrapper">
+    ${view.topPad > 0 ? html`<div class="uc-list-spacer" style="height:${view.topPad}px"></div>` : ''}
     ${repeat(
-      uploadList,
+      windowItems,
       ({ uid }) => uid,
       ({ uid }) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
     )}
+    ${view.bottomPad > 0 ? html`<div class="uc-list-spacer" style="height:${view.bottomPad}px"></div>` : ''}
     </div>
     <button
       type="button"

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -4,6 +4,7 @@ import { CollectionStateController } from '../../abstract/controllers/Collection
 import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { RouterController } from '../../abstract/controllers/RouterController';
 import { UploadCollectionController } from '../../abstract/controllers/UploadCollectionController';
+import { deriveEntryStatus } from '../../abstract/deriveEntryStatus';
 import { inject } from '../../abstract/di/inject';
 import { TelemetryManager } from '../../abstract/managers/TelemetryManager';
 import { UploaderPublicApi } from '../../abstract/UploaderPublicApi';
@@ -170,6 +171,52 @@ export class UploadList extends ActivityChildBlock {
     }
   }
 
+  // Cheap toolbar summary: ONE pass over the raw collection entries computing
+  // status counts, instead of `getOutputCollectionState()` which builds a full
+  // `OutputFileEntry` object per entry (O(N) allocation) just for these numbers.
+  // Status precedence is single-sourced with `getOutputItem` via
+  // `deriveEntryStatus`. `anyValidationPending` mirrors the old
+  // `allEntries.some(isValidationPending)` (ANY entry), while
+  // `validatingBeforeUploading` counts only IDLE entries pending validation.
+  private _computeSummary(): Summary & { anyValidationPending: boolean } {
+    const collection = this._uploadCollection;
+    let succeed = 0;
+    let uploading = 0;
+    let failed = 0;
+    let validatingBeforeUploading = 0;
+    let anyValidationPending = false;
+
+    for (const id of collection.items()) {
+      const entry = collection.read(id);
+      if (!entry) {
+        continue;
+      }
+      const fields = entry.values;
+      if (fields.isValidationPending) {
+        anyValidationPending = true;
+      }
+      switch (deriveEntryStatus(fields)) {
+        case 'failed':
+          failed++;
+          break;
+        case 'success':
+          succeed++;
+          break;
+        case 'uploading':
+          uploading++;
+          break;
+        case 'idle':
+          if (fields.isValidationPending) {
+            validatingBeforeUploading++;
+          }
+          break;
+        // 'removed' entries are not counted.
+      }
+    }
+
+    return { total: collection.size, succeed, uploading, failed, validatingBeforeUploading, anyValidationPending };
+  }
+
   private _updateUploadsState(): void {
     // Imperative derived-state recompute (writes the toolbar/button `@state`
     // below), not a render read — runs only from the throttled tick after its
@@ -177,22 +224,24 @@ export class UploadList extends ActivityChildBlock {
     // Config reads use the untracked `get()` (a re-render is driven by the
     // throttled tick's config-`observe`/collection observers, not by tracking here).
     const config = this._config;
-    const collectionState = this._api.getOutputCollectionState();
-    const summary: Summary = {
-      total: collectionState.totalCount,
-      succeed: collectionState.successCount,
-      uploading: collectionState.uploadingCount,
-      failed: collectionState.failedCount,
-      validatingBeforeUploading: collectionState.idleEntries.filter((e) => e.isValidationPending).length,
-    };
-    const fitCountRestrictions = !collectionState.errors.some(
-      (err) => err.type === 'TOO_MANY_FILES' || err.type === 'TOO_FEW_FILES',
-    );
-    const tooMany = collectionState.errors.some((err) => err.type === 'TOO_MANY_FILES');
+    const { anyValidationPending, ...summary } = this._computeSummary();
+    const errors = this._collectionState.get('collectionErrors');
+
+    // One pass over the (tiny) collection-error list instead of two `.some()` scans.
+    let tooMany = false;
+    let fitCountRestrictions = true;
+    for (const err of errors) {
+      if (err.type === 'TOO_MANY_FILES') {
+        tooMany = true;
+        fitCountRestrictions = false;
+      } else if (err.type === 'TOO_FEW_FILES') {
+        fitCountRestrictions = false;
+      }
+    }
+
     const multiple = config.get('multiple');
-    const exact = collectionState.totalCount === (multiple ? config.get('multipleMax') : 1);
-    const isValidationPending = collectionState.allEntries.some((entry) => entry.isValidationPending);
-    const validationOk = summary.failed === 0 && collectionState.errors.length === 0 && !isValidationPending;
+    const exact = summary.total === (multiple ? config.get('multipleMax') : 1);
+    const validationOk = summary.failed === 0 && errors.length === 0 && !anyValidationPending;
     let uploadBtnVisible = false;
     let allDone = false;
     let doneBtnEnabled = false;
@@ -202,7 +251,7 @@ export class UploadList extends ActivityChildBlock {
       uploadBtnVisible = true;
     } else {
       allDone = true;
-      const groupOk = config.get('groupOutput') ? !!collectionState.group : true;
+      const groupOk = config.get('groupOutput') ? !!this._collectionState.get('groupInfo') : true;
       doneBtnEnabled = summary.total === summary.succeed && fitCountRestrictions && validationOk && groupOk;
     }
 
@@ -213,7 +262,20 @@ export class UploadList extends ActivityChildBlock {
     this._addMoreBtnVisible = !exact || multiple;
     this._hasFiles = summary.total > 0;
 
-    this._latestSummary = summary;
+    // Only replace the summary object when a count actually changed — a fresh
+    // object every tick would dirty `@state` and force a re-render even when the
+    // toolbar text is identical (the other fields above are primitives Lit dedups).
+    const prev = this._latestSummary;
+    if (
+      !prev ||
+      prev.total !== summary.total ||
+      prev.succeed !== summary.succeed ||
+      prev.uploading !== summary.uploading ||
+      prev.failed !== summary.failed ||
+      prev.validatingBeforeUploading !== summary.validatingBeforeUploading
+    ) {
+      this._latestSummary = summary;
+    }
   }
 
   private _getHeaderText(summary: Summary): string {

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -81,18 +81,26 @@ export class UploadList extends ActivityChildBlock {
     itemSelector: 'uc-file-item',
     rowMetrics: (scrollEl, firstItem) => {
       if (this._config.get('filesViewMode') !== 'grid') {
+        this._rowGap = 0;
         return { columns: 1, rowHeight: firstItem.offsetHeight };
       }
       const gridCol = Number.parseInt(getComputedStyle(this).getPropertyValue('--uc-grid-col'), 10);
       // Flex `gap` sits BETWEEN grid cells (not in offsetHeight), so one grid row
       // is a cell plus one inter-row gap; list rows fold the gap into their box.
       const rowGap = Number.parseFloat(getComputedStyle(scrollEl).rowGap) || 0;
+      this._rowGap = rowGap;
       return {
         columns: Number.isFinite(gridCol) && gridCol >= 1 ? gridCol : 1,
         rowHeight: firstItem.offsetHeight + rowGap,
       };
     },
   });
+
+  // The measured inter-row flex gap (grid mode; 0 in list mode). A spacer is
+  // itself a flex line, so the browser inserts one extra `gap` between it and the
+  // adjacent item row — subtract it from the spacer height so the visible window
+  // isn't pushed down/up by one gap.
+  private _rowGap = 0;
 
   private get _headerText() {
     if (!this._latestSummary) {
@@ -405,6 +413,12 @@ export class UploadList extends ActivityChildBlock {
     // the scroll height. Unmeasured geometry → full list, no spacers (unchanged).
     const view = this._virtualList.window(uploadList);
     const windowItems = view.items;
+    // A spacer occupies its own flex line, so the flex `gap` adds one extra gap
+    // between it and the adjacent row — shrink the spacer by that gap so the
+    // rendered window lands where the scroll position expects (grid mode; `_rowGap`
+    // is 0 in list mode, where the gap is folded into each row's own box).
+    const topSpacer = view.topPad > 0 ? Math.max(0, view.topPad - this._rowGap) : 0;
+    const bottomSpacer = view.bottomPad > 0 ? Math.max(0, view.bottomPad - this._rowGap) : 0;
     return html`
   <uc-activity-header>
     <span aria-live="polite" class="uc-header-text">${this._headerText}</span>
@@ -425,13 +439,13 @@ export class UploadList extends ActivityChildBlock {
 
   <div class="uc-files">
     <div class="uc-files-wrapper">
-    ${view.topPad > 0 ? html`<div class="uc-list-spacer" style="height:${view.topPad}px"></div>` : ''}
+    ${topSpacer > 0 ? html`<div class="uc-list-spacer" style="height:${topSpacer}px"></div>` : ''}
     ${repeat(
       windowItems,
       ({ uid }) => uid,
       ({ uid }) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
     )}
-    ${view.bottomPad > 0 ? html`<div class="uc-list-spacer" style="height:${view.bottomPad}px"></div>` : ''}
+    ${bottomSpacer > 0 ? html`<div class="uc-list-spacer" style="height:${bottomSpacer}px"></div>` : ''}
     </div>
     <button
       type="button"

--- a/src/blocks/UploadList/upload-list.css
+++ b/src/blocks/UploadList/upload-list.css
@@ -27,6 +27,15 @@
     display: contents;
   }
 
+  /* Virtualization spacers: hold the scroll height for the rows outside the
+     rendered window. Full-width so they force clean row breaks in the flex-wrap
+     grid (and stack as plain blocks in list mode); inert to pointer/a11y. */
+  uc-upload-list .uc-list-spacer {
+    flex: 0 0 100%;
+    width: 100%;
+    pointer-events: none;
+  }
+
   uc-upload-list .uc-toolbar {
     display: flex;
     gap: 4px;

--- a/src/lit/VirtualListController.test.ts
+++ b/src/lit/VirtualListController.test.ts
@@ -1,0 +1,239 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { VirtualListController } from './VirtualListController';
+
+class FakeHost implements ReactiveControllerHost {
+  public readonly controllers: ReactiveController[] = [];
+  public updateCount = 0;
+  public addController(controller: ReactiveController): void {
+    this.controllers.push(controller);
+  }
+  public removeController(): void {}
+  public requestUpdate(): void {
+    this.updateCount++;
+  }
+  public get updateComplete(): Promise<boolean> {
+    return Promise.resolve(true);
+  }
+}
+
+type FakeScrollEl = HTMLElement & { _fire: (type: string) => void; scrollTop: number; clientHeight: number };
+
+const makeScrollEl = (opts: { clientHeight: number; itemHeight: number; hasItem?: boolean }): FakeScrollEl => {
+  const listeners: Record<string, Array<() => void>> = {};
+  const el = {
+    clientHeight: opts.clientHeight,
+    scrollTop: 0,
+    addEventListener: (type: string, fn: () => void) => {
+      const bucket = listeners[type];
+      if (bucket) {
+        bucket.push(fn);
+      } else {
+        listeners[type] = [fn];
+      }
+    },
+    removeEventListener: (type: string, fn: () => void) => {
+      listeners[type] = (listeners[type] ?? []).filter((l) => l !== fn);
+    },
+    querySelector: () => (opts.hasItem === false ? null : ({ offsetHeight: opts.itemHeight } as HTMLElement)),
+    _fire: (type: string) => {
+      for (const l of listeners[type] ?? []) l();
+    },
+  };
+  return el as unknown as FakeScrollEl;
+};
+
+let disconnectSpy: ReturnType<typeof vi.fn<() => void>>;
+
+beforeEach(() => {
+  disconnectSpy = vi.fn<() => void>();
+  vi.stubGlobal(
+    'ResizeObserver',
+    class {
+      public observe(): void {}
+      public unobserve(): void {}
+      public disconnect(): void {
+        disconnectSpy();
+      }
+    },
+  );
+  // Run rAF synchronously so scroll handling is testable without a real frame.
+  vi.stubGlobal('requestAnimationFrame', (cb: FrameRequestCallback) => {
+    cb(0);
+    return 1;
+  });
+  vi.stubGlobal('cancelAnimationFrame', () => {});
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+const listOf = (n: number): readonly { id: number }[] => Array.from({ length: n }, (_, i) => ({ id: i }));
+
+describe('VirtualListController', () => {
+  it('registers itself on the host', () => {
+    const host = new FakeHost();
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => null,
+      itemSelector: 'x',
+      rowMetrics: () => ({ columns: 1, rowHeight: 0 }),
+    });
+    expect(host.controllers).toContain(controller);
+  });
+
+  it('renders the FULL list with no spacers before any measurement', () => {
+    const host = new FakeHost();
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => null,
+      itemSelector: 'x',
+      rowMetrics: () => ({ columns: 1, rowHeight: 40 }),
+    });
+    const items = listOf(100);
+    expect(controller.window(items)).toEqual({ items, topPad: 0, bottomPad: 0 });
+  });
+
+  it('renders the full list when the scroll container is never found', () => {
+    const host = new FakeHost();
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => null,
+      itemSelector: 'x',
+      rowMetrics: () => ({ columns: 1, rowHeight: 40 }),
+    });
+    controller.hostUpdated();
+    const items = listOf(50);
+    expect(controller.window(items).items).toHaveLength(50);
+  });
+
+  it('windows to the visible slice + spacers once measured', () => {
+    const host = new FakeHost();
+    const scrollEl = makeScrollEl({ clientHeight: 200, itemHeight: 40 });
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, firstItem) => ({ columns: 1, rowHeight: firstItem.offsetHeight }),
+      overscanRows: 0,
+    });
+
+    controller.hostUpdated(); // measure: viewport 200, rowHeight 40, columns 1
+    expect(host.updateCount).toBeGreaterThan(0);
+
+    const slice = controller.window(listOf(100));
+    expect(slice.items).toHaveLength(5); // ceil(200/40)
+    expect(slice.topPad).toBe(0);
+    expect(slice.bottomPad).toBe(95 * 40);
+  });
+
+  it('re-windows on scroll (rAF-coalesced) and requests a host update', () => {
+    const host = new FakeHost();
+    const scrollEl = makeScrollEl({ clientHeight: 200, itemHeight: 40 });
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, firstItem) => ({ columns: 1, rowHeight: firstItem.offsetHeight }),
+      overscanRows: 0,
+    });
+    controller.hostUpdated();
+
+    scrollEl.scrollTop = 400;
+    const before = host.updateCount;
+    scrollEl._fire('scroll');
+    expect(host.updateCount).toBe(before + 1);
+
+    const slice = controller.window(listOf(100));
+    // scrollTop 400 / 40 = row 10 → window [10, 15).
+    expect(slice.items).toEqual(listOf(100).slice(10, 15));
+    expect(slice.topPad).toBe(10 * 40);
+  });
+
+  it('folds columns for a grid: whole rows of N per window row', () => {
+    const host = new FakeHost();
+    const scrollEl = makeScrollEl({ clientHeight: 240, itemHeight: 100 });
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      // grid: 3 columns, +20px inter-row gap → rowHeight 120.
+      rowMetrics: (_el, firstItem) => ({ columns: 3, rowHeight: firstItem.offsetHeight + 20 }),
+      overscanRows: 0,
+    });
+    controller.hostUpdated();
+
+    const slice = controller.window(listOf(100));
+    // ceil(240/120) = 2 rows × 3 cols = 6 items.
+    expect(slice.items).toHaveLength(6);
+  });
+
+  it('latches row metrics: a later differently-sized first row does not re-window or loop (regression: scroll hang)', () => {
+    const host = new FakeHost();
+    // A mutable first item — simulates the window shifting to a taller/empty row.
+    const firstItem = { offsetHeight: 40 };
+    const scrollEl = {
+      clientHeight: 200,
+      scrollTop: 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      querySelector: () => firstItem as unknown as HTMLElement,
+    } as unknown as HTMLElement;
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, item) => ({ columns: 1, rowHeight: item.offsetHeight }),
+      overscanRows: 0,
+    });
+
+    controller.hostUpdated(); // measure rowHeight 40 → 200/40 = 5 rows
+    expect(controller.window(listOf(100)).items).toHaveLength(5);
+    const settledCount = host.updateCount;
+
+    // The measured "first item" is now a different, taller row (variable heights).
+    firstItem.offsetHeight = 80;
+    controller.hostUpdated();
+
+    // Latched: still 40 → 5 rows, and NO further update scheduled (converged — the
+    // scroll-hang loop was rowHeight oscillating between renders).
+    expect(controller.window(listOf(100)).items).toHaveLength(5);
+    expect(host.updateCount).toBe(settledCount);
+  });
+
+  it('re-measures row metrics after invalidate() (mode change / resize)', () => {
+    const host = new FakeHost();
+    const firstItem = { offsetHeight: 40 };
+    const scrollEl = {
+      clientHeight: 240,
+      scrollTop: 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      querySelector: () => firstItem as unknown as HTMLElement,
+    } as unknown as HTMLElement;
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, item) => ({ columns: 1, rowHeight: item.offsetHeight }),
+      overscanRows: 0,
+    });
+    controller.hostUpdated();
+    expect(controller.window(listOf(100)).items).toHaveLength(6); // 240/40
+
+    // Layout changed (e.g. list → grid): invalidate, then the next measure re-reads.
+    firstItem.offsetHeight = 120;
+    controller.invalidate();
+    controller.hostUpdated();
+    expect(controller.window(listOf(100)).items).toHaveLength(2); // 240/120
+  });
+
+  it('tears down the scroll listener + observer on host disconnect', () => {
+    const host = new FakeHost();
+    const scrollEl = makeScrollEl({ clientHeight: 200, itemHeight: 40 });
+    const removeSpy = vi.spyOn(scrollEl, 'removeEventListener');
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, firstItem) => ({ columns: 1, rowHeight: firstItem.offsetHeight }),
+    });
+    controller.hostUpdated(); // attaches listener + observer
+
+    controller.hostDisconnected();
+    expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    expect(disconnectSpy).toHaveBeenCalled();
+  });
+});

--- a/src/lit/VirtualListController.test.ts
+++ b/src/lit/VirtualListController.test.ts
@@ -44,12 +44,21 @@ const makeScrollEl = (opts: { clientHeight: number; itemHeight: number; hasItem?
 };
 
 let disconnectSpy: ReturnType<typeof vi.fn<() => void>>;
+// Last-created observer's callback, so a test can simulate a resize.
+let roCallback: ResizeObserverCallback | null = null;
+const fireResize = (height: number): void => {
+  roCallback?.([{ contentRect: { height } } as ResizeObserverEntry], {} as ResizeObserver);
+};
 
 beforeEach(() => {
   disconnectSpy = vi.fn<() => void>();
+  roCallback = null;
   vi.stubGlobal(
     'ResizeObserver',
     class {
+      public constructor(cb: ResizeObserverCallback) {
+        roCallback = cb;
+      }
       public observe(): void {}
       public unobserve(): void {}
       public disconnect(): void {
@@ -193,6 +202,30 @@ describe('VirtualListController', () => {
     // scroll-hang loop was rowHeight oscillating between renders).
     expect(controller.window(listOf(100)).items).toHaveLength(5);
     expect(host.updateCount).toBe(settledCount);
+  });
+
+  it('tracks viewport height via the ResizeObserver (not a per-render layout read)', () => {
+    const host = new FakeHost();
+    const firstItem = { offsetHeight: 40 };
+    const scrollEl = {
+      clientHeight: 200,
+      scrollTop: 0,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      querySelector: () => firstItem as unknown as HTMLElement,
+    } as unknown as HTMLElement;
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, item) => ({ columns: 1, rowHeight: item.offsetHeight }),
+      overscanRows: 0,
+    });
+    controller.hostUpdated(); // seeds viewport 200 on attach, latches rowHeight 40
+    expect(controller.window(listOf(100)).items).toHaveLength(5); // 200/40
+
+    // A resize is delivered through the observer, not a render-time clientHeight read.
+    fireResize(400);
+    expect(controller.window(listOf(100)).items).toHaveLength(10); // 400/40
   });
 
   it('re-measures row metrics after invalidate() (mode change / resize)', () => {

--- a/src/lit/VirtualListController.test.ts
+++ b/src/lit/VirtualListController.test.ts
@@ -228,6 +228,43 @@ describe('VirtualListController', () => {
     expect(controller.window(listOf(100)).items).toHaveLength(10); // 400/40
   });
 
+  it('seeds scrollTop from the container on attach (reconnect to an already-scrolled list)', () => {
+    const host = new FakeHost();
+    const firstItem = { offsetHeight: 40 };
+    const scrollEl = {
+      clientHeight: 200,
+      scrollTop: 400, // already scrolled before the controller attaches
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      querySelector: () => firstItem as unknown as HTMLElement,
+    } as unknown as HTMLElement;
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, item) => ({ columns: 1, rowHeight: item.offsetHeight }),
+      overscanRows: 0,
+    });
+
+    controller.hostUpdated(); // attach seeds scrollTop 400 (no scroll event fired)
+    // 400 / 40 = row 10 → topPad reflects the 10 skipped rows without a scroll event.
+    expect(controller.window(listOf(100)).topPad).toBe(10 * 40);
+  });
+
+  it('clamps a negative overscanRows to 0', () => {
+    const host = new FakeHost();
+    const scrollEl = makeScrollEl({ clientHeight: 200, itemHeight: 40 });
+    const controller = new VirtualListController(host, {
+      scrollContainer: () => scrollEl,
+      itemSelector: 'x',
+      rowMetrics: (_el, item) => ({ columns: 1, rowHeight: item.offsetHeight }),
+      overscanRows: -5,
+    });
+    controller.hostUpdated();
+    const slice = controller.window(listOf(100));
+    expect(slice.topPad).toBe(0); // starts at the top
+    expect(slice.items).toHaveLength(5); // ceil(200/40), no negative overscan blowup
+  });
+
   it('re-measures row metrics after invalidate() (mode change / resize)', () => {
     const host = new FakeHost();
     const firstItem = { offsetHeight: 40 };

--- a/src/lit/VirtualListController.ts
+++ b/src/lit/VirtualListController.ts
@@ -80,7 +80,8 @@ export class VirtualListController implements ReactiveController {
     this._scrollContainer = options.scrollContainer;
     this._itemSelector = options.itemSelector;
     this._rowMetrics = options.rowMetrics;
-    this._overscanRows = options.overscanRows ?? 4;
+    // Clamp to >= 0: a negative overscan would shrink the window / yield a bad slice.
+    this._overscanRows = Math.max(0, options.overscanRows ?? 4);
     host.addController(this);
   }
 
@@ -156,8 +157,12 @@ export class VirtualListController implements ReactiveController {
       this._scrollEl = scrollEl;
       this._measured = false;
       scrollEl.addEventListener('scroll', this._onScroll, { passive: true });
-      // Seed viewport once; the observer owns it thereafter (no per-render read).
+      // Seed viewport + scroll offset once (a reconnect/restore can attach to an
+      // already-scrolled container; without this `_scrollTop` stays 0 until the
+      // next scroll event and the first window would be wrong). The observer +
+      // scroll listener own them thereafter (no per-render layout read).
       this._viewportHeight = scrollEl.clientHeight;
+      this._scrollTop = scrollEl.scrollTop;
       this._resizeObserver = new ResizeObserver((entries) => {
         const height = entries[0]?.contentRect.height ?? scrollEl.clientHeight;
         // A resize can change viewport AND row metrics (grid cell height scales

--- a/src/lit/VirtualListController.ts
+++ b/src/lit/VirtualListController.ts
@@ -1,0 +1,223 @@
+import type { ReactiveController, ReactiveControllerHost } from 'lit';
+import { computeWindow } from './computeWindow';
+
+export type VirtualListRowMetrics = {
+  /** Columns per row (1 for a vertical list, N for a wrapped grid). */
+  columns: number;
+  /** Measured height of one row in px — the item box plus the inter-row gap in grid mode. */
+  rowHeight: number;
+};
+
+export type VirtualListSlice<T> = {
+  /** The items to actually render this frame (the visible window + overscan). */
+  items: readonly T[];
+  /** Spacer height above the window, in px (preserves scroll height). */
+  topPad: number;
+  /** Spacer height below the window, in px. */
+  bottomPad: number;
+};
+
+export type VirtualListOptions = {
+  /**
+   * Locate the scroll container in the host's DOM. Re-queried each render, so a
+   * host that renders into light DOM (this repo's `LightDomMixin`) just returns
+   * `this.querySelector('.scroller')`.
+   */
+  scrollContainer: () => HTMLElement | null;
+  /** Selector for a rendered row inside the scroll container, used to measure row height. */
+  itemSelector: string;
+  /**
+   * Derive the row metrics from the live container + its first rendered item.
+   * App-specific (list vs grid, CSS-variable-driven columns/gap), so the host
+   * supplies it. Return `rowHeight: 0` when it can't be measured — the controller
+   * then renders the full list (no virtualization), which is the safe default.
+   */
+  rowMetrics: (scrollContainer: HTMLElement, firstItem: HTMLElement) => VirtualListRowMetrics;
+  /** Extra rows rendered above and below the viewport to hide scroll-in latency (default 4). */
+  overscanRows?: number;
+};
+
+/**
+ * Reusable list virtualization as a Lit {@link ReactiveController}: it measures a
+ * host-owned scroll container after each render, tracks scroll/resize, and turns
+ * an item array into the visible window (+ overscan) plus the top/bottom spacer
+ * heights that keep the scrollbar sized as if the whole list were laid out.
+ *
+ * It attaches to the host's OWN scroll element rather than wrapping the list in a
+ * new element — so it never disturbs the host's DOM structure or CSS (important
+ * where theming and grid/flex layout target specific light-DOM selectors). Any
+ * block can add one, point it at its scroller, and render `controller.window(items)`.
+ *
+ * Fully degrades to non-virtualized rendering whenever the geometry can't be
+ * measured (a non-laid-out environment, a hidden/zero-height container, or the
+ * pre-measurement first paint): {@link computeWindow} returns the full range with
+ * no spacers, so the host renders its original array unchanged.
+ */
+export class VirtualListController implements ReactiveController {
+  private readonly _host: ReactiveControllerHost;
+  private readonly _scrollContainer: () => HTMLElement | null;
+  private readonly _itemSelector: string;
+  private readonly _rowMetrics: VirtualListOptions['rowMetrics'];
+  private readonly _overscanRows: number;
+
+  private _scrollEl: HTMLElement | null = null;
+  private _resizeObserver?: ResizeObserver;
+  private _rafId = 0;
+  private _measureRafId = 0;
+
+  private _scrollTop = 0;
+  private _viewportHeight = 0;
+  private _rowHeight = 0;
+  private _columns = 1;
+  // Row metrics are measured ONCE and latched. Re-measuring the current first row
+  // every render is circular — the window decides which row is first, and rows are
+  // not perfectly uniform — so it oscillates and never settles (a scroll hang).
+  // `invalidate()` / a resize clears the latch to re-measure once.
+  private _measured = false;
+
+  public constructor(host: ReactiveControllerHost, options: VirtualListOptions) {
+    this._host = host;
+    this._scrollContainer = options.scrollContainer;
+    this._itemSelector = options.itemSelector;
+    this._rowMetrics = options.rowMetrics;
+    this._overscanRows = options.overscanRows ?? 4;
+    host.addController(this);
+  }
+
+  public hostUpdated(): void {
+    this._measure();
+  }
+
+  public hostDisconnected(): void {
+    this._detach();
+  }
+
+  /**
+   * Drop the latched row metrics so they are re-measured on the next render.
+   * Call when a layout change can alter row height/columns (e.g. a list⇆grid
+   * view-mode switch) — a resize is handled automatically.
+   */
+  public invalidate(): void {
+    this._measured = false;
+    this._rowHeight = 0;
+    this._columns = 1;
+    this._host.requestUpdate();
+  }
+
+  /**
+   * Slice `items` down to the current window. Call in the host's `render()`.
+   * `topPad`/`bottomPad` are the heights of full-width spacer elements the host
+   * renders before/after the windowed items.
+   */
+  public window<T>(items: readonly T[]): VirtualListSlice<T> {
+    const slice = computeWindow({
+      total: items.length,
+      scrollTop: this._scrollTop,
+      viewportHeight: this._viewportHeight,
+      rowHeight: this._rowHeight,
+      columns: this._columns,
+      overscanRows: this._overscanRows,
+    });
+    const windowed = slice.start === 0 && slice.end === items.length ? items : items.slice(slice.start, slice.end);
+    return { items: windowed, topPad: slice.topPad, bottomPad: slice.bottomPad };
+  }
+
+  // rAF-coalesced: a scroll burst updates `_scrollTop` at most once per frame,
+  // then re-renders the host (which re-windows).
+  private _onScroll = (): void => {
+    if (this._rafId) {
+      return;
+    }
+    this._rafId = requestAnimationFrame(() => {
+      this._rafId = 0;
+      const top = this._scrollEl?.scrollTop ?? 0;
+      if (top !== this._scrollTop) {
+        this._scrollTop = top;
+        this._host.requestUpdate();
+      }
+    });
+  };
+
+  // Measure geometry off the live DOM after each render and lazily wire the
+  // scroll listener + a ResizeObserver. Row metrics are measured ONCE and latched
+  // (`_measured`) — measuring them every render is circular (see the field note)
+  // and hangs. Viewport height tracks continuously (it can't feed back). A resize
+  // clears the latch so row metrics are re-measured. The measurement-driven
+  // re-render is scheduled OUTSIDE the update lifecycle (rAF) so it never trips
+  // Lit's "scheduled an update after an update completed" warning.
+  private _measure(): void {
+    const scrollEl = this._scrollContainer();
+    if (!scrollEl) {
+      return;
+    }
+    if (this._scrollEl !== scrollEl) {
+      this._detach();
+      this._scrollEl = scrollEl;
+      this._measured = false;
+      scrollEl.addEventListener('scroll', this._onScroll, { passive: true });
+      this._resizeObserver = new ResizeObserver(() => {
+        const height = scrollEl.clientHeight;
+        // A resize can change both viewport and row metrics (e.g. grid columns),
+        // so re-latch. This callback runs outside the update lifecycle → direct
+        // requestUpdate is safe.
+        if (height !== this._viewportHeight || this._measured) {
+          this._viewportHeight = height;
+          this._measured = false;
+          this._host.requestUpdate();
+        }
+      });
+      this._resizeObserver.observe(scrollEl);
+    }
+
+    let changed = false;
+    const viewportHeight = scrollEl.clientHeight;
+    if (viewportHeight !== this._viewportHeight) {
+      this._viewportHeight = viewportHeight;
+      changed = true;
+    }
+
+    if (!this._measured) {
+      const firstItem = scrollEl.querySelector<HTMLElement>(this._itemSelector);
+      if (firstItem) {
+        const { columns, rowHeight } = this._rowMetrics(scrollEl, firstItem);
+        if (rowHeight > 0) {
+          this._columns = columns >= 1 ? columns : 1;
+          this._rowHeight = rowHeight;
+          this._measured = true;
+          changed = true;
+        }
+      }
+    }
+
+    if (changed) {
+      this._scheduleMeasureUpdate();
+    }
+  }
+
+  // Re-render after a measurement change, but deferred to the next frame so the
+  // `requestUpdate` lands outside the update lifecycle (no change-in-update warning).
+  private _scheduleMeasureUpdate(): void {
+    if (this._measureRafId) {
+      return;
+    }
+    this._measureRafId = requestAnimationFrame(() => {
+      this._measureRafId = 0;
+      this._host.requestUpdate();
+    });
+  }
+
+  private _detach(): void {
+    if (this._rafId) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = 0;
+    }
+    if (this._measureRafId) {
+      cancelAnimationFrame(this._measureRafId);
+      this._measureRafId = 0;
+    }
+    this._scrollEl?.removeEventListener('scroll', this._onScroll);
+    this._scrollEl = null;
+    this._resizeObserver?.disconnect();
+    this._resizeObserver = undefined;
+  }
+}

--- a/src/lit/VirtualListController.ts
+++ b/src/lit/VirtualListController.ts
@@ -138,13 +138,14 @@ export class VirtualListController implements ReactiveController {
     });
   };
 
-  // Measure geometry off the live DOM after each render and lazily wire the
-  // scroll listener + a ResizeObserver. Row metrics are measured ONCE and latched
-  // (`_measured`) — measuring them every render is circular (see the field note)
-  // and hangs. Viewport height tracks continuously (it can't feed back). A resize
-  // clears the latch so row metrics are re-measured. The measurement-driven
-  // re-render is scheduled OUTSIDE the update lifecycle (rAF) so it never trips
-  // Lit's "scheduled an update after an update completed" warning.
+  // Measure geometry after each render and lazily wire the scroll listener + a
+  // ResizeObserver. Viewport height is seeded with ONE layout read on attach and
+  // then owned by the ResizeObserver — steady-state renders do NOT read
+  // `clientHeight`, so a scroll/re-render doesn't force a layout. Row metrics are
+  // measured ONCE and latched (`_measured`) — measuring them every render is
+  // circular (see the field note) and hangs; a resize clears the latch so they
+  // re-measure. The measurement-driven re-render is scheduled OUTSIDE the update
+  // lifecycle (rAF) so it never trips Lit's change-in-update warning.
   private _measure(): void {
     const scrollEl = this._scrollContainer();
     if (!scrollEl) {
@@ -155,11 +156,13 @@ export class VirtualListController implements ReactiveController {
       this._scrollEl = scrollEl;
       this._measured = false;
       scrollEl.addEventListener('scroll', this._onScroll, { passive: true });
-      this._resizeObserver = new ResizeObserver(() => {
-        const height = scrollEl.clientHeight;
-        // A resize can change both viewport and row metrics (e.g. grid columns),
-        // so re-latch. This callback runs outside the update lifecycle → direct
-        // requestUpdate is safe.
+      // Seed viewport once; the observer owns it thereafter (no per-render read).
+      this._viewportHeight = scrollEl.clientHeight;
+      this._resizeObserver = new ResizeObserver((entries) => {
+        const height = entries[0]?.contentRect.height ?? scrollEl.clientHeight;
+        // A resize can change viewport AND row metrics (grid cell height scales
+        // with width via aspect-ratio), so re-latch. This callback runs outside
+        // the update lifecycle → direct requestUpdate is safe.
         if (height !== this._viewportHeight || this._measured) {
           this._viewportHeight = height;
           this._measured = false;
@@ -167,13 +170,6 @@ export class VirtualListController implements ReactiveController {
         }
       });
       this._resizeObserver.observe(scrollEl);
-    }
-
-    let changed = false;
-    const viewportHeight = scrollEl.clientHeight;
-    if (viewportHeight !== this._viewportHeight) {
-      this._viewportHeight = viewportHeight;
-      changed = true;
     }
 
     if (!this._measured) {
@@ -184,13 +180,9 @@ export class VirtualListController implements ReactiveController {
           this._columns = columns >= 1 ? columns : 1;
           this._rowHeight = rowHeight;
           this._measured = true;
-          changed = true;
+          this._scheduleMeasureUpdate();
         }
       }
-    }
-
-    if (changed) {
-      this._scheduleMeasureUpdate();
     }
   }
 

--- a/src/lit/computeWindow.test.ts
+++ b/src/lit/computeWindow.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest';
+import { computeWindow, type WindowMetrics } from './computeWindow';
+
+// (relocated to src/lit/ — shared virtualization primitive used by VirtualListController)
+
+const base: WindowMetrics = {
+  total: 0,
+  scrollTop: 0,
+  viewportHeight: 0,
+  rowHeight: 0,
+  columns: 1,
+  overscanRows: 0,
+};
+
+describe('computeWindow', () => {
+  describe('unmeasurable / empty → render-all fallback (no spacers)', () => {
+    it('returns the full range when rowHeight is 0 (not measured)', () => {
+      expect(computeWindow({ ...base, total: 100, viewportHeight: 500, rowHeight: 0 })).toEqual({
+        start: 0,
+        end: 100,
+        topPad: 0,
+        bottomPad: 0,
+      });
+    });
+
+    it('returns the full range when viewportHeight is 0 (hidden/zero-height)', () => {
+      expect(computeWindow({ ...base, total: 100, viewportHeight: 0, rowHeight: 40 })).toEqual({
+        start: 0,
+        end: 100,
+        topPad: 0,
+        bottomPad: 0,
+      });
+    });
+
+    it('returns the full range when columns < 1', () => {
+      expect(computeWindow({ ...base, total: 100, viewportHeight: 500, rowHeight: 40, columns: 0 })).toEqual({
+        start: 0,
+        end: 100,
+        topPad: 0,
+        bottomPad: 0,
+      });
+    });
+
+    it('returns an empty range for an empty list', () => {
+      expect(computeWindow({ ...base, total: 0, viewportHeight: 500, rowHeight: 40 })).toEqual({
+        start: 0,
+        end: 0,
+        topPad: 0,
+        bottomPad: 0,
+      });
+    });
+  });
+
+  describe('list mode (columns = 1)', () => {
+    // 100 rows × 40px, 200px viewport → 5 visible rows, no overscan.
+    const listBase: WindowMetrics = {
+      ...base,
+      total: 100,
+      viewportHeight: 200,
+      rowHeight: 40,
+      columns: 1,
+      overscanRows: 0,
+    };
+
+    it('windows to the visible rows at the top', () => {
+      expect(computeWindow({ ...listBase, scrollTop: 0 })).toEqual({
+        start: 0,
+        end: 5,
+        topPad: 0,
+        bottomPad: 95 * 40,
+      });
+    });
+
+    it('windows to the scrolled-into-view rows in the middle', () => {
+      // scrollTop 400 → first visible row 10.
+      expect(computeWindow({ ...listBase, scrollTop: 400 })).toEqual({
+        start: 10,
+        end: 15,
+        topPad: 10 * 40,
+        bottomPad: 85 * 40,
+      });
+    });
+
+    it('clamps the window at the bottom of the list', () => {
+      // Max real scrollTop = totalHeight - viewportHeight = 100*40 - 200 = 3800
+      // → first visible row 95, window runs to the last row (100).
+      const result = computeWindow({ ...listBase, scrollTop: 3800 });
+      expect(result.end).toBe(100);
+      expect(result.bottomPad).toBe(0);
+      expect(result.start).toBe(95);
+      expect(result.topPad).toBe(95 * 40);
+    });
+
+    it('applies overscan above and below without going out of bounds', () => {
+      const result = computeWindow({ ...listBase, scrollTop: 400, overscanRows: 3 });
+      // firstVisibleRow 10, overscan 3 → startRow 7; visibleRowCount 5 + 6 = 11 → endRow 18.
+      expect(result).toEqual({ start: 7, end: 18, topPad: 7 * 40, bottomPad: (100 - 18) * 40 });
+    });
+
+    it('does not let overscan push startRow below 0 near the top', () => {
+      const result = computeWindow({ ...listBase, scrollTop: 40, overscanRows: 5 });
+      expect(result.start).toBe(0);
+      expect(result.topPad).toBe(0);
+    });
+  });
+
+  describe('grid mode (columns > 1)', () => {
+    // 100 items, 3 columns → 34 rows; 120px rows, 240px viewport → 2 visible rows.
+    const gridBase: WindowMetrics = {
+      ...base,
+      total: 100,
+      viewportHeight: 240,
+      rowHeight: 120,
+      columns: 3,
+      overscanRows: 0,
+    };
+
+    it('windows whole rows of columns at the top', () => {
+      const result = computeWindow({ ...gridBase, scrollTop: 0 });
+      // 2 visible rows × 3 cols = 6 items; 34 total rows → 32 rows below.
+      expect(result).toEqual({ start: 0, end: 6, topPad: 0, bottomPad: 32 * 120 });
+    });
+
+    it('windows whole rows when scrolled', () => {
+      // scrollTop 600 → first visible row 5 → start item 15.
+      const result = computeWindow({ ...gridBase, scrollTop: 600 });
+      expect(result.start).toBe(15);
+      expect(result.end).toBe(15 + 6);
+      expect(result.topPad).toBe(5 * 120);
+    });
+
+    it('clamps end to total (last partial row) at the bottom', () => {
+      // 100 items / 3 cols → last row has 1 item (row 33). Scroll to the end.
+      const result = computeWindow({ ...gridBase, scrollTop: 34 * 120 });
+      expect(result.end).toBe(100);
+      expect(result.bottomPad).toBe(0);
+    });
+  });
+});

--- a/src/lit/computeWindow.test.ts
+++ b/src/lit/computeWindow.test.ts
@@ -130,10 +130,61 @@ describe('computeWindow', () => {
     });
 
     it('clamps end to total (last partial row) at the bottom', () => {
-      // 100 items / 3 cols → last row has 1 item (row 33). Scroll to the end.
+      // 100 items / 3 cols → 34 rows. An over-scroll past the end (34*120) is
+      // clamped to the last page: 2 visible rows → start row 32 → item 96.
       const result = computeWindow({ ...gridBase, scrollTop: 34 * 120 });
+      expect(result.start).toBe(96);
+      expect(result.topPad).toBe(32 * 120);
       expect(result.end).toBe(100);
       expect(result.bottomPad).toBe(0);
+    });
+  });
+
+  describe('stale / over-scrolled scrollTop → clamped to last page (never an empty window)', () => {
+    it('list: a scrollTop far past a shrunken list snaps to the last page', () => {
+      // Was 1000+ rows, user scrolled deep (scrollTop 40000), list shrank to 10.
+      const result = computeWindow({
+        ...base,
+        total: 10,
+        viewportHeight: 200,
+        rowHeight: 40,
+        columns: 1,
+        overscanRows: 0,
+        scrollTop: 40_000,
+      });
+      // maxScrollTop = 10*40 - 200 = 200 → row 5 → last 5 rows, NOT an empty slice.
+      expect(result.start).toBe(5);
+      expect(result.end).toBe(10);
+      expect(result.topPad).toBe(200);
+      expect(result.bottomPad).toBe(0);
+      expect(result.end).toBeGreaterThan(result.start);
+    });
+
+    it('list shorter than the viewport clamps to the whole list', () => {
+      const result = computeWindow({
+        ...base,
+        total: 3,
+        viewportHeight: 500,
+        rowHeight: 40,
+        columns: 1,
+        overscanRows: 0,
+        scrollTop: 9999,
+      });
+      expect(result).toEqual({ start: 0, end: 3, topPad: 0, bottomPad: 0 });
+    });
+
+    it('grid: an over-scrolled offset never yields start > end', () => {
+      const result = computeWindow({
+        ...base,
+        total: 100,
+        viewportHeight: 240,
+        rowHeight: 120,
+        columns: 3,
+        overscanRows: 0,
+        scrollTop: 999_999,
+      });
+      expect(result.start).toBeLessThan(result.end);
+      expect(result.end).toBe(100);
     });
   });
 });

--- a/src/lit/computeWindow.ts
+++ b/src/lit/computeWindow.ts
@@ -48,7 +48,14 @@ export function computeWindow(metrics: WindowMetrics): WindowSlice {
   }
 
   const totalRows = Math.ceil(total / columns);
-  const firstVisibleRow = Math.floor(Math.max(0, scrollTop) / rowHeight);
+  // Clamp scrollTop to the real scrollable range. A stale/oversized offset — the
+  // list shrank while scrolled deep, or an over-scroll the browser clamped
+  // without firing `scroll` — would otherwise push `firstVisibleRow` past the
+  // last row, making `start > end` (an empty window with a huge top spacer, i.e.
+  // a blank list). Clamping snaps the window to the last page instead.
+  const maxScrollTop = Math.max(0, totalRows * rowHeight - viewportHeight);
+  const clampedScrollTop = Math.min(Math.max(0, scrollTop), maxScrollTop);
+  const firstVisibleRow = Math.floor(clampedScrollTop / rowHeight);
   const startRow = Math.max(0, firstVisibleRow - overscanRows);
   const visibleRowCount = Math.ceil(viewportHeight / rowHeight) + overscanRows * 2;
   const endRow = Math.min(totalRows, startRow + visibleRowCount);

--- a/src/lit/computeWindow.ts
+++ b/src/lit/computeWindow.ts
@@ -1,0 +1,62 @@
+export type WindowMetrics = {
+  /** Total number of items in the list. */
+  total: number;
+  /** Current scroll offset of the scroll container, in px. */
+  scrollTop: number;
+  /** Visible height of the scroll container, in px. */
+  viewportHeight: number;
+  /** Measured height of one row, in px (item height, plus the inter-row gap in grid mode). */
+  rowHeight: number;
+  /** Columns per row (1 in list mode, `--uc-grid-col` in grid mode). */
+  columns: number;
+  /** Extra rows rendered above and below the viewport to hide scroll-in latency. */
+  overscanRows: number;
+};
+
+export type WindowSlice = {
+  /** Inclusive start index into the item list. */
+  start: number;
+  /** Exclusive end index into the item list. */
+  end: number;
+  /** Spacer height above the rendered window, in px (preserves scroll height). */
+  topPad: number;
+  /** Spacer height below the rendered window, in px. */
+  bottomPad: number;
+};
+
+/**
+ * Pure windowing math for {@link UploadList}: given the scroll geometry, return
+ * the `[start, end)` slice of items to render plus the top/bottom spacer heights
+ * that keep the scrollbar sized as if the whole list were laid out.
+ *
+ * Fixed-row-height model — both view modes render uniform rows in practice (list
+ * rows are pinned to `min-height: --uc-file-item-height`; grid cells are a fixed
+ * `--uc-grid-preview-image-height`). `columns` folds the flex-wrap grid onto the
+ * same row math.
+ *
+ * Degrades safely: when the geometry can't be measured yet (`rowHeight`/
+ * `viewportHeight` still 0 — happy-dom, a hidden or zero-height container, the
+ * pre-measurement first paint) or the list is empty, it returns the FULL range
+ * with no spacers, i.e. exactly the non-virtualized behavior. Callers can render
+ * the original array unchanged in that case.
+ */
+export function computeWindow(metrics: WindowMetrics): WindowSlice {
+  const { total, scrollTop, viewportHeight, rowHeight, columns, overscanRows } = metrics;
+
+  if (total <= 0 || rowHeight <= 0 || viewportHeight <= 0 || columns < 1) {
+    return { start: 0, end: total > 0 ? total : 0, topPad: 0, bottomPad: 0 };
+  }
+
+  const totalRows = Math.ceil(total / columns);
+  const firstVisibleRow = Math.floor(Math.max(0, scrollTop) / rowHeight);
+  const startRow = Math.max(0, firstVisibleRow - overscanRows);
+  const visibleRowCount = Math.ceil(viewportHeight / rowHeight) + overscanRows * 2;
+  const endRow = Math.min(totalRows, startRow + visibleRowCount);
+
+  const start = startRow * columns;
+  const end = Math.min(total, endRow * columns);
+  const topPad = startRow * rowHeight;
+  const bottomPad = (totalRows - endRow) * rowHeight;
+
+  return { start, end, topPad, bottomPad };
+}


### PR DESCRIPTION
The low-risk FileItem large-N wins from the three-tool (claude + codex + grok) perf review of UploadList/FileItem. No public-API surface; behavior-preserving.

- **O(1) click focus** — replaces an O(N) sweep over `FileItem.activeInstances` that mutated `[focused]` on every connected row (dirtying style for the whole list per click) with a single static focused-ref. Also removes the static `Set` that pinned every row from GC. (Regression test: clicking one item focuses it and unfocuses the previous.)
- **One-shot IntersectionObserver** — FileItem's observer only un-pauses render on first view, yet kept firing on every scroll for the row's whole life; now disconnected after the flip (matches Thumb).
- **Unsubscribe on disconnect** — `FileItemConfig.disconnectedCallback` replaced `_entrySubs` with a new `Set` **without calling the unsubscribes**, leaking `Listeners` callbacks that ran `select()` on every later entry write until the entry's ~10 s deferred destroy. Now it `reset()`s (unsubscribes first).

Deferred to follow-ups (larger): collapse the ~15 per-key row observers to one `subscribeKeys` (+ drop duplicates), progress-only update path, and list virtualization (`@lit-labs/virtualizer`).

## Gate
`tsc` · `build` (size-limit, editor 48.56 KB) · **1132** specs · locales · **384** e2e · lint (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Virtualized rendering for large upload lists for smoother scrolling.
  * Added a **queued** visual/preloader state for file action buttons.
* **Bug Fixes**
  * In-flight uploads are aborted when their entries are removed.
  * Click-to-focus now reliably clears focus from the previously focused item in the same uploader context, including during uploading transitions.
  * Unified entry status derivation to ensure consistent output status precedence across states.
* **Tests**
  * Expanded unit coverage for focus behavior, multiple entry states (including queued/uploading), virtualization windowing, and removal/abort behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->