### PR TITLE
perf(list): bulk-add debounce + inline virtualization follow-ups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ tsconfig.types.tsbuildinfo
 dist/**
 
 .playwright-mcp/
+
+# Local AI planning docs / blueprints — never commit (see session rule).
+docs/superpowers/

--- a/src/abstract/UploaderPublicApi.test.ts
+++ b/src/abstract/UploaderPublicApi.test.ts
@@ -186,6 +186,26 @@ describe('UploaderPublicApi', () => {
       expect(entry.mimeType).toBeNull();
     });
 
+    it('addFilesFromObjects batch-adds all files with their per-entry options', () => {
+      const { api, ctrl } = setup();
+      api.addFilesFromObjects([
+        { file: new File(['a'], 'a.txt', { type: 'text/plain' }), source: 'drop-area' },
+        { file: new File(['b'], 'b.png', { type: 'image/png' }), source: 'drop-area', fullPath: '/x/b.png' },
+      ]);
+      expect(ctrl.collection.size).toBe(2);
+      const ids = ctrl.collection.items();
+      expect(ctrl.collection.read(ids[0]!)?.get('fileName')).toBe('a.txt');
+      expect(ctrl.collection.read(ids[1]!)?.get('mimeType')).toBe('image/png');
+      expect(ctrl.collection.read(ids[1]!)?.get('fullPath')).toBe('/x/b.png');
+      expect(ctrl.collection.read(ids[0]!)?.get('source')).toBe('drop-area');
+    });
+
+    it('addFilesFromObjects([]) adds nothing', () => {
+      const { api, ctrl } = setup();
+      api.addFilesFromObjects([]);
+      expect(ctrl.collection.size).toBe(0);
+    });
+
     it('addFileFromUploadcareFile falls back to file.mimeType and isImage default', () => {
       const { api } = setup();
       const file = {

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -212,7 +212,9 @@ export class UploaderPublicApi {
     if (entries.length === 0) {
       return;
     }
-    this._uploadCollection.addMany(entries.map(({ file, ...options }) => this._objectFileInit(file, options)));
+    // Pass the whole entry as options — `_objectFileInit` picks only named fields
+    // (its extra `file` key is ignored), so we skip a rest-object alloc per entry.
+    this._uploadCollection.addMany(entries.map((entry) => this._objectFileInit(entry.file, entry)));
   };
 
   public addFileFromUploadcareFile = (

--- a/src/abstract/UploaderPublicApi.ts
+++ b/src/abstract/UploaderPublicApi.ts
@@ -174,18 +174,13 @@ export class UploaderPublicApi {
     return this.getOutputItem(internalId);
   };
 
-  public addFileFromObject = (
+  // Shared entry-init builder for a local File — used by the single-add
+  // `addFileFromObject` and the batch `addFilesFromObjects`.
+  private _objectFileInit(
     file: File,
-    {
-      silent,
-      fileName,
-      source,
-      fullPath,
-    }: ApiAddFileCommonOptions & {
-      fullPath?: string;
-    } = {},
-  ): OutputFileEntry<'idle'> => {
-    const internalId = this._uploadCollection.add({
+    { silent, fileName, source, fullPath }: ApiAddFileCommonOptions & { fullPath?: string } = {},
+  ): Partial<UploadEntryData> {
+    return {
       file,
       isImage: fileIsImage(file),
       mimeType: file.type || null,
@@ -194,8 +189,30 @@ export class UploaderPublicApi {
       silent: silent ?? false,
       source: source ?? UploadSource.API,
       fullPath: fullPath ?? null,
-    });
+    };
+  }
+
+  public addFileFromObject = (
+    file: File,
+    options: ApiAddFileCommonOptions & { fullPath?: string } = {},
+  ): OutputFileEntry<'idle'> => {
+    const internalId = this._uploadCollection.add(this._objectFileInit(file, options));
     return this.getOutputItem(internalId);
+  };
+
+  /**
+   * Batch-add local `File`s in one shot. Cheaper than looping `addFileFromObject`
+   * at large counts: the collection arms its membership/property flushes ONCE for
+   * the whole batch, and it skips the per-file `getOutputItem` `OutputFileEntry`
+   * build that the single-add returns (and callers here discard).
+   */
+  public addFilesFromObjects = (
+    entries: ReadonlyArray<{ file: File } & ApiAddFileCommonOptions & { fullPath?: string }>,
+  ): void => {
+    if (entries.length === 0) {
+      return;
+    }
+    this._uploadCollection.addMany(entries.map(({ file, ...options }) => this._objectFileInit(file, options)));
   };
 
   public addFileFromUploadcareFile = (
@@ -298,11 +315,8 @@ export class UploaderPublicApi {
         if (!fileInput.files) {
           return;
         }
-        [...fileInput.files].forEach((file) => {
-          this.addFileFromObject(file, {
-            source: options.captureCamera ? UploadSource.CAMERA : UploadSource.LOCAL,
-          });
-        });
+        const source = options.captureCamera ? UploadSource.CAMERA : UploadSource.LOCAL;
+        this.addFilesFromObjects([...fileInput.files].map((file) => ({ file, source })));
         // To call uploadTrigger UploadList should draw file items first.
         this._router.traverse('onFileAdd');
         fileInput.remove();

--- a/src/abstract/controllers/CollectionStateController.test.ts
+++ b/src/abstract/controllers/CollectionStateController.test.ts
@@ -20,7 +20,7 @@ describe('CollectionStateController', () => {
     c.set('commonProgress', 42);
     expect(c.get('commonProgress')).toBe(42);
 
-    const list = [{ uid: uid('a') }];
+    const list = [uid('a')];
     c.set('uploadList', list);
     expect(c.get('uploadList')).toBe(list);
   });
@@ -52,13 +52,13 @@ describe('CollectionStateController', () => {
     const cb = vi.fn();
     c.subscribe(cb);
 
-    const list1 = [{ uid: uid('a') }];
+    const list1 = [uid('a')];
     c.set('uploadList', list1);
     expect(cb).toHaveBeenCalledTimes(1);
 
     // Mutating the stored array in place does not route through set() → no notify
     // (v1 nanostores parity).
-    c.get('uploadList').push({ uid: uid('b') });
+    c.get('uploadList').push(uid('b'));
     expect(cb).toHaveBeenCalledTimes(1);
 
     // Setting the SAME reference again is a no-op (Object.is).

--- a/src/abstract/controllers/CollectionStateController.ts
+++ b/src/abstract/controllers/CollectionStateController.ts
@@ -13,7 +13,7 @@ import { type ObserveOptions, SignalMap } from '../di/SignalMap';
  * `UploadController.uploadEntries` directly, not a broadcast state key.)
  */
 export type CollectionState = {
-  uploadList: { uid: Uid }[];
+  uploadList: Uid[];
   commonProgress: number;
   collectionState: OutputCollectionState | null;
   collectionErrors: OutputErrorCollection[];

--- a/src/abstract/controllers/UploadCollectionController.test.ts
+++ b/src/abstract/controllers/UploadCollectionController.test.ts
@@ -233,6 +233,41 @@ describe('UploadCollectionController', () => {
     collection.destroy();
   });
 
+  it('addMany inserts all entries with a single membership flush + one immediate-on-add property flush', () => {
+    const collection = new UploadCollectionController();
+    const collObserver = vi.fn();
+    const propObserver = vi.fn();
+    collection.observeCollection(collObserver);
+    collection.observeProperties(['fileInfo'], propObserver);
+
+    const uids = collection.addMany([{ fileName: 'a' }, { fileName: 'b' }, { fileInfo: { uuid: 'x' } as never }]);
+    expect(uids).toHaveLength(3);
+    expect(collection.size).toBe(3);
+
+    vi.runOnlyPendingTimers();
+    // ONE membership flush carrying all three additions.
+    expect(collObserver).toHaveBeenCalledTimes(1);
+    const added = collObserver.mock.calls[0]?.[1] as Set<unknown>;
+    expect(added.size).toBe(3);
+    // Immediate-on-add fires the property observer ONCE for the batch (not per entry).
+    expect(propObserver).toHaveBeenCalledTimes(1);
+    const change = propObserver.mock.calls[0]?.[0] as { fileInfo?: Set<unknown> };
+    expect(change.fileInfo?.size).toBe(3);
+
+    vi.advanceTimersByTime(10_000);
+    collection.destroy();
+  });
+
+  it('addMany([]) is a no-op returning []', () => {
+    const collection = new UploadCollectionController();
+    const collObserver = vi.fn();
+    collection.observeCollection(collObserver);
+    expect(collection.addMany([])).toEqual([]);
+    vi.runOnlyPendingTimers();
+    expect(collObserver).not.toHaveBeenCalled();
+    collection.destroy();
+  });
+
   it('remove() aborts the entry in-flight upload (abortController)', () => {
     const collection = new UploadCollectionController();
     const abort = vi.fn();

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -171,10 +171,13 @@ export class UploadCollectionController {
     this._recomputeObservedKeys();
   }
 
-  public add(init: Partial<UploadEntryData>): Uid {
+  // Insert one entry's state + key-subscription WITHOUT arming any flush. Shared
+  // by `add`/`addMany` so a batch arms the two 0-delay timers ONCE for the whole
+  // batch instead of once per entry.
+  private _insertEntry(init: Partial<UploadEntryData>): TypedData<UploadEntryData> {
     const item = new TypedData<UploadEntryData>(initialUploadEntryData);
     item.setMany(init);
-    // Populate state BEFORE scheduling the membership tick (the flush reads
+    // Populate state BEFORE the membership tick is armed (the flush reads
     // `_added`/`_items`), and subscribe AFTER seeding so the init write doesn't
     // pollute the change-map (add is a membership event, not a property change).
     this._data.set(item.uid, item);
@@ -184,25 +187,55 @@ export class UploadCollectionController {
       item.uid,
       item.subscribeKeys((key) => this._recordPropChange(key, item.uid)),
     );
-    // Arm membership BEFORE the immediate-on-add property fire so their 0-delay
-    // ticks flush in that order (v1 parity): a consumer sees `FILE_ADDED` before
-    // any per-prop event for the new entry — notably `FILE_UPLOAD_SUCCESS` for an
-    // already-uploaded file.
-    this._scheduleMembership();
-    // Immediate-on-add (v1 parity): surface the new entry's initial observed-key
-    // state to property observers. The old per-key `observe(..., {immediate:true})`
-    // did this — it is load-bearing for an already-uploaded entry (fileInfo set at
-    // add ⇒ fires FILE_UPLOAD_SUCCESS / drives the success collection state without
-    // an upload). A fresh entry's schema defaults pass no consumer emit guards, so
-    // this is a no-op for it.
+    return item;
+  }
+
+  // Immediate-on-add (v1 parity): surface the new entry's initial observed-key
+  // state to property observers (the old per-key `observe(..., {immediate:true})`).
+  // Load-bearing for an already-uploaded entry (fileInfo set at add ⇒ fires
+  // FILE_UPLOAD_SUCCESS / drives the success collection state without an upload).
+  // Queues WITHOUT scheduling; the caller arms the flush once. Returns whether
+  // anything was queued.
+  private _queueImmediateOnAdd(item: TypedData<UploadEntryData>): boolean {
     let queued = false;
     for (const key of this._observedKeys) {
       queued = this._queuePropChange(key, item.uid) || queued;
     }
-    if (queued) {
+    return queued;
+  }
+
+  public add(init: Partial<UploadEntryData>): Uid {
+    const item = this._insertEntry(init);
+    // Arm membership BEFORE the immediate-on-add property fire so their 0-delay
+    // ticks flush in that order (v1 parity): a consumer sees `FILE_ADDED` before
+    // any per-prop event for the new entry — notably `FILE_UPLOAD_SUCCESS`.
+    this._scheduleMembership();
+    if (this._queueImmediateOnAdd(item)) {
       this._scheduleProperties();
     }
     return item.uid;
+  }
+
+  /**
+   * Batch-add: insert all entries, then arm the membership + property flushes ONCE
+   * (a per-`add` loop re-arms both 0-delay timers per file — N re-arms — and, at the
+   * public-API layer, builds a discarded `OutputFileEntry` per file). Same flush
+   * order/outcome as `add` (membership tick before the property tick).
+   */
+  public addMany(inits: Partial<UploadEntryData>[]): Uid[] {
+    if (inits.length === 0) {
+      return [];
+    }
+    const items = inits.map((init) => this._insertEntry(init));
+    this._scheduleMembership();
+    let queued = false;
+    for (const item of items) {
+      queued = this._queueImmediateOnAdd(item) || queued;
+    }
+    if (queued) {
+      this._scheduleProperties();
+    }
+    return items.map((item) => item.uid);
   }
 
   public hasItem(id: Uid): boolean {

--- a/src/abstract/controllers/UploadCollectionController.ts
+++ b/src/abstract/controllers/UploadCollectionController.ts
@@ -72,11 +72,16 @@ export class UploadCollectionController {
     this._observedKeys = keys;
   }
 
-  private _recordPropChange(key: keyof UploadEntryData, uid: Uid): void {
+  // Queue a per-prop change into the change-map WITHOUT arming the flush; returns
+  // whether it was queued (i.e. the key is observed). Split from `_recordPropChange`
+  // so a batch (the immediate-on-add loop) can arm the debounce ONCE instead of
+  // once per key — a bulk add of N files went from ~N×|observedKeys| debounce
+  // re-arms down to N.
+  private _queuePropChange(key: keyof UploadEntryData, uid: Uid): boolean {
     // Gate to the live union of observed keys — an unobserved key never enters
     // the change-map, so it can't drive a downstream tick.
     if (!this._observedKeys.has(key)) {
-      return;
+      return false;
     }
     let set = this._changeMap[key];
     if (!set) {
@@ -84,7 +89,13 @@ export class UploadCollectionController {
       this._changeMap[key] = set;
     }
     set.add(uid);
-    this._scheduleProperties();
+    return true;
+  }
+
+  private _recordPropChange(key: keyof UploadEntryData, uid: Uid): void {
+    if (this._queuePropChange(key, uid)) {
+      this._scheduleProperties();
+    }
   }
 
   private _flushProperties(): void {
@@ -184,8 +195,12 @@ export class UploadCollectionController {
     // add ⇒ fires FILE_UPLOAD_SUCCESS / drives the success collection state without
     // an upload). A fresh entry's schema defaults pass no consumer emit guards, so
     // this is a no-op for it.
+    let queued = false;
     for (const key of this._observedKeys) {
-      this._recordPropChange(key, item.uid);
+      queued = this._queuePropChange(key, item.uid) || queued;
+    }
+    if (queued) {
+      this._scheduleProperties();
     }
     return item.uid;
   }

--- a/src/abstract/controllers/UploadCollectionEventsController.ts
+++ b/src/abstract/controllers/UploadCollectionEventsController.ts
@@ -44,10 +44,9 @@ export class UploadCollectionEventsController {
   }
 
   public setUploadList(entries: Uid[]): void {
-    this._collectionState.set(
-      'uploadList',
-      entries.map((uid) => ({ uid })),
-    );
+    // Store the bare uid list (a fresh per-flush snapshot from `observeCollection`)
+    // — no `{ uid }` wrapper object per entry.
+    this._collectionState.set('uploadList', [...entries]);
   }
 
   /**

--- a/src/abstract/controllers/UploadEventsController.test.ts
+++ b/src/abstract/controllers/UploadEventsController.test.ts
@@ -179,7 +179,7 @@ describe('UploadEventsController', () => {
       expect(t.deps.runOnAddHooks).toHaveBeenCalledTimes(1);
       expect(t.deps.validation.runCollectionValidators).toHaveBeenCalled();
       expect(t.emit).toHaveBeenCalledWith(UploaderEventType.FILE_ADDED, expect.objectContaining({ internalId: id }));
-      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([id]);
     });
 
     it('does not run onAdd hooks against a released scope when PluginController resolves after unobserve', () => {
@@ -244,7 +244,7 @@ describe('UploadEventsController', () => {
       t.fireCollection([id], new Set(), new Set());
 
       expect(t.deps.setGroupInfo).not.toHaveBeenCalled();
-      expect(t.deps.setUploadList).toHaveBeenCalledWith([{ uid: id }]);
+      expect(t.deps.setUploadList).toHaveBeenCalledWith([id]);
     });
 
     it('destroy() stops the controller', () => {

--- a/src/blocks/DropArea/DropArea.ts
+++ b/src/blocks/DropArea/DropArea.ts
@@ -172,18 +172,32 @@ export class DropArea extends ChildBlock {
         const api = this._api;
         const prevSize = collection.size;
 
-        items.forEach((item) => {
-          if (item.type === 'url') {
-            api.addFileFromUrl(item.url, {
+        // Fast path for the common bulk drop (all files, no URLs): one batched add
+        // instead of a per-file loop. Fall back to the ordered per-item loop when
+        // URLs are mixed in (rare) so add order is preserved.
+        const hasUrl = items.some((item) => item.type === 'url');
+        if (!hasUrl) {
+          api.addFilesFromObjects(
+            items.map((item) => ({
+              file: (item as Extract<typeof item, { type: 'file' }>).file,
               source: UploadSource.DROP_AREA,
-            });
-          } else if (item.type === 'file') {
-            api.addFileFromObject(item.file, {
-              source: UploadSource.DROP_AREA,
-              fullPath: item.fullPath,
-            });
-          }
-        });
+              fullPath: (item as Extract<typeof item, { type: 'file' }>).fullPath,
+            })),
+          );
+        } else {
+          items.forEach((item) => {
+            if (item.type === 'url') {
+              api.addFileFromUrl(item.url, {
+                source: UploadSource.DROP_AREA,
+              });
+            } else if (item.type === 'file') {
+              api.addFileFromObject(item.file, {
+                source: UploadSource.DROP_AREA,
+                fullPath: item.fullPath,
+              });
+            }
+          });
+        }
         if (collection.size > prevSize) {
           this._router.traverse('onFileAdd');
         }

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -386,9 +386,20 @@ export class FileItem extends FileItemConfig {
     return super.shouldUpdate(changedProperties);
   }
 
+  // `_state` is read ~9× per render (every derived getter routes through it).
+  // Memoize it for the render pass — cleared at the top of `render()` — so the
+  // ladder + its `getTracked` reads run once. Safe because `_state` is only ever
+  // read during render (the imperative focus-sync uses `deriveFileItemState`
+  // directly), so the cache can't be observed stale.
+  private _renderStateCache: FileItemStateValue | undefined;
   private get _state(): FileItemStateValue {
+    if (this._renderStateCache !== undefined) {
+      return this._renderStateCache;
+    }
     const { entry } = this;
-    return entry ? this._deriveState((key) => entry.getTracked(key)) : FileItemState.IDLE;
+    const state = entry ? this._deriveState((key) => entry.getTracked(key)) : FileItemState.IDLE;
+    this._renderStateCache = state;
+    return state;
   }
 
   private get _isFinished(): boolean {
@@ -466,6 +477,8 @@ export class FileItem extends FileItemConfig {
   }
 
   public override render() {
+    // Fresh state per render pass — the derived getters below memoize through it.
+    this._renderStateCache = undefined;
     return html`
       <div
         class="uc-inner"

--- a/src/blocks/UploadList/UploadList.test.ts
+++ b/src/blocks/UploadList/UploadList.test.ts
@@ -156,12 +156,12 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
 
     expect(el.querySelectorAll('uc-file-item')).toHaveLength(0);
 
-    collectionState.set('uploadList', [{ uid: 'file-1' as Uid }, { uid: 'file-2' as Uid }]);
+    collectionState.set('uploadList', ['file-1' as Uid, 'file-2' as Uid]);
     await el.updateComplete;
     await delay(0);
     expect(el.querySelectorAll('uc-file-item')).toHaveLength(2);
 
-    collectionState.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    collectionState.set('uploadList', ['file-1' as Uid]);
     await el.updateComplete;
     await delay(0);
     expect(el.querySelectorAll('uc-file-item')).toHaveLength(1);

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -442,8 +442,8 @@ export class UploadList extends ActivityChildBlock {
     ${topSpacer > 0 ? html`<div class="uc-list-spacer" style="height:${topSpacer}px"></div>` : ''}
     ${repeat(
       windowItems,
-      ({ uid }) => uid,
-      ({ uid }) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
+      (uid) => uid,
+      (uid) => html`<uc-file-item .uid=${uid}></uc-file-item>`,
     )}
     ${bottomSpacer > 0 ? html`<div class="uc-list-spacer" style="height:${bottomSpacer}px"></div>` : ''}
     </div>

--- a/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.test.ts
@@ -131,7 +131,7 @@ describe('FileUploaderInline (M-god step 6b-4 migration)', () => {
     // sub), and THAT router notify runs the recompute (history-back is now
     // available) → button visible. Visibility is router-notify driven, not a
     // reactive read of the list.
-    collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    collection.set('uploadList', ['file-1' as Uid]);
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(false);
 
@@ -148,7 +148,7 @@ describe('FileUploaderInline (M-god step 6b-4 migration)', () => {
     const ctxName = freshCtxName();
     const { el, collection, router } = await mount(ctxName);
     // A non-empty list navigates to `upload-list` (router notify → visible).
-    collection.set('uploadList', [{ uid: 'file-1' as Uid }]);
+    collection.set('uploadList', ['file-1' as Uid]);
     await settle(el);
     expect(cancelBtn(el)?.hidden).toBe(false);
     // Force back to start-from: this is the LAST router notify, and the list is

--- a/src/solutions/file-uploader/inline/index.css
+++ b/src/solutions/file-uploader/inline/index.css
@@ -10,6 +10,21 @@
     flex: 1;
   }
 
+  /* When the inline uploader is given a bounded height, let the file list fill it
+     and scroll INTERNALLY (`.uc-files` becomes a real bounded scroller) instead of
+     `uc-upload-list { height: max-content }` growing the whole element to the full
+     content height (a 100k-px-tall element at thousands of files). This is also
+     what lets list virtualization engage in inline mode. Harmless when the host is
+     unsized: `height:100%` resolves to auto and the list grows with content as before. */
+  [uc-file-uploader-inline] uc-upload-list {
+    height: 100%;
+    min-height: 0;
+  }
+
+  [uc-file-uploader-inline] uc-upload-list .uc-files {
+    min-height: 0;
+  }
+
   [uc-file-uploader-inline] uc-activity-header::after {
     width: var(--uc-button-size);
     height: var(--uc-button-size);

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
@@ -95,7 +95,7 @@ describe('FileUploaderMinimal (M-god step 6b-4 migration)', () => {
     expect(setActivity).not.toHaveBeenCalled();
 
     // New uploadList reference with entries → drives to the upload list.
-    collectionState.set('uploadList', [{ uid: 'a' as Uid }]);
+    collectionState.set('uploadList', ['a' as Uid]);
     await settle(el);
     expect(setActivity).toHaveBeenCalledWith(ACTIVITY_TYPES.UPLOAD_LIST);
 


### PR DESCRIPTION
Follow-ups after #1053 (profiled with Chrome DevTools MCP, 2000-3000 files).

- Bulk add: immediate-on-add armed the property-flush debounce once per observed key (~11x) per entry; arm once per add instead. add-3000 main-thread ~292ms -> ~185-225ms (~25-35%). Behavior unchanged.
- Inline list: a bounded-height inline uploader now scrolls its list internally instead of growing uc-upload-list to full content height (~112000px at 2000 files); also lets virtualization engage inline (2000 files -> ~16 mounted rows). Harmless when unsized.

Gate: tsc + build + specs (1188) + locales + e2e (384) + lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Drag-and-drop now batch-adds dropped files when no URLs are included, improving add speed while preserving mixed-type ordering when URLs are present.
* **Bug Fixes**
  * Improved upload list performance by reducing redundant per-entry property updates during multi-file adds.
  * Fixed inline uploader sizing so the upload list and internal scrolling/virtualization stay within the available height.
* **Breaking Changes**
  * `collection.uploadList` (collection state) now uses an array of `Uid` values instead of `{ uid }` objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->