### PR TITLE
refactor(solutions): UploadList chrome + shared layout fragments

### DIFF
--- a/src/blocks/UploadList/UploadList.test.ts
+++ b/src/blocks/UploadList/UploadList.test.ts
@@ -74,6 +74,7 @@ const mount = async (
     entries?: Partial<UploadEntryData>[];
     collectionErrors?: { type: string; message: string }[];
     config?: Partial<ConfigType>;
+    chrome?: UploadList['chrome'];
   } = {},
 ): Promise<{
   el: UploadList;
@@ -115,6 +116,9 @@ const mount = async (
   const clearAll = vi.spyOn(collection, 'clearAll');
   const el = document.createElement('uc-upload-list') as UploadList;
   el.setAttribute('ctx-name', ctxName);
+  if (opts.chrome) {
+    el.chrome = opts.chrome;
+  }
   document.body.append(el);
   mounted.push(el);
   await el.updateComplete;
@@ -348,5 +352,42 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
     const sameGroup = collectionState.get('groupInfo');
     collectionState.set('groupInfo', sameGroup);
     expect(tick).toHaveBeenCalledTimes(1);
+  });
+
+  describe('chrome variants', () => {
+    it('default chrome reflects chrome="default" and renders full header + toolbar', async () => {
+      const ctxName = freshCtxName();
+      const { el } = await mount(ctxName);
+
+      expect(el.chrome).toBe('default');
+      expect(el.getAttribute('chrome')).toBe('default');
+      expect(el.querySelector('uc-activity-header')).not.toBeNull();
+      expect(el.querySelector('button.uc-close-btn')).not.toBeNull();
+      expect(el.querySelector('button.uc-cancel-btn')).not.toBeNull();
+      expect(el.querySelector('button.uc-upload-btn')).not.toBeNull();
+      expect(el.querySelector('button.uc-done-btn')).not.toBeNull();
+      expect(el.querySelectorAll('button.uc-add-more-btn').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('compact chrome omits header and non-add-more toolbar actions', async () => {
+      const ctxName = freshCtxName();
+      const { el } = await mount(ctxName, { chrome: 'compact' });
+
+      expect(el.getAttribute('chrome')).toBe('compact');
+      expect(el.querySelector('uc-activity-header')).toBeNull();
+      expect(el.querySelector('button.uc-close-btn')).toBeNull();
+      expect(el.querySelector('button.uc-cancel-btn')).toBeNull();
+      expect(el.querySelector('button.uc-upload-btn')).toBeNull();
+      expect(el.querySelector('button.uc-done-btn')).toBeNull();
+      // Toolbar add-more still present (files-area add-more also exists).
+      expect(el.querySelector('button.uc-add-more-btn')).not.toBeNull();
+    });
+
+    it('compact chrome still runs add-more → initFlow', async () => {
+      const ctxName = freshCtxName();
+      const { el, spies } = await mount(ctxName, { chrome: 'compact' });
+      el.querySelector<HTMLButtonElement>('button.uc-add-more-btn')?.click();
+      expect(spies.initFlow).toHaveBeenCalledWith(true);
+    });
   });
 });

--- a/src/blocks/UploadList/UploadList.test.ts
+++ b/src/blocks/UploadList/UploadList.test.ts
@@ -355,12 +355,13 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
   });
 
   describe('chrome variants', () => {
-    it('default chrome reflects chrome="default" and renders full header + toolbar', async () => {
+    it('default chrome leaves the chrome attribute off and renders full header + toolbar', async () => {
       const ctxName = freshCtxName();
       const { el } = await mount(ctxName);
 
       expect(el.chrome).toBe('default');
-      expect(el.getAttribute('chrome')).toBe('default');
+      // Default does not reflect — keeps regular/inline hosts free of a redundant attr.
+      expect(el.hasAttribute('chrome')).toBe(false);
       expect(el.querySelector('uc-activity-header')).not.toBeNull();
       expect(el.querySelector('button.uc-close-btn')).not.toBeNull();
       expect(el.querySelector('button.uc-cancel-btn')).not.toBeNull();
@@ -379,14 +380,16 @@ describe('UploadList (M-god step 6b-8 migration)', () => {
       expect(el.querySelector('button.uc-cancel-btn')).toBeNull();
       expect(el.querySelector('button.uc-upload-btn')).toBeNull();
       expect(el.querySelector('button.uc-done-btn')).toBeNull();
-      // Toolbar add-more still present (files-area add-more also exists).
-      expect(el.querySelector('button.uc-add-more-btn')).not.toBeNull();
+      // List-mode compact chrome relies on the toolbar add-more (files-area is CSS-hidden).
+      expect(el.querySelector('.uc-toolbar button.uc-add-more-btn')).not.toBeNull();
     });
 
-    it('compact chrome still runs add-more → initFlow', async () => {
+    it('compact chrome still runs toolbar add-more → initFlow', async () => {
       const ctxName = freshCtxName();
       const { el, spies } = await mount(ctxName, { chrome: 'compact' });
-      el.querySelector<HTMLButtonElement>('button.uc-add-more-btn')?.click();
+      const toolbarAddMore = el.querySelector<HTMLButtonElement>('.uc-toolbar button.uc-add-more-btn');
+      expect(toolbarAddMore).not.toBeNull();
+      toolbarAddMore?.click();
       expect(spies.initFlow).toHaveBeenCalledWith(true);
     });
   });

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -59,10 +59,19 @@ export class UploadList extends ActivityChildBlock {
   public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
 
   /**
-   * Chrome variant — reflected so block CSS can key off `[chrome="compact"]`.
-   * Prefer omitting nodes over solution CSS `display: none` hacks.
+   * Chrome variant. Prefer omitting nodes over solution CSS `display: none`.
+   * Only non-default values reflect (`chrome="compact"`); default leaves the
+   * attribute off so regular/inline hosts stay free of a redundant host attr.
+   * Block CSS keys off `[chrome="compact"]`.
    */
-  @property({ reflect: true })
+  @property({
+    reflect: true,
+    converter: {
+      fromAttribute: (value: string | null): UploadListChrome => (value === 'compact' ? 'compact' : 'default'),
+      // `null` removes the attribute (Lit) when chrome is the default.
+      toAttribute: (value: UploadListChrome): string | null => (value === 'compact' ? 'compact' : null),
+    },
+  })
   public chrome: UploadListChrome = 'default';
 
   @state()

--- a/src/blocks/UploadList/UploadList.ts
+++ b/src/blocks/UploadList/UploadList.ts
@@ -1,5 +1,5 @@
 import { html, type PropertyValues } from 'lit';
-import { state } from 'lit/decorators.js';
+import { property, state } from 'lit/decorators.js';
 import { CollectionStateController } from '../../abstract/controllers/CollectionStateController';
 import { ConfigController } from '../../abstract/controllers/ConfigController';
 import { RouterController } from '../../abstract/controllers/RouterController';
@@ -23,6 +23,15 @@ import '../FileItem/FileItem';
 import '../DropArea/DropArea';
 
 export type FilesViewMode = 'grid' | 'list';
+
+/**
+ * Visual chrome of the upload list. Solutions set this at composition time;
+ * default preserves the full modal-list UI (header + full toolbar).
+ *
+ * - `default` — activity header (title + close) and full toolbar
+ * - `compact` — no header; toolbar is add-more only (minimal solution)
+ */
+export type UploadListChrome = 'default' | 'compact';
 
 export type Summary = {
   total: number;
@@ -48,6 +57,13 @@ export class UploadList extends ActivityChildBlock {
   @inject(UploadCollectionController) private readonly _uploadCollection!: UploadCollectionController;
 
   public override activityType = ACTIVITY_TYPES.UPLOAD_LIST;
+
+  /**
+   * Chrome variant — reflected so block CSS can key off `[chrome="compact"]`.
+   * Prefer omitting nodes over solution CSS `display: none` hacks.
+   */
+  @property({ reflect: true })
+  public chrome: UploadListChrome = 'default';
 
   @state()
   private _doneBtnVisible = false;
@@ -408,6 +424,7 @@ export class UploadList extends ActivityChildBlock {
     // `SignalWatcher`, so a collection change re-renders with no `ctx.sub`.
     const uploadList = this._collectionState.getTracked('uploadList');
     const commonErrorMessage = this._commonErrorMessage;
+    const compact = this.chrome === 'compact';
 
     // Render only the visible window (+ overscan) with top/bottom spacers holding
     // the scroll height. Unmeasured geometry → full list, no spacers (unchanged).
@@ -420,6 +437,10 @@ export class UploadList extends ActivityChildBlock {
     const topSpacer = view.topPad > 0 ? Math.max(0, view.topPad - this._rowGap) : 0;
     const bottomSpacer = view.bottomPad > 0 ? Math.max(0, view.bottomPad - this._rowGap) : 0;
     return html`
+  ${
+    compact
+      ? null
+      : html`
   <uc-activity-header>
     <span aria-live="polite" class="uc-header-text">${this._headerText}</span>
     <button
@@ -432,6 +453,8 @@ export class UploadList extends ActivityChildBlock {
       <uc-icon name="close"></uc-icon>
     </button>
   </uc-activity-header>
+`
+  }
 
   <div class="uc-no-files" ?hidden=${this._hasFiles}>
     ${this.yield('empty', html`<span>${this.l10n('no-files')}</span>`)}
@@ -465,6 +488,20 @@ export class UploadList extends ActivityChildBlock {
   </div>
 
   <div class="uc-toolbar">
+    ${
+      compact
+        ? html`
+    <button
+      type="button"
+      class="uc-add-more-btn uc-secondary-btn"
+      ?hidden=${!this._addMoreBtnVisible}
+      ?disabled=${!this._addMoreBtnEnabled}
+      @click=${this._handleAdd}
+    >
+      <uc-icon name="add"></uc-icon><span>${this.l10n('add-more')}</span>
+    </button>
+`
+        : html`
     <button type="button" class="uc-cancel-btn uc-secondary-btn" @click=${this._handleCancel}>${this.l10n('clear')}</button>
     <div class="uc-toolbar-spacer"></div>
     <button
@@ -491,6 +528,8 @@ export class UploadList extends ActivityChildBlock {
     >
       ${this.l10n('done')}
     </button>
+`
+    }
   </div>
 
   <uc-drop-area ghost></uc-drop-area>

--- a/src/blocks/UploadList/upload-list.css
+++ b/src/blocks/UploadList/upload-list.css
@@ -96,4 +96,71 @@
   uc-upload-list .uc-files .uc-add-more-btn {
     display: none;
   }
+
+  /* Compact chrome (minimal solution) — structure omits header + non-add-more
+     toolbar actions; these rules own the dashed card surface and icon-only
+     add-more placement (list toolbar vs grid files-area). */
+  uc-upload-list[chrome="compact"] {
+    width: 100%;
+    height: unset;
+    padding: 4px;
+    background-color: var(--uc-background);
+    border: 1px dashed var(--uc-border);
+    border-radius: calc(var(--uc-radius) * 1.75);
+  }
+
+  uc-upload-list[chrome="compact"] .uc-files {
+    padding: 0;
+  }
+
+  uc-upload-list[chrome="compact"] .uc-toolbar {
+    display: block;
+    padding: 0;
+    background-color: transparent;
+  }
+
+  uc-upload-list[chrome="compact"] .uc-toolbar .uc-add-more-btn {
+    width: 100%;
+    height: calc(var(--uc-preview-size) + var(--uc-padding) * 2);
+    margin-top: 4px;
+  }
+
+  uc-upload-list[chrome="compact"] .uc-toolbar .uc-add-more-btn[disabled] {
+    display: none;
+  }
+
+  uc-upload-list[chrome="compact"] .uc-toolbar .uc-add-more-btn > span {
+    display: none;
+  }
+
+  uc-upload-list[chrome="compact"] .uc-toolbar .uc-add-more-btn > uc-icon {
+    display: flex;
+  }
+
+  uc-upload-list[chrome="compact"] uc-drop-area {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    border-radius: calc(var(--uc-radius) * 1.75);
+  }
+
+  uc-upload-list[chrome="compact"] .uc-common-error {
+    margin: 4px 0 0;
+  }
+
+  uc-upload-list[chrome="compact"][mode="grid"] .uc-toolbar .uc-add-more-btn {
+    display: none;
+  }
+
+  uc-upload-list[chrome="compact"][mode="grid"] .uc-files .uc-add-more-btn {
+    display: flex;
+  }
+
+  uc-upload-list[chrome="compact"][mode="grid"] .uc-files .uc-add-more-btn > span {
+    display: none;
+  }
+
+  uc-upload-list[chrome="compact"][mode="grid"] .uc-files .uc-add-more-btn > uc-icon {
+    display: flex;
+  }
 }

--- a/src/solutions/file-uploader/inline/FileUploaderInline.ts
+++ b/src/solutions/file-uploader/inline/FileUploaderInline.ts
@@ -12,6 +12,7 @@ import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
 import { subscription, type Unsubscribe } from '../../../lit/subscription';
 import './index.css';
 
+import { renderInlineStartFrom } from '../layout-fragments.js';
 import { fileUploaderLazyPlugins } from '../lazyPlugins.js';
 
 import '../../../blocks/StartFrom/StartFrom';
@@ -146,19 +147,11 @@ export class FileUploaderInline extends SolutionChildBlock {
   public override render() {
     return html`
       ${super.render()}
-      <uc-start-from>
-        <uc-drop-area with-icon clickable></uc-drop-area>
-        <uc-source-list role="list" wrap></uc-source-list>
-        <button
-          type="button"
-          class="uc-cancel-btn uc-secondary-btn"
-          @click=${this._handleCancel}
-          ?hidden=${!this._couldCancel}
-        >
-          ${this.l10n('start-from-cancel')}
-        </button>
-        <uc-copyright></uc-copyright>
-      </uc-start-from>
+      ${renderInlineStartFrom({
+        onCancel: this._handleCancel,
+        cancelLabel: this.l10n('start-from-cancel'),
+        cancelHidden: !this._couldCancel,
+      })}
       <uc-upload-list></uc-upload-list>
       <uc-plugin-activity-renderer mode="inline"></uc-plugin-activity-renderer>
     `;

--- a/src/solutions/file-uploader/layout-fragments.test.ts
+++ b/src/solutions/file-uploader/layout-fragments.test.ts
@@ -6,14 +6,23 @@ type LitTemplate = { strings: TemplateStringsArray; values: unknown[] };
 const staticText = (result: LitTemplate): string => result.strings.join('');
 
 describe('layout-fragments', () => {
-  it('renderModalSourcePicker builds a modal start-from tree', () => {
+  it('renderModalSourcePicker builds a modal start-from tree with fidelity-critical attrs', () => {
     const onCancel = vi.fn();
     const result = renderModalSourcePicker({ onCancel, cancelLabel: 'Cancel' }) as LitTemplate;
     const text = staticText(result);
     expect(text).toContain('uc-modal');
+    expect(text).toContain('id="start-from"');
+    expect(text).toContain('strokes');
+    expect(text).toContain('block-body-scrolling');
     expect(text).toContain('uc-start-from');
     expect(text).toContain('uc-drop-area');
+    expect(text).toContain('with-icon');
+    expect(text).toContain('clickable');
     expect(text).toContain('uc-source-list');
+    expect(text).toContain('role="list"');
+    expect(text).toContain('uc-secondary-btn');
+    // Modal cancel is secondary only — not the inline `.uc-cancel-btn` class.
+    expect(text).not.toContain('uc-cancel-btn');
     expect(result.values).toContain(onCancel);
     expect(result.values).toContain('Cancel');
   });
@@ -33,26 +42,36 @@ describe('layout-fragments', () => {
     expect(without.values).toContain(null);
   });
 
-  it('renderMinimalTrigger includes label and single flag', () => {
+  it('renderMinimalTrigger pins initflow, clickable, tabindex, label, and single', () => {
     const result = renderMinimalTrigger({ single: true, label: 'Choose file' }) as LitTemplate;
     const text = staticText(result);
     expect(text).toContain('uc-start-from');
     expect(text).toContain('uc-drop-area');
+    expect(text).toContain('initflow');
+    expect(text).toContain('clickable');
+    expect(text).toContain('tabindex="0"');
     expect(text).toContain('uc-copyright');
     expect(result.values).toContain('Choose file');
-    expect(result.values).toContain(true);
+    expect(result.values).toContain(true); // single
   });
 
-  it('renderInlineStartFrom wires cancel visibility and label', () => {
+  it('renderInlineStartFrom pins cancel class, with-icon drop-area, and visibility', () => {
     const onCancel = vi.fn();
     const result = renderInlineStartFrom({
       onCancel,
       cancelLabel: 'Back',
       cancelHidden: true,
     }) as LitTemplate;
-    expect(staticText(result)).toContain('uc-cancel-btn');
+    const text = staticText(result);
+    expect(text).toContain('uc-drop-area');
+    expect(text).toContain('with-icon');
+    expect(text).toContain('clickable');
+    expect(text).toContain('uc-source-list');
+    expect(text).toContain('uc-cancel-btn');
+    expect(text).toContain('uc-secondary-btn');
+    expect(text).toContain('uc-copyright');
     expect(result.values).toContain(onCancel);
     expect(result.values).toContain('Back');
-    expect(result.values).toContain(true);
+    expect(result.values).toContain(true); // cancelHidden
   });
 });

--- a/src/solutions/file-uploader/layout-fragments.test.ts
+++ b/src/solutions/file-uploader/layout-fragments.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it, vi } from 'vitest';
+import { renderInlineStartFrom, renderMinimalTrigger, renderModalSourcePicker } from './layout-fragments';
+
+type LitTemplate = { strings: TemplateStringsArray; values: unknown[] };
+
+const staticText = (result: LitTemplate): string => result.strings.join('');
+
+describe('layout-fragments', () => {
+  it('renderModalSourcePicker builds a modal start-from tree', () => {
+    const onCancel = vi.fn();
+    const result = renderModalSourcePicker({ onCancel, cancelLabel: 'Cancel' }) as LitTemplate;
+    const text = staticText(result);
+    expect(text).toContain('uc-modal');
+    expect(text).toContain('uc-start-from');
+    expect(text).toContain('uc-drop-area');
+    expect(text).toContain('uc-source-list');
+    expect(result.values).toContain(onCancel);
+    expect(result.values).toContain('Cancel');
+  });
+
+  it('renderModalSourcePicker with copyright includes a nested template', () => {
+    const withCopyright = renderModalSourcePicker({
+      onCancel: vi.fn(),
+      cancelLabel: 'Cancel',
+      copyright: true,
+    }) as LitTemplate;
+    const without = renderModalSourcePicker({
+      onCancel: vi.fn(),
+      cancelLabel: 'Cancel',
+    }) as LitTemplate;
+    // copyright:true injects a TemplateResult; false/absent injects null.
+    expect(withCopyright.values.some((v) => v !== null && typeof v === 'object')).toBe(true);
+    expect(without.values).toContain(null);
+  });
+
+  it('renderMinimalTrigger includes label and single flag', () => {
+    const result = renderMinimalTrigger({ single: true, label: 'Choose file' }) as LitTemplate;
+    const text = staticText(result);
+    expect(text).toContain('uc-start-from');
+    expect(text).toContain('uc-drop-area');
+    expect(text).toContain('uc-copyright');
+    expect(result.values).toContain('Choose file');
+    expect(result.values).toContain(true);
+  });
+
+  it('renderInlineStartFrom wires cancel visibility and label', () => {
+    const onCancel = vi.fn();
+    const result = renderInlineStartFrom({
+      onCancel,
+      cancelLabel: 'Back',
+      cancelHidden: true,
+    }) as LitTemplate;
+    expect(staticText(result)).toContain('uc-cancel-btn');
+    expect(result.values).toContain(onCancel);
+    expect(result.values).toContain('Back');
+    expect(result.values).toContain(true);
+  });
+});

--- a/src/solutions/file-uploader/layout-fragments.ts
+++ b/src/solutions/file-uploader/layout-fragments.ts
@@ -1,0 +1,65 @@
+import { html, type TemplateResult } from 'lit';
+
+/**
+ * Shared light-DOM composition fragments for file-uploader solutions.
+ * Pure HTML factories — no DI, no controllers. Solutions pass handlers/labels.
+ */
+
+/** Modal source picker used by regular + minimal (foreground start-from). */
+export function renderModalSourcePicker(opts: {
+  onCancel: () => void;
+  cancelLabel: string;
+  /** Regular includes copyright inside the modal; minimal does not. */
+  copyright?: boolean;
+}): TemplateResult {
+  return html`
+    <uc-modal id="start-from" strokes block-body-scrolling>
+      <uc-start-from>
+        <uc-drop-area with-icon clickable></uc-drop-area>
+        <uc-source-list role="list" wrap></uc-source-list>
+        <button type="button" class="uc-secondary-btn" @click=${opts.onCancel}>
+          ${opts.cancelLabel}
+        </button>
+        ${opts.copyright ? html`<uc-copyright></uc-copyright>` : null}
+      </uc-start-from>
+    </uc-modal>
+  `;
+}
+
+/** Minimal persistent empty-state trigger (background start-from). */
+export function renderMinimalTrigger(opts: { single: boolean; label: string }): TemplateResult {
+  return html`
+    <uc-start-from>
+      <uc-drop-area
+        ?single=${opts.single}
+        initflow
+        clickable
+        tabindex="0"
+      ><span>${opts.label}</span></uc-drop-area>
+      <uc-copyright></uc-copyright>
+    </uc-start-from>
+  `;
+}
+
+/** Inline start-from shell (drop area + sources + cancel + copyright). */
+export function renderInlineStartFrom(opts: {
+  onCancel: () => void;
+  cancelLabel: string;
+  cancelHidden: boolean;
+}): TemplateResult {
+  return html`
+    <uc-start-from>
+      <uc-drop-area with-icon clickable></uc-drop-area>
+      <uc-source-list role="list" wrap></uc-source-list>
+      <button
+        type="button"
+        class="uc-cancel-btn uc-secondary-btn"
+        @click=${opts.onCancel}
+        ?hidden=${opts.cancelHidden}
+      >
+        ${opts.cancelLabel}
+      </button>
+      <uc-copyright></uc-copyright>
+    </uc-start-from>
+  `;
+}

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.test.ts
@@ -57,6 +57,17 @@ const settle = async (el: FileUploaderMinimal): Promise<void> => {
 const inlineDropArea = (el: FileUploaderMinimal): Element | null => el.querySelector('uc-start-from uc-drop-area');
 
 describe('FileUploaderMinimal (M-god step 6b-4 migration)', () => {
+  it('composes a compact upload list (chrome=compact) and dual start-from trees', async () => {
+    const ctxName = freshCtxName();
+    const { el } = await mount(ctxName);
+    const list = el.querySelector('uc-upload-list');
+    expect(list).not.toBeNull();
+    expect(list?.getAttribute('chrome')).toBe('compact');
+    // Persistent trigger + modal picker (two start-from activity mounts).
+    expect(el.querySelectorAll('uc-start-from')).toHaveLength(2);
+    expect(el.querySelector('uc-modal#start-from')).not.toBeNull();
+  });
+
   it('resolves its dependencies via @inject fields on the element', async () => {
     const ctxName = freshCtxName();
     const { el, config, router } = await mount(ctxName);

--- a/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
+++ b/src/solutions/file-uploader/minimal/FileUploaderMinimal.ts
@@ -10,6 +10,7 @@ import { ACTIVITY_TYPES } from '../../../lit/activity-constants';
 import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
 import { subscription, type Unsubscribe } from '../../../lit/subscription';
 import './index.css';
+import { renderMinimalTrigger, renderModalSourcePicker } from '../layout-fragments.js';
 import { fileUploaderLazyPlugins } from '../lazyPlugins.js';
 
 import '../../../blocks/Modal/Modal';
@@ -145,30 +146,18 @@ export class FileUploaderMinimal extends SolutionChildBlock {
   public override render() {
     return html`
       ${super.render()}
-      <uc-start-from>
-        <uc-drop-area
-          ?single=${this._singleUpload}
-          initflow
-          clickable
-          tabindex="0"
-        ><span>${this.l10n(this._buttonTextKey)}</span></uc-drop-area>
-        <uc-copyright></uc-copyright>
-      </uc-start-from>
-      <uc-upload-list></uc-upload-list>
+      ${renderMinimalTrigger({
+        single: this._singleUpload,
+        label: this.l10n(this._buttonTextKey),
+      })}
+      <uc-upload-list chrome="compact"></uc-upload-list>
 
-      <uc-modal id="start-from" strokes block-body-scrolling>
-        <uc-start-from>
-          <uc-drop-area with-icon clickable></uc-drop-area>
-          <uc-source-list role="list" wrap></uc-source-list>
-          <button
-            type="button"
-            class="uc-secondary-btn"
-            @click=${() => this._router.traverse('onCancel')}
-          >${this.l10n('start-from-cancel')}</button>
-        </uc-start-from>
-      </uc-modal>
+      ${renderModalSourcePicker({
+        onCancel: () => this._router.traverse('onCancel'),
+        cancelLabel: this.l10n('start-from-cancel'),
+      })}
 
-        <uc-plugin-activity-renderer mode="modal"></uc-plugin-activity-renderer>
+      <uc-plugin-activity-renderer mode="modal"></uc-plugin-activity-renderer>
     `;
   }
 }

--- a/src/solutions/file-uploader/minimal/index.css
+++ b/src/solutions/file-uploader/minimal/index.css
@@ -1,7 +1,7 @@
 @import url("../../../blocks/themes/uc-basic/index.css");
 
 @layer uc.solutions {
-  /* ICONS: */
+  /* Solution shell only — UploadList chrome lives on uc-upload-list[chrome=compact]. */
   :where([uc-file-uploader-minimal]) {
     position: relative;
     display: block;
@@ -48,56 +48,6 @@
     aspect-ratio: var(--uc-grid-aspect-ratio);
   }
 
-  [uc-file-uploader-minimal] uc-upload-list uc-activity-header {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list > .uc-toolbar {
-    background-color: transparent;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list {
-    width: 100%;
-    height: unset;
-    padding: 4px;
-    background-color: var(--uc-background);
-    border: 1px dashed var(--uc-border);
-    border-radius: calc(var(--uc-radius) * 1.75);
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-files {
-    padding: 0;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar {
-    display: block;
-    padding: 0;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-cancel-btn,
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-upload-btn,
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-done-btn {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-add-more-btn {
-    width: 100%;
-    height: calc(var(--uc-preview-size) + var(--uc-padding) * 2);
-    margin-top: 4px;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-add-more-btn[disabled] {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-add-more-btn > span {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-toolbar .uc-add-more-btn > uc-icon {
-    display: flex;
-  }
-
   [uc-file-uploader-minimal][mode="list"] uc-file-item uc-progress-bar {
     top: 0;
     height: 100%;
@@ -113,34 +63,7 @@
     border-radius: var(--uc-radius);
   }
 
-  [uc-file-uploader-minimal] uc-upload-list uc-drop-area {
-    width: 100%;
-    height: 100%;
-    margin: 0;
-    border-radius: calc(var(--uc-radius) * 1.75);
-  }
-
-  [uc-file-uploader-minimal] uc-upload-list .uc-common-error {
-    margin: 4px 0 0;
-  }
-
   [uc-file-uploader-minimal] uc-copyright .uc-credits {
     position: static;
-  }
-
-  [uc-file-uploader-minimal][mode="grid"] uc-upload-list .uc-toolbar .uc-add-more-btn {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal][mode="grid"] uc-upload-list .uc-files .uc-add-more-btn {
-    display: flex;
-  }
-
-  [uc-file-uploader-minimal][mode="grid"] uc-upload-list .uc-files .uc-add-more-btn > span {
-    display: none;
-  }
-
-  [uc-file-uploader-minimal][mode="grid"] uc-upload-list .uc-files .uc-add-more-btn > uc-icon {
-    display: flex;
   }
 }

--- a/src/solutions/file-uploader/regular/FileUploaderRegular.ts
+++ b/src/solutions/file-uploader/regular/FileUploaderRegular.ts
@@ -7,6 +7,7 @@ import { TelemetryManager } from '../../../abstract/managers/TelemetryManager';
 import { InternalEventType } from '../../../blocks/UploadCtxProvider/EventEmitter';
 import { SolutionChildBlock } from '../../../lit/SolutionChildBlock';
 import './index.css';
+import { renderModalSourcePicker } from '../layout-fragments.js';
 import { fileUploaderLazyPlugins } from '../lazyPlugins.js';
 
 import '../../../blocks/Modal/Modal';
@@ -85,14 +86,11 @@ export class FileUploaderRegular extends SolutionChildBlock {
 
     ${this._renderButton()}
 
-  <uc-modal id="start-from" strokes block-body-scrolling>
-    <uc-start-from>
-      <uc-drop-area with-icon clickable></uc-drop-area>
-      <uc-source-list role="list" wrap></uc-source-list>
-      <button type="button" class="uc-secondary-btn" @click=${() => this._router.traverse('onCancel')}>${this.l10n('start-from-cancel')}</button>
-      <uc-copyright></uc-copyright>
-    </uc-start-from>
-  </uc-modal>
+  ${renderModalSourcePicker({
+    onCancel: () => this._router.traverse('onCancel'),
+    cancelLabel: this.l10n('start-from-cancel'),
+    copyright: true,
+  })}
 
   <uc-modal id="upload-list" strokes block-body-scrolling>
     <uc-upload-list></uc-upload-list>


### PR DESCRIPTION
## Summary

Implements the locked solution-layout design (Option C):

- **`UploadList.chrome`**: `'default' | 'compact'` — compact omits activity header and non-add-more toolbar nodes (structure over `display:none`); compact surface CSS lives on the block (`upload-list.css`).
- **`layout-fragments.ts`**: shared Lit helpers for modal source picker, minimal trigger, and inline start-from — regular/minimal/inline stop copy-pasting those trees.
- **Minimal** wires `<uc-upload-list chrome="compact">` and drops host-selector UploadList chrome hacks from `minimal/index.css` (trigger/file-item shell CSS remains solution-owned).
- Product wiring unchanged: force-`confirmUpload`, dual start-from, inline cancel stale-by-design, regular headless/dynamic-button.

Design note (local, gitignored under `docs/superpowers/`): solution layout + UploadList chrome.

## Test plan

- [x] `npm run tsc:app`
- [x] `npm run build` (size-limit OK)
- [x] `npm run test:specs` (1272 passed)
- [x] e2e: `file-uploader-minimal` (11), plus earlier regular/minimal/inline run exit 0
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact display mode for upload lists, with a streamlined layout and add-more control.
  * Updated the minimal uploader to use the compact upload-list experience.
  * Added shared start-from UI components for source selection, drop areas, and cancellation.
  * Improved start-from modal and inline uploader interactions, including localized cancel actions.

* **Bug Fixes**
  * Ensured add-more remains available and functional in compact upload-list mode.

* **Tests**
  * Added coverage for compact upload-list behavior and shared uploader UI components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->