### PR TITLE
fix: use location.ancestorOrigins to detect top-level origin

### DIFF
--- a/src/utils/get-top-level-origin.test.ts
+++ b/src/utils/get-top-level-origin.test.ts
@@ -1,9 +1,45 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { getTopLevelOrigin } from './get-top-level-origin';
 
 describe('getTopLevelOrigin', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   it('should return the top-level origin', () => {
     const origin = getTopLevelOrigin();
     expect(origin).toBe(window.location.origin);
+  });
+
+  it('should return the last ancestor origin when framed', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://self.example',
+      ancestorOrigins: ['https://parent.example', 'https://top.example'],
+    });
+    expect(getTopLevelOrigin()).toBe('https://top.example');
+  });
+
+  it('should fall back when ancestorOrigins is empty', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://self.example',
+      ancestorOrigins: [],
+    });
+    expect(getTopLevelOrigin()).toBe('https://self.example');
+  });
+
+  it('should fall back when ancestorOrigins is not supported', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://self.example',
+      ancestorOrigins: undefined,
+    });
+    expect(getTopLevelOrigin()).toBe('https://self.example');
+  });
+
+  it('should fall back when the top-level origin is opaque', () => {
+    vi.stubGlobal('location', {
+      origin: 'https://self.example',
+      ancestorOrigins: ['https://parent.example', 'null'],
+    });
+    expect(getTopLevelOrigin()).toBe('https://self.example');
   });
 });

--- a/src/utils/get-top-level-origin.ts
+++ b/src/utils/get-top-level-origin.ts
@@ -1,4 +1,13 @@
 export const getTopLevelOrigin = (): string => {
+  // The last entry of ancestorOrigins is the top-level origin, readable even from cross-origin iframes.
+  // The list is empty when not framed and unsupported in older Firefox; "null" means an opaque origin
+  // (e.g. a sandboxed ancestor) — useless as an origin value, so fall through in all those cases.
+  const ancestorOrigins = globalThis.location.ancestorOrigins;
+  const topAncestorOrigin = ancestorOrigins?.[ancestorOrigins.length - 1];
+  if (topAncestorOrigin && topAncestorOrigin !== 'null') {
+    return topAncestorOrigin;
+  }
+
   const topLevelWindow = globalThis.top ?? globalThis.parent ?? globalThis.self;
   try {
     return topLevelWindow.location.origin;


### PR DESCRIPTION
## Summary

`getTopLevelOrigin()` previously tried `top.location.origin`, which throws in cross-origin iframes — exactly the case where the correct top-level origin matters (e.g. the `origin` param passed to the social sources / Google Drive Picker window). The catch branch silently degraded to the iframe's own origin.

This PR makes the util prefer [`location.ancestorOrigins`](https://developer.mozilla.org/en-US/docs/Web/API/Location/ancestorOrigins): its last entry is the top-level origin and is readable even across origins.

## Behavior

- **Framed (any origin):** returns the last `ancestorOrigins` entry.
- **Fallback to previous behavior** when:
  - the list is empty (not embedded),
  - `ancestorOrigins` is unsupported (older Firefox),
  - the top entry is the opaque origin string `"null"` (e.g. sandboxed ancestor without `allow-same-origin`).
- The `topLevelOrigin` config option still takes precedence at the call site (`ExternalSource`), unchanged.

## Tests

Extended `get-top-level-origin.test.ts` from 1 to 5 specs (real-environment default, framed, empty list, unsupported API, opaque origin) using `vi.stubGlobal('location', …)` under happy-dom.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved origin detection in framed environments by using the highest available ancestor origin.
  * Added fallbacks for unsupported ancestor data, empty values, opaque origins, and inaccessible top-level locations.
  * Expanded test coverage for these scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->