### PR TITLE
chore: drop references to removed v1 machinery

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "image editing",
     "image size",
     "cloud image editor",
-    "symbiote.js",
     "upload api client",
     "building blocks",
     "blocks",

--- a/src/abstract/UploaderRegistry.test.ts
+++ b/src/abstract/UploaderRegistry.test.ts
@@ -325,10 +325,8 @@ describe('UploaderRegistry', () => {
     UploaderRegistry.unregister(name, second);
   });
 
-  // M-god step 9a: the container lifecycle (create + cache + eager
-  // Config -> Router -> Telemetry init + dispose) was folded here out of
-  // `PubSubCompat._resolveContainer`/`deleteCtx`, so it is now covered directly
-  // against the registry — independent of any `PubSubCompat`/nanostores map.
+  // The registry owns the container lifecycle: create + cache + eager
+  // Config -> Router -> Telemetry init + dispose. Covered directly against it.
   describe('ensure / dispose (container lifecycle)', () => {
     it('ensure creates and caches one container per ctx-name', () => {
       const name = uniqueName();

--- a/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
+++ b/src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts
@@ -127,7 +127,7 @@ export class CloudImageEditorBlock extends CloudImageEditorBlockBase {
   })
   public testMode?: boolean;
 
-  /** Own `ctx-name` attribute — mirrors `SymbioteCompatMixin`'s `_ctxNameAttr`. */
+  /** Own `ctx-name` attribute — wins over the inherited `ctxNameContext` value. */
   @property({ type: String, attribute: 'ctx-name', reflect: true })
   public ctxName: string | null = null;
 

--- a/src/blocks/CloudImageEditor/src/editor-context.ts
+++ b/src/blocks/CloudImageEditor/src/editor-context.ts
@@ -233,11 +233,10 @@ export abstract class EditorBlock extends EditorBlockBase {
 
   /**
    * Per-key reactive subscription to a single cross-cutting controller state
-   * key — mirrors `ChildBlock.subConfigValue`. `subscribeEditor` above is
-   * coarse (fires on ANY controller state change, for "re-render on
-   * anything"); many descendants instead have per-key imperative reactions
-   * (the old shared-ctx `this.sub('*tabId', ...)`, etc.) that must NOT fire on
-   * unrelated changes — this filters the coarse notifications down to one key
+   * key. `subscribeEditor` above is coarse (fires on ANY controller state
+   * change, for "re-render on anything"); many descendants instead have
+   * per-key imperative reactions that must NOT fire on unrelated changes —
+   * this filters the coarse notifications down to one key
    * via `Object.is` dedup, firing `cb` immediately with the current value and
    * again only when that key's value actually changes.
    *

--- a/src/lit/ChildBlock.ts
+++ b/src/lit/ChildBlock.ts
@@ -36,12 +36,12 @@ const ChildBlockBase = SignalWatcher(RegisterableElementMixin(LightDomMixin(LitE
 const isCustomElement = (el: Element): boolean => el.tagName?.includes('-') ?? false;
 
 /**
- * Base class for blocks ported off `SymbioteCompatMixin` (M9). Resolves the
- * per-ctx `ControllerContainer` by ctx-name — from the element's own
- * `ctx-name` attribute or, when absent, from the nearest v1 ancestor's
- * `ctxNameContext` provider — via `UploaderRegistry.whenAvailable`, which
- * fires synchronously when a container is already registered and again
- * across a remount, so subclasses re-adopt without losing bindings. If the
+ * Base class for uploader blocks. Resolves the per-ctx `ControllerContainer`
+ * by ctx-name — from the element's own `ctx-name` attribute or, when absent,
+ * from the nearest ancestor's `ctxNameContext` provider — via
+ * `UploaderRegistry.whenAvailable`, which fires synchronously when a container
+ * is already registered and again across a remount, so subclasses re-adopt
+ * without losing bindings. If the
  * ctx dies while this block stays connected (the last consumer elsewhere
  * disconnected and tore the ctx down), the registry notifies with `null` and
  * the block releases its container — closing the render gate — rather than
@@ -238,9 +238,8 @@ export abstract class ChildBlock extends ChildBlockBase {
 
   protected override willUpdate(changed: PropertyValues<this>): void {
     super.willUpdate(changed);
-    // Re-provide the effective ctx-name downward so v1 children nested under
-    // a ported block keep resolving their ctx exactly as they would under a
-    // v1 parent.
+    // Re-provide the effective ctx-name downward so descendants without their
+    // own `ctx-name` attribute resolve this block's ctx.
     const effective = this.effectiveCtxName;
     if (effective) {
       if (!this._ctxNameProvider) {
@@ -329,8 +328,8 @@ export abstract class ChildBlock extends ChildBlockBase {
     // closed (willUpdate never runs then) — react to it here, where Lit
     // calls in even for gated updates.
     if (changed.has('ctxName')) this._watchRegistry();
-    // v1 parity: SymbioteCompatMixin gates rendering until the ctx is
-    // initialized; here the gate is container adoption.
+    // The render gate: nothing renders until a container is adopted, so
+    // subclasses can read controllers unconditionally in `render()`.
     if (!this._container) {
       return false;
     }

--- a/src/lit/ctx-name-context.ts
+++ b/src/lit/ctx-name-context.ts
@@ -3,7 +3,7 @@ import { createContext } from '@lit/context';
 /**
  * `@lit/context` token carrying the shared `ctx-name` down the element tree, so
  * a descendant without its own `ctx-name` attribute resolves the nearest
- * ancestor's. Extracted from the removed `SymbioteCompatMixin` (v1 layer); still
- * used by `ChildBlock`, `ensureUploaderCtx`, and `<uc-cloud-image-editor>`.
+ * ancestor's. Consumed by `ChildBlock`, `ensureUploaderCtx`, and
+ * `<uc-cloud-image-editor>`.
  */
 export const ctxNameContext = createContext<string>('ctx-name-context');


### PR DESCRIPTION
## What

M11 cleanup. The v1 state layer is gone, but a few comments and one `package.json` keyword still cite it as if it were live.

- `package.json` — drop the `"symbiote.js"` keyword.
- Rewrite comments to state the current invariant instead of naming removed machinery:
  - `src/lit/ctx-name-context.ts` — "Extracted from the removed `SymbioteCompatMixin`" → lists its consumers.
  - `src/lit/ChildBlock.ts` ×3 — "blocks ported off `SymbioteCompatMixin` (M9)", "nearest **v1** ancestor's", "**v1 children** nested under a ported block", "v1 parity: SymbioteCompatMixin gates rendering…" → plain statements of what the code does.
  - `src/blocks/CloudImageEditor/src/CloudImageEditorBlock.ts` — "mirrors `SymbioteCompatMixin`'s `_ctxNameAttr`" → "wins over the inherited `ctxNameContext` value" (matches `_effectiveCtxName`).
  - `src/blocks/CloudImageEditor/src/editor-context.ts` — drops "mirrors `ChildBlock.subConfigValue`" (no such method exists any more) and the shared-ctx `sub('*tabId')` aside.
  - `src/abstract/UploaderRegistry.test.ts` — drops the `PubSubCompat._resolveContainer` / nanostores archaeology.

Comments that explicitly mark themselves as v1 history (`Thumb`, `DynamicBtn`, `PrimaryAction`) are accurate and left untouched.

## Why

Audited what M11 ("remove undocumented internals") still had in it. Outside `Img`'s `CssDataMixin`/`--cfg-*` — deliberately kept — there is no code left to remove: `PubSubCompat`, `SymbioteCompatMixin`, `SharedState`, `LitBlock`, `LitActivityBlock`, `ModalManager`, `CTX.ts`, the `$` proxy, `*`-keys and nanostores are all already absent. What remained was misleading prose pointing at classes and methods that no longer exist.

## Scope

Comments and package metadata only — **no behavior change**. `MIGRATION-PLAN.md` reconciliation is intentionally kept out of this PR.

## Verification

- `npx tsc -p tsconfig.app.json --noEmit` → clean
- `npm run lint` → exit 0 (4 pre-existing warnings, untouched files)
- `npm run test:specs` → 120 files / 1272 tests passed
- e2e **not** run: the diff has no runtime surface and e2e needs a full build.

Note for anyone else on this branch: `@lit-labs/signals` was declared but missing from `node_modules` on my checkout, so `test:specs` failed to resolve imports until `npm install`. `package-lock.json` unchanged — local drift only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SYwsNovYExYQGvMaY7dEnx

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation for controller container lifecycle handling and uploader block behavior.
  * Updated guidance on context inheritance, rendering gates, and reactive editor subscriptions.
  * Refined documentation for the cloud image editor’s context naming and context token usage.
* **Chores**
  * Removed an outdated package keyword.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->