### PR TITLE
feat(dynamic-btn): add null (plain) view mode with default icon

### DIFF
--- a/demo/solutions/regular.html
+++ b/demo/solutions/regular.html
@@ -16,6 +16,6 @@
   </script>
 </head>
 
-<uc-file-uploader-regular ctx-name="my-uploader"></uc-file-uploader-regular>
+<uc-file-uploader-regular dynamic-button ctx-name="my-uploader"></uc-file-uploader-regular>
 <uc-config ctx-name="my-uploader" pubkey="demopublickey" quality-insights="false" test-mode></uc-config>
 <uc-upload-ctx-provider ctx-name="my-uploader"></uc-upload-ctx-provider>

--- a/src/blocks/Config/initialConfig.ts
+++ b/src/blocks/Config/initialConfig.ts
@@ -94,7 +94,7 @@ const config = {
 
   plugins: [],
 
-  dynamicButtonViewMode: 'auto',
+  dynamicButtonViewMode: null,
   dynamicButtonShowFirstIcon: true,
 } satisfies ConfigType;
 

--- a/src/blocks/Config/initialConfig.ts
+++ b/src/blocks/Config/initialConfig.ts
@@ -94,7 +94,7 @@ const config = {
 
   plugins: [],
 
-  dynamicButtonViewMode: null,
+  dynamicButtonViewMode: 'plain',
   dynamicButtonShowFirstIcon: true,
 } satisfies ConfigType;
 

--- a/src/blocks/Config/validatorsType.ts
+++ b/src/blocks/Config/validatorsType.ts
@@ -125,7 +125,7 @@ const asFilesViewMode = (value: unknown): FilesViewMode => {
 
 const asDynamicButtonViewMode = (value: unknown): DynamicButtonMode => {
   const strValue = asString(value);
-  if (['auto', 'menu', 'toolbar', 'compact', null].includes(strValue)) {
+  if (['auto', 'menu', 'toolbar', 'compact', 'plain'].includes(strValue)) {
     return strValue as DynamicButtonMode;
   }
   throw new Error(`Invalid value: "${strValue}"`);

--- a/src/blocks/Config/validatorsType.ts
+++ b/src/blocks/Config/validatorsType.ts
@@ -125,7 +125,7 @@ const asFilesViewMode = (value: unknown): FilesViewMode => {
 
 const asDynamicButtonViewMode = (value: unknown): DynamicButtonMode => {
   const strValue = asString(value);
-  if (['auto', 'menu', 'toolbar', 'compact'].includes(strValue)) {
+  if (['auto', 'menu', 'toolbar', 'compact', null].includes(strValue)) {
     return strValue as DynamicButtonMode;
   }
   throw new Error(`Invalid value: "${strValue}"`);

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -22,7 +22,7 @@ import '../FileItem/FileActionButton';
 import './NoWrapModeDynamicBtn';
 import { ACTIVITY_TYPES } from '../../lit/activity-constants';
 
-export type DynamicButtonMode = 'auto' | 'menu' | 'toolbar' | 'compact';
+export type DynamicButtonMode = 'auto' | 'menu' | 'toolbar' | 'compact' | null;
 
 type SourceSplit = {
   main: SourceButtonConfig | null;
@@ -30,7 +30,7 @@ type SourceSplit = {
 };
 
 const adjustSourceBasedOnMode = (sources: SourceButtonConfig[], mode: DynamicButtonMode): SourceSplit => {
-  if (mode === 'compact' || sources.length === 0) {
+  if (mode === 'compact' || mode === null || sources.length === 0) {
     return {
       main: null,
       remain: sources,
@@ -43,7 +43,7 @@ const adjustSourceBasedOnMode = (sources: SourceButtonConfig[], mode: DynamicBut
   };
 };
 
-const iconsBasedOnMode: Record<Exclude<DynamicButtonMode, 'toolbar'>, string> = {
+const iconsBasedOnMode: Record<Exclude<DynamicButtonMode, 'toolbar' | null>, string> = {
   compact: 'paperclip',
   menu: 'arrow-dropdown',
   auto: 'arrow-dropdown',
@@ -96,6 +96,13 @@ export class DynamicBtn extends LitUploaderBlock {
 
   private get isCollapsedMode() {
     return this._mode === 'compact';
+  }
+
+  /**
+   *
+   */
+  private get isPlainMode() {
+    return this._mode === null;
   }
 
   private get shouldShowPrimaryAction(): boolean {
@@ -220,7 +227,7 @@ export class DynamicBtn extends LitUploaderBlock {
   }
 
   private _getDropdownIconName(): string {
-    return iconsBasedOnMode[this._mode as Exclude<DynamicButtonMode, 'toolbar'>] ?? 'arrow-dropdown';
+    return iconsBasedOnMode[this._mode as Exclude<DynamicButtonMode, 'toolbar' | null>] ?? 'arrow-dropdown';
   }
 
   private _clearAllEntries() {
@@ -313,9 +320,9 @@ export class DynamicBtn extends LitUploaderBlock {
       <uc-drop-area .disabled=${!this.dropzone}>
         <div class=${this._getInnerClassMap()}>
           ${cache(this.shouldShowPrimaryAction ? this._renderPrimaryAction() : null)}
-          ${cache(this.shouldShowInline ? this._renderInline() : null)}
-          ${cache(this.shouldShowCompactSingleSource ? this._renderCompactSingleSource() : null)}
-          ${cache(this.shouldShowDropdown ? this._renderDropdown() : null)}
+          ${cache(!this.isPlainMode && this.shouldShowInline ? this._renderInline() : null)}
+          ${cache(!this.isPlainMode && this.shouldShowCompactSingleSource ? this._renderCompactSingleSource() : null)}
+          ${cache(!this.isPlainMode && this.shouldShowDropdown ? this._renderDropdown() : null)}
           ${cache(this.shouldShowAbortAction || this.hasCollectionEntries ? this._renderAbortAction() : null)}
           ${cache(this._renderVisualDropArea())}
         </div>

--- a/src/blocks/DynamicBtn/DynamicBtn.ts
+++ b/src/blocks/DynamicBtn/DynamicBtn.ts
@@ -22,7 +22,7 @@ import '../FileItem/FileActionButton';
 import './NoWrapModeDynamicBtn';
 import { ACTIVITY_TYPES } from '../../lit/activity-constants';
 
-export type DynamicButtonMode = 'auto' | 'menu' | 'toolbar' | 'compact' | null;
+export type DynamicButtonMode = 'auto' | 'menu' | 'toolbar' | 'compact' | 'plain';
 
 type SourceSplit = {
   main: SourceButtonConfig | null;
@@ -30,7 +30,7 @@ type SourceSplit = {
 };
 
 const adjustSourceBasedOnMode = (sources: SourceButtonConfig[], mode: DynamicButtonMode): SourceSplit => {
-  if (mode === 'compact' || mode === null || sources.length === 0) {
+  if (mode === 'compact' || mode === 'plain' || sources.length === 0) {
     return {
       main: null,
       remain: sources,
@@ -43,7 +43,7 @@ const adjustSourceBasedOnMode = (sources: SourceButtonConfig[], mode: DynamicBut
   };
 };
 
-const iconsBasedOnMode: Record<Exclude<DynamicButtonMode, 'toolbar' | null>, string> = {
+const iconsBasedOnMode: Record<Exclude<DynamicButtonMode, 'toolbar' | 'plain'>, string> = {
   compact: 'paperclip',
   menu: 'arrow-dropdown',
   auto: 'arrow-dropdown',
@@ -102,7 +102,7 @@ export class DynamicBtn extends LitUploaderBlock {
    *
    */
   private get isPlainMode() {
-    return this._mode === null;
+    return this._mode === 'plain';
   }
 
   private get shouldShowPrimaryAction(): boolean {
@@ -227,7 +227,7 @@ export class DynamicBtn extends LitUploaderBlock {
   }
 
   private _getDropdownIconName(): string {
-    return iconsBasedOnMode[this._mode as Exclude<DynamicButtonMode, 'toolbar' | null>] ?? 'arrow-dropdown';
+    return iconsBasedOnMode[this._mode as Exclude<DynamicButtonMode, 'toolbar' | 'plain'>] ?? 'arrow-dropdown';
   }
 
   private _clearAllEntries() {

--- a/src/blocks/DynamicBtn/PrimaryAction.ts
+++ b/src/blocks/DynamicBtn/PrimaryAction.ts
@@ -13,6 +13,8 @@ import '../Thumb/Thumb';
 export class PrimaryAction extends LitUploaderBlock {
   public static override styleAttrs = [...super.styleAttrs, 'uc-primary-action'];
 
+  private static readonly DEFAULT_ICON = 'upload';
+
   private static readonly SOURCE_TEXT_CONFIG: Record<string, { action: string }> = {
     [UploadSource.LOCAL]: { action: 'upload-from' },
     [UploadSource.URL]: { action: 'upload-from' },
@@ -79,6 +81,10 @@ export class PrimaryAction extends LitUploaderBlock {
       return headerText;
     }
 
+    if (!this.source) {
+      return this.l10n(this._isMultiple ? 'upload-files' : 'upload-file');
+    }
+
     return this._getSourceLabelText();
   }
 
@@ -127,7 +133,12 @@ export class PrimaryAction extends LitUploaderBlock {
       return;
     }
 
-    void this.source?.onClick();
+    if (!this.source) {
+      this.api.initFlow();
+      return;
+    }
+
+    void this.source.onClick();
   }
 
   private _renderThumbnail() {
@@ -141,7 +152,7 @@ export class PrimaryAction extends LitUploaderBlock {
       return null;
     }
 
-    const iconName = this.source?.icon;
+    const iconName = this.source?.icon ?? PrimaryAction.DEFAULT_ICON;
     return this.showIcon && iconName ? html`<uc-icon .name=${iconName}></uc-icon>` : null;
   }
 

--- a/src/blocks/DynamicBtn/dynamic-btn.css
+++ b/src/blocks/DynamicBtn/dynamic-btn.css
@@ -9,6 +9,7 @@
   }
 
   :where([uc-dynamic-btn] .uc-dynamic-btn-inner) {
+    width: 100%;
     display: flex;
     gap: 3px;
     background-color: var(--uc-simple-btn);

--- a/src/blocks/DynamicBtn/primary-action.css
+++ b/src/blocks/DynamicBtn/primary-action.css
@@ -1,9 +1,11 @@
 @layer uc.components {
   :where([uc-primary-action]) {
     position: relative;
+    width: 100%;
   }
 
   :where([uc-primary-action] button) {
+    width: 100%;
     background-color: transparent;
     color: var(--uc-foreground);
   }

--- a/src/blocks/SimpleBtn/simple-btn.css
+++ b/src/blocks/SimpleBtn/simple-btn.css
@@ -5,6 +5,7 @@
   }
 
   :where([uc-simple-btn]) button {
+    width: 100%;
     height: auto;
     gap: 0.5em;
     padding: var(--uc-simple-btn-padding);

--- a/tests/dynamic-btn-upload-list.e2e.test.tsx
+++ b/tests/dynamic-btn-upload-list.e2e.test.tsx
@@ -12,7 +12,13 @@ beforeEach(() => {
   page.render(
     <>
       <uc-file-uploader-regular dynamic-button ctx-name={ctxName}></uc-file-uploader-regular>
-      <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-config
+        dynamicButtonViewMode="auto"
+        qualityInsights={false}
+        ctx-name={ctxName}
+        pubkey="demopublickey"
+        testMode
+      ></uc-config>
     </>,
   );
 });


### PR DESCRIPTION
When dynamicButtonViewMode is null, render a single "Upload File" button that acts as the primary action: opens the full upload flow when idle, and once files are added shows upload status, errors, progress, and the abort/remove action. The primary action falls back to a default "upload" icon when no source is bound.

## Description

<!-- Link to the related issue -->

<!-- Write a brief description of the changes introduced by this PR -->

<!-- Provide code snippets / GIFs or screenshots, if it makes sense -->

## Checklist

- [ ] Tests (if applicable)
- [ ] Documentation (if applicable)
- [ ] Changelog stub (or use [conventional commit messages](https://www.conventionalcommits.org/))


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a **plain** dynamic button mode that shows upload/drop-area UI without inline, compact, or dropdown controls.
  - Upload actions now fall back to a default **upload** icon and localized labels when no custom action is configured.
- **Bug Fixes**
  - Improved upload start behavior when there’s no predefined source (initializes the flow reliably).
- **Style**
  - Updated dynamic, primary, and simple buttons to use **full available width** for more consistent layouts.
- **Configuration**
  - Changed the default dynamic button view mode to **plain** in the initial configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->