### PR TITLE
fix(modal): keep an activity that a closing modal doesn't own

### DIFF
--- a/src/blocks/Modal/Modal.ts
+++ b/src/blocks/Modal/Modal.ts
@@ -36,7 +36,12 @@ export class Modal extends LitBlock {
 
     if (!this.modalManager?.hasActiveModals) {
       document.body.style.overflow = '';
-      this.$['*currentActivity'] = null;
+      // Only drop the activity if it's still ours: the dialog also closes as a
+      // consequence of navigating elsewhere (e.g. to the inline upload list),
+      // and blanking it then would undo that navigation.
+      if (this.$['*currentActivity'] === this.id) {
+        this.$['*currentActivity'] = null;
+      }
     }
   };
 

--- a/tests/file-uploader-minimal.e2e.test.tsx
+++ b/tests/file-uploader-minimal.e2e.test.tsx
@@ -44,6 +44,19 @@ describe('File uploader minimal', () => {
       await expect.element(uploadList).toBeVisible();
     });
 
+    it('should show the upload list after a file is picked from the device dialog', async () => {
+      await page.getByText('Choose files', { exact: true }).click();
+      await page.getByText('From device', { exact: true }).click();
+
+      // openSystemDialog() appends a hidden input and clicks it; the native dialog
+      // never opens under test, so feed the input directly to fire its change handler.
+      const fileInput = page.elementLocator(document.querySelector('[uploadcare-file-input]')!);
+      await userEvent.upload(fileInput, new File(['regression'], 'regression.txt', { type: 'text/plain' }));
+
+      await expect.element(page.getByTestId('uc-upload-list')).toBeVisible();
+      await expect.element(page.getByTestId('uc-file-item')).toBeVisible();
+    });
+
     it('should open cloud image editor modal on edit button click', async () => {
       const ctxProvider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
       const api = ctxProvider.getAPI();


### PR DESCRIPTION
## The bug

Picking a file from the system dialog left the upload list hidden until the next click.

`Modal.closeDialog()` blanked `*currentActivity` whenever the last modal closed. But the dialog also closes as a **consequence** of navigating elsewhere: `navigateAfterFileAdd()` moves the activity to `upload-list`, the solution closes its modals, and the native `<dialog>` `close` event then arrives and wipes the activity we just navigated to. `FileUploaderMinimal`'s `!val -> initActivity` fallback bounced it to `start-from`, deactivating the inline upload list — `<uc-upload-list activity="upload-list" class="">` with no `active` attribute, which `[activity]:not([active], .active)` hides.

Observed state at failure (probe): `{"currentActivity":"start-from","history":["upload-list","start-from"],"uploadListLen":1}`.

## The fix

Only drop the activity if it's still the one this modal owns. No solution-level changes needed.

## Verification

`tests/file-uploader-minimal.e2e.test.tsx` drives the real flow — click through to "From device", then feed the hidden `[uploadcare-file-input]` that `openSystemDialog()` appends:

- Without the fix: fails (`Received element is not visible: <uc-upload-list activity="upload-list" class="" />`).
- With the fix: 5/5 pass, 312 specs pass, `npm run tsc` clean.

> 🤖 Written by Claude Code on behalf of @nd0ut