### PR TITLE
test: pin public event order and telemetry payloads

### DIFF
--- a/tests/events.e2e.test.tsx
+++ b/tests/events.e2e.test.tsx
@@ -1,0 +1,306 @@
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { page } from 'vitest/browser';
+import type { Config, UploadCtxProvider } from '@/index.js';
+import { delay } from '@/utils/delay';
+import { IMAGE } from './fixtures/files';
+import { TEST_IMAGE_URL } from './utils/constants';
+import { type EventRecorder, recordEvents } from './utils/event-recorder';
+import { getCtxName } from './utils/test-renderer';
+import '../types/jsx';
+
+/**
+ * Baseline for the public event contract: which events fire, and in which order. The ordered assertions are exact, so a
+ * reordered, dropped or extra event fails the test.
+ *
+ * `change` is deliberately excluded from the ordered comparisons: it is debounced twice (300ms collection flush + 20ms
+ * emit debounce), so where it lands relative to the upload events depends on network timing. It is asserted separately
+ * instead — that it fires and carries the right final state.
+ */
+
+/** Longer than the 300ms `_flushOutputItems` debounce, so every trailing `change` has landed. */
+const SETTLE_MS = 1000;
+
+const CHANGE = 'change' as const;
+const PROGRESS = ['file-upload-progress', 'common-upload-progress'] as const;
+
+let provider: UploadCtxProvider;
+let config: Config;
+let recorder: EventRecorder;
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+beforeEach(async () => {
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      <uc-config qualityInsights={false} ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+    </>,
+  );
+  await delay(0);
+  provider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+  config = page.getByTestId('uc-config').query()! as Config;
+  recorder = recordEvents(provider);
+});
+
+const api = () => provider.api;
+
+describe('Events: upload lifecycle', () => {
+  it('fires the full ordered sequence for a single local file', async () => {
+    api().addFileFromObject(IMAGE.PIXEL);
+    await recorder.waitFor('file-added');
+    api().uploadAll();
+
+    await recorder.waitFor('common-upload-success');
+    await delay(SETTLE_MS);
+
+    expect(recorder.typesExcluding(CHANGE)).toEqual([
+      'file-added',
+      'common-upload-start',
+      'file-upload-start',
+      'file-upload-progress',
+      'common-upload-progress',
+      'file-upload-success',
+      'file-url-changed',
+      'common-upload-success',
+    ]);
+
+    const changes = recorder.detailsOf(CHANGE);
+    expect(changes.length).toBeGreaterThan(0);
+    expect(changes.at(-1)).toMatchObject({ status: 'success', successCount: 1, failedCount: 0 });
+  });
+
+  it('fires the full ordered sequence for a file added from a URL', async () => {
+    api().addFileFromUrl(TEST_IMAGE_URL);
+    await recorder.waitFor('file-added');
+    api().uploadAll();
+
+    await recorder.waitFor('common-upload-success');
+    await delay(SETTLE_MS);
+
+    // Progress events are excluded here: a URL upload is polled server-side, so it can finish without reporting any
+    // intermediate progress.
+    expect(recorder.typesExcluding(CHANGE, ...PROGRESS)).toEqual([
+      'file-added',
+      'common-upload-start',
+      'file-upload-start',
+      'file-upload-success',
+      'file-url-changed',
+      'common-upload-success',
+    ]);
+
+    const successPayload = recorder.detailsOf('file-upload-success')[0];
+    expect(successPayload.externalUrl).toBe(TEST_IMAGE_URL);
+    expect(successPayload.cdnUrl).toBeTruthy();
+  });
+
+  it('fires per-file events for every file when uploading several at once', async () => {
+    api().addFileFromObject(IMAGE.PIXEL);
+    api().addFileFromObject(IMAGE.SQUARE);
+    await vi.waitFor(() => expect(recorder.detailsOf('file-added')).toHaveLength(2), { timeout: 20_000 });
+    api().uploadAll();
+
+    await recorder.waitFor('common-upload-success');
+    await delay(SETTLE_MS);
+
+    expect(recorder.detailsOf('file-added')).toHaveLength(2);
+    expect(recorder.detailsOf('file-upload-start')).toHaveLength(2);
+    expect(recorder.detailsOf('file-upload-success')).toHaveLength(2);
+    // The common-* events describe the collection, so they fire once regardless of the file count.
+    expect(recorder.detailsOf('common-upload-start')).toHaveLength(1);
+    expect(recorder.detailsOf('common-upload-success')).toHaveLength(1);
+    expect(recorder.detailsOf(CHANGE).at(-1)).toMatchObject({ status: 'success', successCount: 2 });
+  });
+
+  it('fires file-removed and a trailing change when a file is removed', async () => {
+    const entry = api().addFileFromObject(IMAGE.PIXEL);
+    await recorder.waitFor('file-added');
+    await delay(SETTLE_MS);
+    recorder.clear();
+
+    api().removeFileByInternalId(entry.internalId);
+    await recorder.waitFor('file-removed');
+    await delay(SETTLE_MS);
+
+    // Removing a file recomputes the common progress, which re-emits it.
+    expect(recorder.types).toEqual(['file-removed', 'common-upload-progress', CHANGE]);
+    expect(recorder.detailsOf('file-removed')[0].internalId).toBe(entry.internalId);
+    expect(recorder.detailsOf(CHANGE)[0]).toMatchObject({ totalCount: 0 });
+  });
+
+  it('fires the failure events when a file does not pass validation', async () => {
+    config.maxLocalFileSizeBytes = 1;
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    await recorder.waitFor('common-upload-failed');
+    await delay(SETTLE_MS);
+
+    // The failure pair fires twice: once from the `add` validators and once from the `change` validators that run in
+    // the next tick. Pinned as-is — this is current behaviour, not an endorsement of it.
+    expect(recorder.typesExcluding(CHANGE)).toEqual([
+      'file-added',
+      'file-upload-failed',
+      'common-upload-failed',
+      'file-upload-failed',
+      'common-upload-failed',
+    ]);
+    expect(recorder.detailsOf('file-upload-failed')[0].errors[0].type).toBe('FILE_SIZE_EXCEEDED');
+    expect(recorder.detailsOf(CHANGE).at(-1)).toMatchObject({ status: 'failed', failedCount: 1 });
+  });
+
+  it('fires group-created after the upload succeeds when groupOutput is enabled', async () => {
+    config.groupOutput = true;
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    await recorder.waitFor('file-added');
+    api().uploadAll();
+
+    const groupState = await recorder.waitFor('group-created');
+    expect(groupState.group?.cdnUrl).toBeTruthy();
+    await delay(SETTLE_MS);
+
+    // group-created is excluded from the ordered comparison: creating the group is a separate network call, so it can
+    // land either side of common-upload-success.
+    expect(recorder.typesExcluding(CHANGE, 'group-created')).toEqual([
+      'file-added',
+      'common-upload-start',
+      'file-upload-start',
+      'file-upload-progress',
+      'common-upload-progress',
+      'file-upload-success',
+      'file-url-changed',
+      'common-upload-success',
+    ]);
+    expect(recorder.detailsOf('group-created')[0].group?.cdnUrl).toBeTruthy();
+  });
+});
+
+describe('Events: UI interaction', () => {
+  const clickInUploadList = async (selector: string) => {
+    const uploadList = page.getByTestId('uc-upload-list').query()!;
+    const button = await vi.waitFor(() => {
+      const found = uploadList.querySelector<HTMLButtonElement>(selector);
+      if (!found || found.hidden || found.disabled) throw new Error(`"${selector}" is not clickable`);
+      return found;
+    }, WAIT);
+    button.click();
+  };
+  const WAIT = { timeout: 20_000, interval: 50 };
+
+  it('fires activity-change then modal-open when the modal is opened', async () => {
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    await delay(SETTLE_MS);
+
+    expect(recorder.types).toEqual(['activity-change', 'modal-open']);
+    expect(recorder.detailsOf('activity-change')[0]).toEqual({ activity: 'start-from' });
+    expect(recorder.detailsOf('modal-open')[0]).toEqual({ modalId: 'start-from' });
+  });
+
+  it('fires upload-click and done-click from the upload list buttons', { timeout: 60_000 }, async () => {
+    // Without confirmUpload the list uploads on its own and never shows the Upload button.
+    config.confirmUpload = true;
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    api().setCurrentActivity('upload-list');
+    api().setModalState(true);
+    await expect.element(page.getByTestId('uc-upload-list')).toBeVisible();
+    await delay(SETTLE_MS);
+    recorder.clear();
+
+    await clickInUploadList('.uc-upload-btn');
+    expect(recorder.types[0]).toBe('upload-click');
+    expect(recorder.types[1]).toBe('common-upload-start');
+
+    await recorder.waitFor('common-upload-success');
+    await clickInUploadList('.uc-done-btn');
+    await delay(SETTLE_MS);
+
+    expect(recorder.detailsOf('done-click')).toHaveLength(1);
+    expect(recorder.detailsOf('done-click')[0]).toMatchObject({ status: 'success', successCount: 1 });
+    expect(recorder.detailsOf('modal-close')[0]).toEqual({ modalId: 'upload-list', hasActiveModals: false });
+  });
+});
+
+describe('Events: sources', () => {
+  /** Picks a source button out of the start-from list by its registered id. */
+  const clickSource = async (sourceId: string) => {
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    const button = await vi.waitFor(() => {
+      const found = document.querySelector<HTMLButtonElement>(`uc-source-btn[data-source-id="${sourceId}"] button`);
+      if (!found) throw new Error(`Source button "${sourceId}" was not rendered`);
+      return found;
+    }, WAIT);
+    button.click();
+  };
+
+  const WAIT = { timeout: 20_000, interval: 50 };
+
+  it('fires file-added with the camera source after a shot is accepted', { timeout: 60_000 }, async () => {
+    await clickSource('camera');
+    // The fake media device comes from the chromium launch flags in vitest.config.ts.
+    const shot = page.getByTestId('uc-camera-source--shot');
+    await expect.element(shot).toBeVisible();
+    recorder.clear();
+
+    await shot.click();
+    const accept = page.getByTestId('uc-camera-source--accept');
+    await expect.element(accept).toBeVisible();
+    await accept.click();
+
+    const added = await recorder.waitFor('file-added');
+    expect(added.source).toBe('camera');
+    expect(added.status).toBe('idle');
+    expect(added.name).toContain('camera');
+  });
+
+  it('fires file-added for every file picked in an external source', { timeout: 60_000 }, async () => {
+    await clickSource('dropbox');
+    const iframe = await vi.waitFor(() => {
+      const found = document.querySelector('uc-external-source iframe');
+      if (!found) throw new Error('External source iframe was not mounted');
+      return found as HTMLIFrameElement;
+    }, WAIT);
+    recorder.clear();
+
+    // Drive the remote picker through its message bridge instead of the real social app.
+    window.dispatchEvent(
+      new MessageEvent('message', {
+        source: iframe.contentWindow,
+        data: {
+          type: 'selected-files-change',
+          total: 2,
+          selectedCount: 2,
+          isReady: true,
+          isMultipleMode: true,
+          selectedFiles: [
+            { obj_type: 'selected_file', url: TEST_IMAGE_URL, filename: 'from-dropbox-1.jpg' },
+            { obj_type: 'selected_file', url: TEST_IMAGE_URL, filename: 'from-dropbox-2.jpg' },
+          ],
+        },
+      }),
+    );
+
+    const doneBtn = await vi.waitFor(() => {
+      const found = document.querySelector<HTMLButtonElement>('uc-external-source .uc-done-btn');
+      if (!found || found.hidden || found.disabled) throw new Error('Done button is not clickable');
+      return found;
+    }, WAIT);
+    doneBtn.click();
+
+    await vi.waitFor(() => {
+      expect(recorder.detailsOf('file-added')).toHaveLength(2);
+    }, WAIT);
+    expect(
+      recorder.detailsOf('file-added').map(({ source, externalUrl, name }) => ({ source, externalUrl, name })),
+    ).toEqual([
+      { source: 'dropbox', externalUrl: TEST_IMAGE_URL, name: 'from-dropbox-1.jpg' },
+      { source: 'dropbox', externalUrl: TEST_IMAGE_URL, name: 'from-dropbox-2.jpg' },
+    ]);
+  });
+});

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -1,0 +1,340 @@
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { page, userEvent } from 'vitest/browser';
+import type { Config, UploadCtxProvider } from '@/index.js';
+import { delay } from '@/utils/delay';
+import { IMAGE } from './fixtures/files';
+import { cleanup, getCtxName } from './utils/test-renderer';
+import '../types/jsx';
+
+/**
+ * Baseline for the telemetry contract: which requests the uploader sends to the telemetry endpoint, in which order,
+ * and with which payloads. Nothing leaves the browser — `fetch` to the telemetry host is stubbed out.
+ *
+ * Note that `LitBlock.emit` mirrors every public event into telemetry, minus `TelemetryManager._excludedEvents`. The
+ * exclusion list is asserted explicitly below, since silently starting to report per-file events would be a regression.
+ */
+
+const TELEMETRY_URL = 'https://tlm.uploadcare.com/api/v1/events';
+/** Longer than the 300ms output flush, so trailing telemetry has been queued and sent. */
+const SETTLE_MS = 1000;
+const WAIT = { timeout: 20_000, interval: 50 };
+
+/** Telemetry bodies are snake_cased on the way out. */
+type TelemetryBody = {
+  event_type: string;
+  session_id: string;
+  app_name: string;
+  app_version: string;
+  component: string | null;
+  activity: string | null;
+  project_pubkey: string;
+  config?: Record<string, unknown>;
+  payload: { location: string; metadata?: Record<string, unknown> & { event?: string }; [key: string]: unknown };
+};
+
+let sent: TelemetryBody[] = [];
+let provider: UploadCtxProvider;
+let config: Config;
+
+const types = () => sent.map((body) => body.event_type);
+const bodiesOf = (type: string) => sent.filter((body) => body.event_type === type);
+const bodiesWithAction = (event: string) => sent.filter((body) => body.payload.metadata?.event === event);
+const actionEvents = () => bodiesOf('action-event').map((body) => body.payload.metadata?.event);
+const waitForType = (type: string) =>
+  vi.waitFor(() => {
+    const found = bodiesOf(type)[0];
+    if (!found) throw new Error(`No telemetry "${type}". Sent: ${types().join(', ')}`);
+    return found;
+  }, WAIT);
+
+beforeAll(async () => {
+  const UC = await import('@/index.js');
+  UC.defineComponents(UC);
+});
+
+beforeEach(async () => {
+  sent = [];
+  const originalFetch = window.fetch.bind(window);
+  vi.spyOn(window, 'fetch').mockImplementation((input, init) => {
+    const url = typeof input === 'string' ? input : input instanceof URL ? input.href : input.url;
+    if (!url.startsWith(TELEMETRY_URL)) {
+      return originalFetch(input, init);
+    }
+    sent.push(JSON.parse(String(init?.body)) as TelemetryBody);
+    return Promise.resolve(new Response('{}', { status: 200, headers: { 'Content-Type': 'application/json' } }));
+  });
+
+  const ctxName = getCtxName();
+  page.render(
+    <>
+      <uc-file-uploader-regular ctx-name={ctxName}></uc-file-uploader-regular>
+      <uc-config ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      <uc-upload-ctx-provider ctx-name={ctxName}></uc-upload-ctx-provider>
+    </>,
+  );
+  await delay(0);
+  provider = page.getByTestId('uc-upload-ctx-provider').query()! as UploadCtxProvider;
+  config = page.getByTestId('uc-config').query()! as Config;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+const api = () => provider.api;
+
+describe('Telemetry: session', () => {
+  it('sends init-solution first, carrying the effective config', async () => {
+    const init = await waitForType('init-solution');
+
+    expect(types()[0]).toBe('init-solution');
+    expect(init.app_name).toBeTruthy();
+    expect(init.app_version).toBeTruthy();
+    expect(init.session_id).toBeTruthy();
+    expect(init.app_name).toBe('blocks');
+    expect(init.component).toBe('uc-file-uploader-regular');
+    expect(init.payload.location).toBe(location.origin);
+    expect(init.config).toMatchObject({ pubkey: 'demopublickey', test_mode: true, quality_insights: true });
+    // The top-level pubkey is still empty at init time — the config has not reached TelemetryManager yet. Pinned as
+    // current behaviour, not an endorsement of it.
+    expect(init.project_pubkey).toBe('');
+  });
+
+  it('sends change-config when a config value changes after init', async () => {
+    await waitForType('init-solution');
+    sent = [];
+
+    config.multiple = false;
+    await waitForType('change-config');
+
+    expect(bodiesOf('change-config')[0].config).toMatchObject({ multiple: false });
+  });
+
+  it('sends nothing when qualityInsights is disabled', async () => {
+    config.qualityInsights = false;
+    sent = [];
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    await delay(SETTLE_MS);
+
+    expect(sent).toEqual([]);
+  });
+});
+
+describe('Telemetry: upload lifecycle', () => {
+  it('reports the collection events and never the per-file ones', async () => {
+    await waitForType('init-solution');
+    sent = [];
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    api().uploadAll();
+    await waitForType('common-upload-success');
+    await delay(SETTLE_MS);
+
+    // No `common-upload-start`: `uploadAll()` emits it straight through the EventEmitter, bypassing `LitBlock.emit`
+    // and therefore telemetry.
+    expect(types()).toEqual(['file-url-changed', 'common-upload-success']);
+
+    // TelemetryManager._excludedEvents — reporting any of these would be a regression.
+    for (const excluded of [
+      'change',
+      'common-upload-progress',
+      'file-added',
+      'file-removed',
+      'file-upload-start',
+      'file-upload-progress',
+      'file-upload-success',
+      'file-upload-failed',
+    ]) {
+      expect(bodiesOf(excluded)).toHaveLength(0);
+    }
+  });
+
+  it('reports modal and activity events with the current activity attached', async () => {
+    await waitForType('init-solution');
+    sent = [];
+
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    await delay(SETTLE_MS);
+
+    expect(types()).toEqual(['activity-change', 'modal-open']);
+    // `activity` is stripped from the payload but kept as a top-level field.
+    expect(bodiesOf('activity-change')[0].activity).toBe('start-from');
+    expect(bodiesOf('activity-change')[0].payload.activity).toBeUndefined();
+    expect(bodiesOf('modal-open')[0].payload.modal_id).toBe('start-from');
+  });
+});
+
+describe('Telemetry: action events', () => {
+  it('reports an action-event when a file is removed from the upload list', { timeout: 60_000 }, async () => {
+    api().addFileFromObject(IMAGE.PIXEL);
+    api().setCurrentActivity('upload-list');
+    api().setModalState(true);
+    await expect.element(page.getByTestId('uc-file-item')).toBeVisible();
+    await waitForType('init-solution');
+    sent = [];
+
+    const fileItem = page.getByTestId('uc-file-item').query()!;
+    fileItem.querySelector<HTMLButtonElement>('.uc-remove-btn')?.click();
+
+    const removal = await vi.waitFor(() => {
+      const found = bodiesWithAction('remove-file')[0];
+      if (!found) throw new Error(`No "remove-file" telemetry. Sent: ${types().join(', ')}`);
+      return found;
+    }, WAIT);
+
+    expect(removal.payload.metadata).toMatchObject({ event: 'remove-file', node: 'UC-FILE-ITEM' });
+    // FileItem sends this one without an eventType, so it goes out with an empty one. Pinned as current behaviour.
+    expect(removal.event_type).toBe('');
+  });
+
+  it('reports an action-event when the upload list is cleared', async () => {
+    api().addFileFromObject(IMAGE.PIXEL);
+    api().setCurrentActivity('upload-list');
+    api().setModalState(true);
+    await expect.element(page.getByTestId('uc-upload-list')).toBeVisible();
+    await waitForType('init-solution');
+    sent = [];
+
+    const uploadList = page.getByTestId('uc-upload-list').query()!;
+    uploadList.querySelector<HTMLButtonElement>('.uc-cancel-btn')?.click();
+    await waitForType('action-event');
+
+    expect(bodiesOf('action-event')[0].payload.metadata).toMatchObject({
+      event: 'clear-all',
+      node: 'UC-UPLOAD-LIST',
+    });
+  });
+});
+
+describe('Telemetry: errors', () => {
+  it('reports an error-event when a file validator throws', async () => {
+    config.fileValidators = [
+      () => {
+        throw new Error('validator exploded');
+      },
+    ];
+
+    api().addFileFromObject(IMAGE.PIXEL);
+    const error = await waitForType('error-event');
+
+    expect(error.payload.metadata).toMatchObject({
+      event: 'error',
+      error: 'validator exploded',
+    });
+    expect(String((error.payload.metadata as Record<string, unknown>).text)).toContain('Error in file validator');
+  });
+});
+
+describe('Telemetry: cloud image editor', () => {
+  beforeEach(async () => {
+    cleanup();
+    sent = [];
+    const ctxName = getCtxName();
+    page.render(
+      <>
+        <uc-cloud-image-editor uuid="f4dc9ebc-ed6d-4b4d-83d1-863bf1e4bb7f" ctx-name={ctxName}></uc-cloud-image-editor>
+        <uc-config cdn-cname="https://ucarecdn.com/" ctx-name={ctxName} pubkey="demopublickey" testMode></uc-config>
+      </>,
+    );
+    await delay(0);
+  });
+
+  it('reports the editor as its own solution', async () => {
+    const init = await waitForType('init-solution');
+
+    expect(init.component).toBe('uc-cloud-image-editor');
+  });
+
+  it('reports an action-event when a toolbar tab is clicked', async () => {
+    await waitForType('init-solution');
+    sent = [];
+
+    await userEvent.click(page.getByRole('tab', { name: /tuning/i }));
+    const action = await waitForType('action-event');
+
+    expect(action.payload.metadata).toMatchObject({ tab_id: 'tuning', event: 'click' });
+  });
+
+  it('reports an action-event when a tuning operation is picked', async () => {
+    await userEvent.click(page.getByRole('tab', { name: /tuning/i }));
+    await waitForType('action-event');
+    sent = [];
+
+    await userEvent.click(page.getByRole('option', { name: /Brightness/i }));
+    const action = await waitForType('action-event');
+
+    // `operation` is read from `*operationTooltip`, which still holds the pre-click value — so it reports the stale
+    // tooltip rather than the operation just picked. Pinned as current behaviour, not an endorsement of it.
+    expect(action.payload.metadata).toMatchObject({
+      tab_id: 'tuning',
+      operation: { filter: 'filter', value: 0 },
+    });
+  });
+});
+
+describe('Telemetry: sources', () => {
+  const WAIT = { timeout: 20_000, interval: 50 };
+
+  /** Picks a source button out of the start-from list by its registered id. */
+  const clickSource = async (sourceId: string) => {
+    await page.getByText('Upload files', { exact: true }).click();
+    await expect.element(page.getByTestId('uc-start-from')).toBeVisible();
+    const button = await vi.waitFor(() => {
+      const found = document.querySelector<HTMLButtonElement>(`uc-source-btn[data-source-id="${sourceId}"] button`);
+      if (!found) throw new Error(`Source button "${sourceId}" was not rendered`);
+      return found;
+    }, WAIT);
+    button.click();
+  };
+
+  it('reports an action-event carrying the source id when a source is picked', async () => {
+    await waitForType('init-solution');
+    sent = [];
+
+    await clickSource('dropbox');
+    const action = await waitForType('action-event');
+
+    // SourceBtn puts the id straight on the payload, not inside `metadata`.
+    expect(action.payload.source_id).toBe('dropbox');
+  });
+
+  it('reports the camera action events in order', { timeout: 60_000 }, async () => {
+    await clickSource('camera');
+    const shot = page.getByTestId('uc-camera-source--shot');
+    await expect.element(shot).toBeVisible();
+    sent = [];
+
+    await page.getByTestId('uc-camera-source--tab-video').click();
+    await page.getByTestId('uc-camera-source--tab-photo').click();
+    await shot.click();
+
+    const accept = page.getByTestId('uc-camera-source--accept');
+    await expect.element(accept).toBeVisible();
+    const retake = document.querySelector<HTMLButtonElement>('uc-camera-source .uc-camera-actions .uc-secondary-btn')!;
+    retake.click();
+
+    await shot.click();
+    await expect.element(accept).toBeVisible();
+    await accept.click();
+
+    await vi.waitFor(() => expect(actionEvents()).toContain('accept-camera'), WAIT);
+    // Every shot reports twice: `shot-camera` from the button handler, then `start-camera` from the shared camera
+    // action dispatcher it calls.
+    expect(actionEvents()).toEqual([
+      'camera-tab-switch',
+      'camera-tab-switch',
+      'shot-camera',
+      'start-camera',
+      'retake-camera',
+      'shot-camera',
+      'start-camera',
+      'accept-camera',
+    ]);
+    expect(bodiesWithAction('camera-tab-switch')[0].payload.metadata).toMatchObject({
+      tab_id: 'video',
+      node: 'UC-CAMERA-SOURCE',
+    });
+  });
+});

--- a/tests/utils/event-recorder.ts
+++ b/tests/utils/event-recorder.ts
@@ -1,0 +1,63 @@
+import { vi } from 'vitest';
+import type { EventKey, EventPayload } from '@/blocks/UploadCtxProvider/EventEmitter';
+import { EventType } from '@/blocks/UploadCtxProvider/EventEmitter';
+
+/** Real uploads run against the network, so waiting for a terminal event needs more than vitest's 1s default. */
+const WAIT_TIMEOUT = { timeout: 20_000, interval: 50 };
+
+export type RecordedEvent = { type: EventKey; detail: unknown };
+
+/**
+ * Events that are emitted repeatedly while a single upload runs. Their count depends on network timing, so consecutive
+ * occurrences are collapsed into one entry in `types`.
+ */
+const COLLAPSIBLE: readonly EventKey[] = [EventType.FILE_UPLOAD_PROGRESS, EventType.COMMON_UPLOAD_PROGRESS];
+
+export type EventRecorder = ReturnType<typeof recordEvents>;
+
+/** Records every public uploader event fired on `target`, in order. */
+export function recordEvents(target: EventTarget) {
+  const events: RecordedEvent[] = [];
+
+  for (const type of Object.values(EventType)) {
+    target.addEventListener(type, (e: Event) => {
+      events.push({ type, detail: (e as CustomEvent).detail });
+    });
+  }
+
+  return {
+    events,
+
+    /** Ordered event types, with consecutive duplicates of timing-dependent events collapsed. */
+    get types(): EventKey[] {
+      return events
+        .map((event) => event.type)
+        .filter((type, index, all) => !(index > 0 && all[index - 1] === type && COLLAPSIBLE.includes(type)));
+    },
+
+    /** Ordered event types with `omit` types filtered out, on top of the collapsing done by `types`. */
+    typesExcluding(...omit: EventKey[]): EventKey[] {
+      return this.types.filter((type) => !omit.includes(type));
+    },
+
+    /** Payloads of every occurrence of `type`, in order. */
+    detailsOf<T extends EventKey>(type: T): EventPayload[T][] {
+      return events.filter((event) => event.type === type).map((event) => event.detail as EventPayload[T]);
+    },
+
+    /** Payload of the first occurrence of `type`, waiting for it to fire. */
+    waitFor<T extends EventKey>(type: T): Promise<EventPayload[T]> {
+      return vi.waitFor(() => {
+        const found = events.find((event) => event.type === type);
+        if (!found) {
+          throw new Error(`Event "${type}" was not fired. Recorded: ${events.map((e) => e.type).join(', ')}`);
+        }
+        return found.detail as EventPayload[T];
+      }, WAIT_TIMEOUT);
+    },
+
+    clear(): void {
+      events.length = 0;
+    },
+  };
+}


### PR DESCRIPTION
Baseline for the v2 migration. Characterisation tests that record **which events the uploader fires, in which order**, and **which telemetry requests it sends**, so the v2 branch can be diffed against current behaviour instead of against expectations.

### What's here

- **`tests/events.e2e.test.tsx`** — exact ordered sequences for the upload lifecycle (single local file, URL, multi-file, removal, validation failure, `groupOutput`) and for the modal / activity / upload-list button events.
- **`tests/telemetry.e2e.test.tsx`** — telemetry requests with `fetch` to `tlm.uploadcare.com` stubbed (nothing leaves the browser): `init-solution`, `change-config`, action events, error events, the cloud image editor, and the `_excludedEvents` list that keeps per-file events off the wire.
- **`tests/utils/event-recorder.ts`** — subscribes to every `EventType` on `uc-upload-ctx-provider` and records payloads in order.

### Notes on strictness

`change` is excluded from the ordered comparisons — it is debounced twice (300ms output flush + 20ms emit debounce), so its position relative to the upload events drifts with network timing. It is asserted separately instead: that it fires, and that its last payload carries the right collection state. Consecutive progress events are collapsed for the same reason.

### Quirks pinned, not fixed

Each is marked in the tests with a comment saying it is current behaviour, not an endorsement:

- validation failure emits `file-upload-failed` + `common-upload-failed` **twice** (`add` validators, then the `change` validators in the next tick)
- `init-solution` telemetry goes out with an empty top-level `project_pubkey` (the config has not reached `TelemetryManager` yet), even though `config.pubkey` is populated
- `common-upload-start` never reaches telemetry — `uploadAll()` emits it straight through the `EventEmitter`, bypassing `LitBlock.emit`
- `FileItem`'s remove-file telemetry is sent without an `eventType`, so it goes out as `""`
- the editor's operation control reports the **stale** `*operationTooltip`, not the operation just picked

### Verification

Full e2e suite green (26 files, 208 tests) and `npm run tsc` clean. The two new files were run 4x back to back with no flakes.

> 🤖 Written by Claude Code on behalf of @nd0ut

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for upload workflows, camera and external-source uploads, validation, modal interactions, and file management.
  * Added telemetry verification for uploader, editor, source selection, configuration, and user actions.
  * Added utilities for recording and validating asynchronous event sequences and payloads.

* **Documentation**
  * Documented event and telemetry behaviors, testing considerations, repository guidance, and contribution requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->