### PR TITLE
fix: the event and telemetry quirks the baseline pinned

### DIFF
--- a/src/abstract/managers/TelemetryManager.ts
+++ b/src/abstract/managers/TelemetryManager.ts
@@ -16,6 +16,13 @@ type TelemetryState = TelemetryRequest & {
   eventTimestamp: number;
   location: string;
 };
+/** The parts of an event that must be captured when it happens, not when it is sent. */
+type EventContext = {
+  timestamp: number;
+  activity: string | null;
+  solution: string | null;
+};
+
 type TelemetryEventBody = Partial<Pick<TelemetryState, 'payload' | 'config'>> & {
   modalId?: string;
   eventType: CommonEventType;
@@ -44,24 +51,16 @@ export class TelemetryManager extends SharedInstance {
     for (const key of Object.keys(this._config) as (keyof ConfigType)[]) {
       this.addSub(
         this._ctx.sub(sharedConfigKey(key), (value) => {
-          if (!this._isEnabled) {
-            return;
-          }
-          if (this._initialized && this._config[key] !== value) {
+          const isChanged = this._config[key] !== value;
+          this._setConfig(key, value);
+
+          if (this._isEnabled && this._initialized && isChanged) {
             this.sendEvent({
               eventType: InternalEventType.CHANGE_CONFIG,
             });
           }
-
-          this._setConfig(key, value);
         }),
       );
-    }
-  }
-
-  private _init(type: CommonEventType | undefined): void {
-    if (type === InternalEventType.INIT_SOLUTION && !this._initialized) {
-      this._initialized = true;
     }
   }
 
@@ -73,7 +72,14 @@ export class TelemetryManager extends SharedInstance {
     this._config[key] = value;
   }
 
-  private _formattingPayload(body: Partial<Pick<TelemetryState, 'eventType' | 'payload' | 'config'>>): TelemetryState {
+  /**
+   * Builds the wire payload. Called when the event is sent rather than when it is raised, so that config-derived
+   * fields (`config`, `projectPubkey`) reflect the config as delivered; `occurredAt` carries what must not drift.
+   */
+  private _formattingPayload(
+    body: Partial<Pick<TelemetryState, 'eventType' | 'payload' | 'config'>>,
+    occurredAt: EventContext,
+  ): TelemetryState {
     const payload = (body.payload ? { ...body.payload } : {}) as Record<string, unknown>;
     if (payload.activity) {
       payload.activity = undefined;
@@ -81,7 +87,7 @@ export class TelemetryManager extends SharedInstance {
 
     const result: Partial<Pick<TelemetryState, 'eventType' | 'payload' | 'config'>> = { ...body };
     if (body.eventType === InternalEventType.INIT_SOLUTION || body.eventType === InternalEventType.CHANGE_CONFIG) {
-      result.config = this._config as TelemetryState['config'];
+      result.config = { ...this._config } as TelemetryState['config'];
     }
 
     return {
@@ -90,12 +96,12 @@ export class TelemetryManager extends SharedInstance {
       appVersion: PACKAGE_VERSION,
       appName: PACKAGE_NAME,
       sessionId: this._sessionId,
-      component: this._solution,
-      activity: this._activity,
+      component: occurredAt.solution,
+      activity: occurredAt.activity,
       projectPubkey: this._config.pubkey,
       userAgent: navigator.userAgent,
       eventType: result.eventType,
-      eventTimestamp: this._timestamp,
+      eventTimestamp: occurredAt.timestamp,
 
       payload: {
         location: this._location,
@@ -128,28 +134,46 @@ export class TelemetryManager extends SharedInstance {
     if (!this._isEnabled) {
       return;
     }
-    const payload = this._formattingPayload({
-      eventType: body.eventType,
-      payload: body.payload,
-      config: body.config,
-    });
 
-    this._init(body.eventType);
-
-    const hasExcludedEvents = this._excludedEvents(body.eventType);
-    if (hasExcludedEvents) {
+    if (this._excludedEvents(body.eventType)) {
       return;
     }
 
-    const hasDataSame = this._lastPayload && this._checkObj(this._lastPayload, payload);
-    if (hasDataSame) {
+    // Stamped now, formatted when the event is actually sent — see `_formattingPayload`.
+    const occurredAt: EventContext = {
+      timestamp: this._timestamp,
+      activity: this._activity,
+      solution: this._solution,
+    };
+
+    const enqueue = () => {
+      this._queue.add(async () => {
+        const payload = this._formattingPayload(
+          { eventType: body.eventType, payload: body.payload, config: body.config },
+          occurredAt,
+        );
+
+        if (this._lastPayload && this._checkObj(this._lastPayload, payload)) {
+          return;
+        }
+
+        this._lastPayload = payload;
+        if (body.eventType === InternalEventType.INIT_SOLUTION) {
+          this._initialized = true;
+        }
+        await this._telemetryInstance.sendEvent(payload);
+      });
+    };
+
+    if (body.eventType === InternalEventType.INIT_SOLUTION) {
+      // A solution block inits before <uc-config> has published its attributes, so the config this event exists to
+      // report is only complete once the current task ends. Everything else waits on `_initialized`, so nothing is
+      // sent ahead of it.
+      setTimeout(enqueue);
       return;
     }
 
-    this._queue.add(async () => {
-      this._lastPayload = payload;
-      await this._telemetryInstance.sendEvent(payload);
-    });
+    enqueue();
   }
 
   public sendEventError(error: unknown, context = 'unknown'): void {

--- a/src/abstract/managers/TelemetryManager.ts
+++ b/src/abstract/managers/TelemetryManager.ts
@@ -18,7 +18,7 @@ type TelemetryState = TelemetryRequest & {
 };
 type TelemetryEventBody = Partial<Pick<TelemetryState, 'payload' | 'config'>> & {
   modalId?: string;
-  eventType?: CommonEventType;
+  eventType: CommonEventType;
 };
 
 export class TelemetryManager extends SharedInstance {
@@ -94,7 +94,7 @@ export class TelemetryManager extends SharedInstance {
       activity: this._activity,
       projectPubkey: this._config.pubkey,
       userAgent: navigator.userAgent,
-      eventType: result.eventType ?? '',
+      eventType: result.eventType,
       eventTimestamp: this._timestamp,
 
       payload: {

--- a/src/abstract/managers/ValidationManager.ts
+++ b/src/abstract/managers/ValidationManager.ts
@@ -122,6 +122,9 @@ export class ValidationManager extends SharedInstance {
     }
   }
 
+  /** Last collection verdict reported, so an unchanged one is not re-reported. */
+  private _reportedCollectionErrors = '[]';
+
   public runCollectionValidators(): void {
     if (this._isDestroyed) return;
 
@@ -150,7 +153,13 @@ export class ValidationManager extends SharedInstance {
 
     this._ctx.pub('*collectionErrors', errors);
 
-    if (errors.length > 0) {
+    // Collection validators re-run on every collection update. Failing is a transition, so an unchanged verdict is
+    // not re-reported. `payload` is left out of the comparison — it snapshots state that moves on every run.
+    const signature = JSON.stringify(errors.map(({ type, message }) => [type, message]));
+    const hasChanged = signature !== this._reportedCollectionErrors;
+    this._reportedCollectionErrors = signature;
+
+    if (errors.length > 0 && hasChanged) {
       this._sharedInstancesBag.eventEmitter.emit(
         EventType.COMMON_UPLOAD_FAILED,
         () => api.getOutputCollectionState() as OutputCollectionState<'failed'>,

--- a/src/blocks/CameraSource/CameraSource.ts
+++ b/src/blocks/CameraSource/CameraSource.ts
@@ -152,19 +152,22 @@ export class CameraSource extends LitUploaderBlock {
   @state()
   private _mutableClassButton = 'uc-shot-btn uc-camera-action';
 
-  private _chooseActionWithCamera = () => {
+  private _reportCameraAction(event: string): void {
     this.telemetryManager.sendEvent({
       eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
-          event: 'start-camera',
+          event,
           node: this.tagName,
           tabId: this._activeTab,
         },
       },
     });
+  }
 
+  private _chooseActionWithCamera = () => {
     if (this._activeTab === CameraSourceTypes.PHOTO) {
+      this._reportCameraAction('shot-camera');
       this._shot();
     }
 
@@ -174,6 +177,7 @@ export class CameraSource extends LitUploaderBlock {
         return;
       }
 
+      this._reportCameraAction('start-camera');
       this._startRecording();
     }
   };
@@ -201,16 +205,6 @@ export class CameraSource extends LitUploaderBlock {
   };
 
   private _handleStartCamera = (): void => {
-    this.telemetryManager.sendEvent({
-      eventType: InternalEventType.ACTION_EVENT,
-      payload: {
-        metadata: {
-          event: 'shot-camera',
-          node: this.tagName,
-          tabId: this._activeTab,
-        },
-      },
-    });
     this._chooseActionWithCamera();
   };
 
@@ -223,30 +217,12 @@ export class CameraSource extends LitUploaderBlock {
   };
 
   private _handleRetake = (): void => {
-    this.telemetryManager.sendEvent({
-      eventType: InternalEventType.ACTION_EVENT,
-      payload: {
-        metadata: {
-          event: 'retake-camera',
-          node: this.tagName,
-          tabId: this._activeTab,
-        },
-      },
-    });
+    this._reportCameraAction('retake-camera');
     this._retake();
   };
 
   private _handleAccept = (): void => {
-    this.telemetryManager.sendEvent({
-      eventType: InternalEventType.ACTION_EVENT,
-      payload: {
-        metadata: {
-          event: 'accept-camera',
-          node: this.tagName,
-          tabId: this._activeTab,
-        },
-      },
-    });
+    this._reportCameraAction('accept-camera');
     this._accept();
   };
 
@@ -371,16 +347,7 @@ export class CameraSource extends LitUploaderBlock {
     this._mediaRecorder?.stop();
     this.classList.remove('uc-recording');
 
-    this.telemetryManager.sendEvent({
-      eventType: InternalEventType.ACTION_EVENT,
-      payload: {
-        metadata: {
-          event: 'stop-camera',
-          node: this.tagName,
-          tabId: this._activeTab,
-        },
-      },
-    });
+    this._reportCameraAction('stop-camera');
   };
 
   /** This method is used to toggle recording pause/resume */

--- a/src/blocks/CloudImageEditor/src/EditorFilterControl.ts
+++ b/src/blocks/CloudImageEditor/src/EditorFilterControl.ts
@@ -10,7 +10,6 @@ import { EditorButtonControl } from './EditorButtonControl.js';
 import { FAKE_ORIGINAL_FILTER } from './EditorSlider.js';
 import { COMMON_OPERATIONS, transformationsToOperations } from './lib/transformationUtils.js';
 import type { Transformations } from './types';
-import { parseFilterValue } from './utils/parseFilterValue.js';
 
 import '../../Icon/Icon';
 
@@ -59,6 +58,18 @@ export class EditorFilterControl extends EditorButtonControl {
     }
   }
 
+  /**
+   * What the slider tooltip will show for this filter. Read from the transformations rather than from
+   * `*operationTooltip`, which the slider only writes in its `updated()` lifecycle — a render after this click.
+   */
+  private _currentFilterValue(): { filter: string; value: number } | null {
+    if (!this._filter) {
+      return null;
+    }
+    const transformations = this.$['*editorTransformations'] as Transformations;
+    return { filter: this._filter, value: transformations.filter?.amount ?? 0 };
+  }
+
   public override onClick(e: MouseEvent) {
     if (!this.active) {
       const slider = this.$['*sliderEl'] as { setOperation: (op: string, filter: string) => void; apply: () => void };
@@ -71,7 +82,7 @@ export class EditorFilterControl extends EditorButtonControl {
     }
 
     this.telemetryManager.sendEventCloudImageEditor(e, this.$['*tabId'], {
-      operation: parseFilterValue(this.$['*operationTooltip']),
+      operation: this._currentFilterValue(),
     });
 
     this.$['*currentFilter'] = this._filter;

--- a/src/blocks/CloudImageEditor/src/EditorOperationControl.ts
+++ b/src/blocks/CloudImageEditor/src/EditorOperationControl.ts
@@ -3,7 +3,6 @@ import { EditorButtonControl } from './EditorButtonControl.js';
 import type { ColorOperation } from './toolbar-constants';
 import { COLOR_OPERATIONS_CONFIG } from './toolbar-constants.js';
 import type { Transformations } from './types';
-import { parseFilterValue } from './utils/parseFilterValue.js';
 
 export class EditorOperationControl extends EditorButtonControl {
   private _operation: ColorOperation | '' = '';
@@ -65,6 +64,19 @@ export class EditorOperationControl extends EditorButtonControl {
       this.active = isActive;
     });
   }
+  /**
+   * What the slider tooltip will show for this operation. Read from the transformations rather than from
+   * `*operationTooltip`, which the slider only writes in its `updated()` lifecycle — a render after this click.
+   */
+  private _currentOperationValue(): { filter: string; value: number } | null {
+    if (!this._operation) {
+      return null;
+    }
+    const transformations = this.$['*editorTransformations'] as Transformations;
+    const value = transformations[this._operation] ?? COLOR_OPERATIONS_CONFIG[this._operation].zero;
+    return { filter: this._operation, value };
+  }
+
   protected override onClick(e: MouseEvent) {
     const slider = this.$['*sliderEl'] as { setOperation: (operation: ColorOperation | '') => void } | undefined;
     slider?.setOperation(this._operation);
@@ -72,7 +84,7 @@ export class EditorOperationControl extends EditorButtonControl {
     this.$['*currentOperation'] = this._operation;
 
     this.telemetryManager.sendEventCloudImageEditor(e, this.$['*tabId'], {
-      operation: parseFilterValue(this.$['*operationTooltip']),
+      operation: this._currentOperationValue(),
     });
   }
 }

--- a/src/blocks/FileItem/FileItem.ts
+++ b/src/blocks/FileItem/FileItem.ts
@@ -16,6 +16,7 @@ import { throttle } from '../../utils/throttle';
 import { canonicalSourceName, ExternalUploadSource } from '../../utils/UploadSource';
 import './file-item.css';
 import type { Uid } from '../../lit/Uid';
+import { InternalEventType } from '../UploadCtxProvider/EventEmitter';
 import { FileItemConfig } from './FileItemConfig';
 
 import '../Thumb/Thumb';
@@ -94,6 +95,7 @@ export class FileItem extends FileItemConfig {
 
   private _handleRemove = (): void => {
     this.telemetryManager.sendEvent({
+      eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
           event: 'remove-file',
@@ -317,6 +319,7 @@ export class FileItem extends FileItemConfig {
     }
 
     this.telemetryManager.sendEvent({
+      eventType: InternalEventType.ACTION_EVENT,
       payload: {
         metadata: {
           event: action.id,

--- a/src/blocks/UploadCtxProvider/EventEmitter.ts
+++ b/src/blocks/UploadCtxProvider/EventEmitter.ts
@@ -105,6 +105,11 @@ export class EventEmitter extends SharedInstance {
       }
     }
 
+    this._sharedInstancesBag.telemetryManager.sendEvent({
+      eventType: type,
+      payload: (payload ?? undefined) as Record<string, unknown> | undefined,
+    });
+
     this._debugPrint?.(() => {
       const copyPayload = !!payload && typeof payload === 'object' ? { ...payload } : payload;
       return [`event "${type}"`, copyPayload];

--- a/src/lit/LitBlock.ts
+++ b/src/lit/LitBlock.ts
@@ -60,13 +60,6 @@ export class LitBlock extends LitBlockBase {
     }
 
     eventEmitter.emit(type, payload, options);
-
-    const resolvedPayload = typeof payload === 'function' ? payload() : payload;
-
-    this.telemetryManager.sendEvent({
-      eventType: type,
-      payload: (resolvedPayload ?? undefined) as Record<string, unknown> | undefined,
-    });
   }
 
   public hasBlockInCtx(callback: (block: LitBlock) => boolean): boolean {

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -184,6 +184,9 @@ export class LitUploaderBlock extends LitActivityBlock {
     }
   }, 300);
 
+  /** Last error verdict reported per entry, so an unchanged one is not re-reported. Keyed by entry uid. */
+  private _reportedErrors = new Map<Uid, string>();
+
   private _handleCollectionUpdate: TypedCollectionObserverHandler<UploadEntryData> = (entries, added, removed) => {
     if (!this.isConnected) return;
     if (added.size || removed.size) {
@@ -217,6 +220,7 @@ export class LitUploaderBlock extends LitActivityBlock {
       });
       const thumbUrl = entry?.getValue('thumbUrl');
       thumbUrl && URL.revokeObjectURL(thumbUrl);
+      this._reportedErrors.delete(entry.uid);
       this.emit(EventType.FILE_REMOVED, this.api.getOutputItem(entry.uid));
     }
 
@@ -296,13 +300,18 @@ export class LitUploaderBlock extends LitActivityBlock {
         const ctx = PubSub.getCtx<UploadEntryData>(entryId);
         if (!ctx) continue;
         const { errors } = ctx.store;
+        // Validators re-run on `add`, `upload` and `change` and write a fresh array each time, so the same verdict
+        // arrives repeatedly. Failing is a transition — report it only when the verdict itself changes.
+        // Identity is the verdict itself. `payload.entry` is a snapshot of the entry at validation time, which
+        // differs on every run — including the errors just reported — so it cannot be part of the comparison.
+        const signature = JSON.stringify(errors.map(({ type, message }) => [type, message]));
+        if (this._reportedErrors.get(entryId) === signature) continue;
+        this._reportedErrors.set(entryId, signature);
+
+        // `common-upload-failed` is not emitted here: any failed file also produces a collection error, so the
+        // collection validators report the collection's transition — from one place.
         if (errors.length > 0) {
           this.emit(EventType.FILE_UPLOAD_FAILED, this.api.getOutputItem(entryId));
-          this.emit(
-            EventType.COMMON_UPLOAD_FAILED,
-            () => this.api.getOutputCollectionState() as OutputCollectionState<'failed'>,
-            { debounce: true },
-          );
         }
       }
       const loadedItems = uploadCollection.findItems((entry) => {

--- a/src/lit/LitUploaderBlock.ts
+++ b/src/lit/LitUploaderBlock.ts
@@ -179,7 +179,14 @@ export class LitUploaderBlock extends LitActivityBlock {
       debounce: true,
     });
 
-    if (this.cfg.groupOutput && collectionState.totalCount > 0 && collectionState.status === 'success') {
+    // `*groupInfo` is cleared whenever a cdnUrl changes, which is what asks for a new group. Without checking it, any
+    // later flush in a success state — the post-upload validator run, say — would build the same group again.
+    if (
+      this.cfg.groupOutput &&
+      collectionState.totalCount > 0 &&
+      collectionState.status === 'success' &&
+      !this.$['*groupInfo']
+    ) {
       this._createGroup(collectionState);
     }
   }, 300);

--- a/tests/events.e2e.test.tsx
+++ b/tests/events.e2e.test.tsx
@@ -157,7 +157,7 @@ describe('Events: upload lifecycle', () => {
     await delay(SETTLE_MS);
 
     // group-created is excluded from the ordered comparison: creating the group is a separate network call, so it can
-    // land either side of common-upload-success.
+    // land either side of common-upload-success. That it fires exactly once is asserted below.
     expect(recorder.typesExcluding(CHANGE, 'group-created')).toEqual([
       'file-added',
       'common-upload-start',
@@ -168,6 +168,7 @@ describe('Events: upload lifecycle', () => {
       'file-url-changed',
       'common-upload-success',
     ]);
+    expect(recorder.detailsOf('group-created')).toHaveLength(1);
     expect(recorder.detailsOf('group-created')[0].group?.cdnUrl).toBeTruthy();
   });
 });

--- a/tests/events.e2e.test.tsx
+++ b/tests/events.e2e.test.tsx
@@ -139,15 +139,8 @@ describe('Events: upload lifecycle', () => {
     await recorder.waitFor('common-upload-failed');
     await delay(SETTLE_MS);
 
-    // The failure pair fires twice: once from the `add` validators and once from the `change` validators that run in
-    // the next tick. Pinned as-is — this is current behaviour, not an endorsement of it.
-    expect(recorder.typesExcluding(CHANGE)).toEqual([
-      'file-added',
-      'file-upload-failed',
-      'common-upload-failed',
-      'file-upload-failed',
-      'common-upload-failed',
-    ]);
+    // The `change` validators run again in the next tick and reach the same verdict, which must not re-report it.
+    expect(recorder.typesExcluding(CHANGE)).toEqual(['file-added', 'file-upload-failed', 'common-upload-failed']);
     expect(recorder.detailsOf('file-upload-failed')[0].errors[0].type).toBe('FILE_SIZE_EXCEEDED');
     expect(recorder.detailsOf(CHANGE).at(-1)).toMatchObject({ status: 'failed', failedCount: 1 });
   });

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -134,9 +134,14 @@ describe('Telemetry: upload lifecycle', () => {
     await waitForType('common-upload-success');
     await delay(SETTLE_MS);
 
-    // No `common-upload-start`: `uploadAll()` emits it straight through the EventEmitter, bypassing `LitBlock.emit`
-    // and therefore telemetry.
-    expect(types()).toEqual(['file-url-changed', 'common-upload-success']);
+    // Two starts: this uploadAll() and the upload list's own, which runs a tick later while the entry still looks
+    // pending. Pinned as current behaviour, not an endorsement of it.
+    expect(types()).toEqual([
+      'common-upload-start',
+      'common-upload-start',
+      'file-url-changed',
+      'common-upload-success',
+    ]);
 
     // TelemetryManager._excludedEvents — reporting any of these would be a regression.
     for (const excluded of [

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -95,9 +95,12 @@ describe('Telemetry: session', () => {
     expect(init.component).toBe('uc-file-uploader-regular');
     expect(init.payload.location).toBe(location.origin);
     expect(init.config).toMatchObject({ pubkey: 'demopublickey', test_mode: true, quality_insights: true });
-    // The top-level pubkey is still empty at init time — the config has not reached TelemetryManager yet. Pinned as
-    // current behaviour, not an endorsement of it.
-    expect(init.project_pubkey).toBe('');
+    expect(init.project_pubkey).toBe('demopublickey');
+
+    // The config arriving is not a config change: nothing is reported until init-solution has gone out.
+    await delay(SETTLE_MS);
+    expect(types()[0]).toBe('init-solution');
+    expect(bodiesOf('change-config')).toHaveLength(0);
   });
 
   it('sends change-config when a config value changes after init', async () => {

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -264,11 +264,9 @@ describe('Telemetry: cloud image editor', () => {
     await userEvent.click(page.getByRole('option', { name: /Brightness/i }));
     const action = await waitForType('action-event');
 
-    // `operation` is read from `*operationTooltip`, which still holds the pre-click value — so it reports the stale
-    // tooltip rather than the operation just picked. Pinned as current behaviour, not an endorsement of it.
     expect(action.payload.metadata).toMatchObject({
       tab_id: 'tuning',
-      operation: { filter: 'filter', value: 0 },
+      operation: { filter: 'brightness', value: 0 },
     });
   });
 });

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -319,16 +319,13 @@ describe('Telemetry: sources', () => {
     await accept.click();
 
     await vi.waitFor(() => expect(actionEvents()).toContain('accept-camera'), WAIT);
-    // Every shot reports twice: `shot-camera` from the button handler, then `start-camera` from the shared camera
-    // action dispatcher it calls.
+    // One event per user action. On the video tab the same button reports `start-camera` / `stop-camera` instead.
     expect(actionEvents()).toEqual([
       'camera-tab-switch',
       'camera-tab-switch',
       'shot-camera',
-      'start-camera',
       'retake-camera',
       'shot-camera',
-      'start-camera',
       'accept-camera',
     ]);
     expect(bodiesWithAction('camera-tab-switch')[0].payload.metadata).toMatchObject({

--- a/tests/telemetry.e2e.test.tsx
+++ b/tests/telemetry.e2e.test.tsx
@@ -185,8 +185,7 @@ describe('Telemetry: action events', () => {
     }, WAIT);
 
     expect(removal.payload.metadata).toMatchObject({ event: 'remove-file', node: 'UC-FILE-ITEM' });
-    // FileItem sends this one without an eventType, so it goes out with an empty one. Pinned as current behaviour.
-    expect(removal.event_type).toBe('');
+    expect(removal.event_type).toBe('action-event');
   });
 
   it('reports an action-event when the upload list is cleared', async () => {


### PR DESCRIPTION
Stacked on #1077. That PR pins current behaviour; this one fixes it, flipping each pinned assertion as it goes. **Merge #1077 first** — the base branch is `test/events-telemetry-baseline`.

One commit per quirk, so each can be reverted on its own.

| Commit | Quirk | Root cause |
|---|---|---|
| `4282784` | remove-file telemetry had `event_type: ""` | `eventType` was optional with an empty-string fallback. Making it required is what found the two sites |
| `7ee1b84` | Camera reported twice per press | The button handler sent `shot-camera`, then the dispatcher it calls sent `start-camera`. Stopping a video recording reported three events for one press |
| `51963d7` | Editor reported the previous operation | Controls read `*operationTooltip`, which the slider only writes in `updated()` — a render after the click |
| `d07fbc6` | `init-solution` had an empty `project_pubkey` | Solution blocks init before `<uc-config>` publishes. The `config` object only looked right because it was queued **by reference** and kept mutating until `JSON.stringify` caught up |
| `e5b8c59` | Validation failure reported twice | Validators run on `add`/`upload`/`change`, each writing a fresh array; and `common-upload-failed` was emitted from two places at once |
| `4b56bf1` | `group-created` fired twice | `_flushOutputItems` built a group whenever it saw a success state, without checking whether one existed |
| `01ce1b9` | `common-upload-start` missing from telemetry | Telemetry was mirrored from `LitBlock.emit`, so direct `EventEmitter` emits were invisible |

### Worth a closer look

**`e5b8c59` — error identity.** Deduping on the whole error object doesn't work: every error embeds a `payload.entry` snapshot that differs on each run, and even contains the errors just reported. The comparison is on `type` + `message`. That nested self-referential snapshot looks like its own problem, left alone here.

**`e5b8c59` — where the dedupe went.** My first attempt suppressed the no-op `errors` write in `ValidationManager`. That broke every upload: `common-upload-success` is emitted from inside the `changeMap.errors` branch, so the post-upload errors write is what signals success. The dedupe is on the emission side instead.

**`d07fbc6` — `init-solution` is now deferred one task**, which is when the config has landed. `_initialized` flips when it is actually sent, so the config arriving no longer looks like a burst of `change-config` racing ahead of it. There's a test asserting exactly that.

**`01ce1b9`** also fixes a second bug in passing: the old code re-invoked a deferred payload thunk to build the telemetry body, so debounced events computed their payload twice.

### New quirk found, not fixed

`uploadAll()` emits `common-upload-start` **twice** for one upload: the caller's, plus `UploadList`'s auto-upload a tick later, which still sees the entry as pending because `isUploading` is set in a `setTimeout`. It's pinned in the telemetry test with a comment rather than fixed — the fix touches upload triggering and retry, which wasn't in the agreed scope. Say the word and I'll take it.

### Verification

Full e2e green (26 files / 212 tests), specs green (32 files / 312 tests), `npm run tsc` clean. The two touched test files run 2× more with no flakes.

> 🤖 Written by Claude Code on behalf of @nd0ut